### PR TITLE
Rename compile env name for gnmi write

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ SRC_FILES=$(shell find . -name '*.go' | grep -v '_test.go' | grep -v '/tests/')
 TEST_FILES=$(wildcard *_test.go)
 TELEMETRY_TEST_DIR = build/tests/gnmi_server
 TELEMETRY_TEST_BIN = $(TELEMETRY_TEST_DIR)/server.test
-ifeq ($(TRANSLIB_ENABLE),y)
-BLD_FLAGS := -tags translib
+ifeq ($(TRANSLIB_ENABLED),y)
+BLD_FLAGS := -tags gnmi_translib
 endif
 
 GO_DEPS := vendor/.done

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ SRC_FILES=$(shell find . -name '*.go' | grep -v '_test.go' | grep -v '/tests/')
 TEST_FILES=$(wildcard *_test.go)
 TELEMETRY_TEST_DIR = build/tests/gnmi_server
 TELEMETRY_TEST_BIN = $(TELEMETRY_TEST_DIR)/server.test
-ifeq ($(TELEMETRY_WRITABLE),y)
-BLD_FLAGS := -tags readwrite
+ifeq ($(TRANSLIB_ENABLE),y)
+BLD_FLAGS := -tags translib
 endif
 
 GO_DEPS := vendor/.done

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ SRC_FILES=$(shell find . -name '*.go' | grep -v '_test.go' | grep -v '/tests/')
 TEST_FILES=$(wildcard *_test.go)
 TELEMETRY_TEST_DIR = build/tests/gnmi_server
 TELEMETRY_TEST_BIN = $(TELEMETRY_TEST_DIR)/server.test
-ifeq ($(TRANSLIB_ENABLED),y)
-BLD_FLAGS := -tags gnmi_translib
+ifeq ($(ENABLE_TRANSLIB_WRITE),y)
+BLD_FLAGS := -tags gnmi_translib_write
 endif
 
 GO_DEPS := vendor/.done

--- a/gnmi_server/constants.go
+++ b/gnmi_server/constants.go
@@ -1,5 +1,5 @@
-// +build !gnmi_translib
+// +build !gnmi_translib_write
 
 package gnmi
 
-const TRANSLIB_ENABLED = false
+const ENABLE_TRANSLIB_WRITE = false

--- a/gnmi_server/constants.go
+++ b/gnmi_server/constants.go
@@ -1,5 +1,5 @@
-// +build !readwrite
+// +build !translib
 
 package gnmi
 
-const READ_WRITE_MODE = false
+const TRANSLIB_ENABLE = false

--- a/gnmi_server/constants.go
+++ b/gnmi_server/constants.go
@@ -1,5 +1,5 @@
-// +build !translib
+// +build !gnmi_translib
 
 package gnmi
 
-const TRANSLIB_ENABLE = false
+const TRANSLIB_ENABLED = false

--- a/gnmi_server/constants_readwrite.go
+++ b/gnmi_server/constants_readwrite.go
@@ -1,5 +1,5 @@
-// +build readwrite
+// +build translib
 
 package gnmi
 
-const READ_WRITE_MODE = true
+const TRANSLIB_ENABLE = true

--- a/gnmi_server/constants_readwrite.go
+++ b/gnmi_server/constants_readwrite.go
@@ -1,5 +1,5 @@
-// +build gnmi_translib
+// +build gnmi_translib_write
 
 package gnmi
 
-const TRANSLIB_ENABLED = true
+const ENABLE_TRANSLIB_WRITE = true

--- a/gnmi_server/constants_readwrite.go
+++ b/gnmi_server/constants_readwrite.go
@@ -1,5 +1,5 @@
-// +build translib
+// +build gnmi_translib
 
 package gnmi
 
-const TRANSLIB_ENABLE = true
+const TRANSLIB_ENABLED = true

--- a/gnmi_server/server.go
+++ b/gnmi_server/server.go
@@ -48,9 +48,8 @@ type Config struct {
 	// for this Server.
 	Port     int64
 	UserAuth AuthTypes
-	MgmtEnable      bool
+	TranslibEnable  bool
 	TelemetryEnable bool
-	MixedEnable     bool
 }
 
 var AuthLock sync.Mutex
@@ -143,11 +142,11 @@ func NewServer(config *Config, opts []grpc.ServerOption) (*Server, error) {
 	}
 	gnmipb.RegisterGNMIServer(srv.s, srv)
 	spb_jwt_gnoi.RegisterSonicJwtServiceServer(srv.s, srv)
-	if srv.config.MgmtEnable {
+	if srv.config.TranslibEnable {
 		gnoi_system_pb.RegisterSystemServer(srv.s, srv)
 		spb_gnoi.RegisterSonicServiceServer(srv.s, srv)
 	}
-	log.V(1).Infof("Created Server on %s, read-only: %t", srv.Address(), !srv.config.MgmtEnable)
+	log.V(1).Infof("Created Server on %s, read-only: %t", srv.Address(), !srv.config.TranslibEnable)
 	return srv, nil
 }
 
@@ -389,7 +388,7 @@ func (s *Server) Set(ctx context.Context, req *gnmipb.SetRequest) (*gnmipb.SetRe
 		/* Add to Set response results. */
 		results = append(results, &res)
 	}
-	if s.config.MgmtEnable {
+	if s.config.TranslibEnable {
 		err = dc.Set(req.GetDelete(), req.GetReplace(), req.GetUpdate())
 	} else {
 		return nil, grpc.Errorf(codes.Unimplemented, "Telemetry is in read-only mode")

--- a/gnmi_server/server.go
+++ b/gnmi_server/server.go
@@ -49,7 +49,7 @@ type Config struct {
 	Port     int64
 	LogLevel int
 	UserAuth AuthTypes
-	TranslibEnable  bool
+	EnableTranslibWrite bool
 }
 
 var AuthLock sync.Mutex
@@ -142,11 +142,11 @@ func NewServer(config *Config, opts []grpc.ServerOption) (*Server, error) {
 	}
 	gnmipb.RegisterGNMIServer(srv.s, srv)
 	spb_jwt_gnoi.RegisterSonicJwtServiceServer(srv.s, srv)
-	if srv.config.TranslibEnable {
+	if srv.config.EnableTranslibWrite {
 		gnoi_system_pb.RegisterSystemServer(srv.s, srv)
 		spb_gnoi.RegisterSonicServiceServer(srv.s, srv)
 	}
-	log.V(1).Infof("Created Server on %s, read-only: %t", srv.Address(), !srv.config.TranslibEnable)
+	log.V(1).Infof("Created Server on %s, read-only: %t", srv.Address(), !srv.config.EnableTranslibWrite)
 	return srv, nil
 }
 
@@ -388,7 +388,7 @@ func (s *Server) Set(ctx context.Context, req *gnmipb.SetRequest) (*gnmipb.SetRe
 		/* Add to Set response results. */
 		results = append(results, &res)
 	}
-	if s.config.TranslibEnable {
+	if s.config.EnableTranslibWrite {
 		err = dc.Set(req.GetDelete(), req.GetReplace(), req.GetUpdate())
 	} else {
 		return nil, grpc.Errorf(codes.Unimplemented, "Telemetry is in read-only mode")

--- a/gnmi_server/server.go
+++ b/gnmi_server/server.go
@@ -49,7 +49,6 @@ type Config struct {
 	Port     int64
 	UserAuth AuthTypes
 	TranslibEnable  bool
-	TelemetryEnable bool
 }
 
 var AuthLock sync.Mutex
@@ -232,9 +231,6 @@ func (s *Server) Subscribe(stream gnmipb.GNMI_SubscribeServer) error {
 		return nil, status.Error(codes.PermissionDenied, msg)
 	}
 	*/
-	if !s.config.TelemetryEnable {
-		return grpc.Errorf(codes.Unimplemented, "Telemetry is disabled")
-	}
 
 	c := NewClient(pr.Addr)
 

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -104,6 +104,25 @@ func createServer(t *testing.T, port int64) *Server {
 	return s
 }
 
+func createDisabledServer(t *testing.T, port int64) *Server {
+	certificate, err := testcert.NewCert()
+	if err != nil {
+		t.Errorf("could not load server key pair: %s", err)
+	}
+	tlsCfg := &tls.Config{
+		ClientAuth:   tls.RequestClientCert,
+		Certificates: []tls.Certificate{certificate},
+	}
+
+	opts := []grpc.ServerOption{grpc.Creds(credentials.NewTLS(tlsCfg))}
+	cfg := &Config{Port: port, MgmtEnable: READ_WRITE_MODE, TelemetryEnable: false, MixedEnable: false}
+	s, err := NewServer(cfg, opts)
+	if err != nil {
+		t.Errorf("Failed to create gNMI server: %v", err)
+	}
+	return s
+}
+
 // runTestGet requests a path from the server by Get grpc call, and compares if
 // the return code and response value are expected.
 func runTestGet(t *testing.T, ctx context.Context, gClient pb.GNMIClient, pathTarget string,
@@ -2249,6 +2268,59 @@ func runTestSubscribe(t *testing.T, namespace string) {
 	}
 }
 
+func runTestDisabledSubscribe(t *testing.T, namespace string) {
+	tests := []struct {
+		desc       string
+		q          client.Query
+		prepares   []tablePathValue
+		updates    []tablePathValue
+		wantErr    bool
+		wantNoti   []client.Notification
+		wantSubErr error
+
+		poll        int
+		wantPollErr string
+
+		generateIntervals bool
+	}{
+		{
+			desc:       "Disable telemetry and test subscribe",
+			q:          createCountersDbQuerySampleMode(t, 1000*time.Millisecond, false, "COUNTERS", "Ethernet1"),
+			updates:    []tablePathValue{},
+			wantSubErr: fmt.Errorf("rpc error: code = Unimplemented desc = Telemetry is disabled"),
+			wantNoti:   []client.Notification{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			q := tt.q
+			q.Addrs = []string{"127.0.0.1:8081"}
+			c := client.New()
+			defer c.Close()
+			var gotNoti []client.Notification
+			q.NotificationHandler = func(n client.Notification) error {
+				if nn, ok := n.(client.Update); ok {
+					nn.TS = time.Unix(0, 200)
+					gotNoti = append(gotNoti, nn)
+				} else {
+					gotNoti = append(gotNoti, n)
+				}
+
+				return nil
+			}
+			go func() {
+				err := c.Subscribe(context.Background(), q)
+				if tt.wantSubErr != nil && tt.wantSubErr.Error() != err.Error() {
+					t.Errorf("c.Subscribe expected %v, got %v", tt.wantSubErr, err)
+				}
+			}()
+			// wait for half second for subscribeRequest to sync
+			time.Sleep(time.Millisecond * 500)
+		})
+	}
+}
+
 func TestGnmiSubscribe(t *testing.T) {
 	s := createServer(t, 8081)
 	go runServer(t, s)
@@ -2512,6 +2584,15 @@ func TestBulkSet(t *testing.T) {
 
 	})
 
+}
+
+func TestGnmiDisabledTelemetry(t *testing.T) {
+	s := createDisabledServer(t, 8081)
+	go runServer(t, s)
+
+	runTestDisabledSubscribe(t, sdcfg.GetDbDefaultNamespace())
+
+	s.s.Stop()
 }
 
 func init() {

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -597,7 +597,7 @@ func mergeStrMaps(sourceOrigin interface{}, updateOrigin interface{}) interface{
 }
 
 func TestGnmiSet(t *testing.T) {
-	if !READ_WRITE_MODE {
+	if !TRANSLIB_ENABLE {
 		t.Skip("skipping test in read-only mode.")
 	}
 	s := createServer(t, 8081)

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -96,7 +96,7 @@ func createServer(t *testing.T, port int64) *Server {
 	}
 
 	opts := []grpc.ServerOption{grpc.Creds(credentials.NewTLS(tlsCfg))}
-	cfg := &Config{Port: port, MgmtEnable: READ_WRITE_MODE, TelemetryEnable: true, MixedEnable: true}
+	cfg := &Config{Port: port, TranslibEnable: true, TelemetryEnable: true}
 	s, err := NewServer(cfg, opts)
 	if err != nil {
 		t.Errorf("Failed to create gNMI server: %v", err)
@@ -115,7 +115,7 @@ func createDisabledServer(t *testing.T, port int64) *Server {
 	}
 
 	opts := []grpc.ServerOption{grpc.Creds(credentials.NewTLS(tlsCfg))}
-	cfg := &Config{Port: port, MgmtEnable: READ_WRITE_MODE, TelemetryEnable: false, MixedEnable: false}
+	cfg := &Config{Port: port, TranslibEnable: false, TelemetryEnable: false}
 	s, err := NewServer(cfg, opts)
 	if err != nil {
 		t.Errorf("Failed to create gNMI server: %v", err)

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -99,7 +99,7 @@ func createServer(t *testing.T, port int64) *Server {
 	}
 
 	opts := []grpc.ServerOption{grpc.Creds(credentials.NewTLS(tlsCfg))}
-	cfg := &Config{Port: port, TranslibEnable: true}
+	cfg := &Config{Port: port, EnableTranslibWrite: true}
 	s, err := NewServer(cfg, opts)
 	if err != nil {
 		t.Errorf("Failed to create gNMI server: %v", err)
@@ -633,7 +633,7 @@ func mergeStrMaps(sourceOrigin interface{}, updateOrigin interface{}) interface{
 }
 
 func TestGnmiSet(t *testing.T) {
-	if !TRANSLIB_ENABLED {
+	if !ENABLE_TRANSLIB_WRITE {
 		t.Skip("skipping test in read-only mode.")
 	}
 	s := createServer(t, 8081)
@@ -2351,7 +2351,7 @@ func TestCapabilities(t *testing.T) {
 }
 
 func TestGNOI(t *testing.T) {
-	if !READ_WRITE_MODE {
+	if !ENABLE_TRANSLIB_WRITE {
 		t.Skip("skipping test in read-only mode.")
 	}
 	s := createServer(t, 8086)

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -96,7 +96,7 @@ func createServer(t *testing.T, port int64) *Server {
 	}
 
 	opts := []grpc.ServerOption{grpc.Creds(credentials.NewTLS(tlsCfg))}
-	cfg := &Config{Port: port}
+	cfg := &Config{Port: port, MgmtEnable: READ_WRITE_MODE, TelemetryEnable: true, MixedEnable: true}
 	s, err := NewServer(cfg, opts)
 	if err != nil {
 		t.Errorf("Failed to create gNMI server: %v", err)

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -96,7 +96,7 @@ func createServer(t *testing.T, port int64) *Server {
 	}
 
 	opts := []grpc.ServerOption{grpc.Creds(credentials.NewTLS(tlsCfg))}
-	cfg := &Config{Port: port, TranslibEnable: true, TelemetryEnable: true}
+	cfg := &Config{Port: port, TranslibEnable: true}
 	s, err := NewServer(cfg, opts)
 	if err != nil {
 		t.Errorf("Failed to create gNMI server: %v", err)
@@ -115,7 +115,7 @@ func createDisabledServer(t *testing.T, port int64) *Server {
 	}
 
 	opts := []grpc.ServerOption{grpc.Creds(credentials.NewTLS(tlsCfg))}
-	cfg := &Config{Port: port, TranslibEnable: false, TelemetryEnable: false}
+	cfg := &Config{Port: port, TranslibEnable: false}
 	s, err := NewServer(cfg, opts)
 	if err != nil {
 		t.Errorf("Failed to create gNMI server: %v", err)

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -597,7 +597,7 @@ func mergeStrMaps(sourceOrigin interface{}, updateOrigin interface{}) interface{
 }
 
 func TestGnmiSet(t *testing.T) {
-	if !TRANSLIB_ENABLE {
+	if !TRANSLIB_ENABLED {
 		t.Skip("skipping test in read-only mode.")
 	}
 	s := createServer(t, 8081)

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -28,7 +28,6 @@ var (
 	jwtRefInt         = flag.Uint64("jwt_refresh_int", 900, "Seconds before JWT expiry the token can be refreshed.")
 	jwtValInt         = flag.Uint64("jwt_valid_int", 3600, "Seconds that JWT token is valid for.")
 	gnmi_translib     = flag.Bool("gnmi_translib", gnmi.READ_WRITE_MODE, "Enable gNMI translib for management framework")
-	telemetryEnable   = flag.Bool("telemetryEnable", true, "Enable gNMI telemetry interface")
 )
 
 func main() {
@@ -61,7 +60,6 @@ func main() {
 	cfg := &gnmi.Config{}
 	cfg.Port = int64(*port)
 	cfg.TranslibEnable = bool(*gnmi_translib)
-	cfg.TelemetryEnable = bool(*telemetryEnable)
 	var opts []grpc.ServerOption
 
 	if !*noTLS {
@@ -132,7 +130,6 @@ func main() {
 	cfg.Port = int64(*port)
 	cfg.UserAuth = userAuth
 	cfg.TranslibEnable = bool(*gnmi_translib)
-	cfg.TelemetryEnable = bool(*telemetryEnable)
 
 	gnmi.GenerateJwtSecretKey()
 }

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -27,7 +27,7 @@ var (
 	allowNoClientCert = flag.Bool("allow_no_client_auth", false, "When set, telemetry server will request but not require a client certificate.")
 	jwtRefInt         = flag.Uint64("jwt_refresh_int", 900, "Seconds before JWT expiry the token can be refreshed.")
 	jwtValInt         = flag.Uint64("jwt_valid_int", 3600, "Seconds that JWT token is valid for.")
-	gnmi_translib     = flag.Bool("gnmi_translib", gnmi.READ_WRITE_MODE, "Enable gNMI translib for management framework")
+	gnmi_translib     = flag.Bool("gnmi_translib", gnmi.TRANSLIB_ENABLE, "Enable gNMI translib for management framework")
 )
 
 func main() {

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -27,7 +27,7 @@ var (
 	allowNoClientCert = flag.Bool("allow_no_client_auth", false, "When set, telemetry server will request but not require a client certificate.")
 	jwtRefInt         = flag.Uint64("jwt_refresh_int", 900, "Seconds before JWT expiry the token can be refreshed.")
 	jwtValInt         = flag.Uint64("jwt_valid_int", 3600, "Seconds that JWT token is valid for.")
-	gnmi_translib     = flag.Bool("gnmi_translib", gnmi.TRANSLIB_ENABLE, "Enable gNMI translib for management framework")
+	gnmi_translib     = flag.Bool("gnmi_translib", gnmi.TRANSLIB_ENABLED, "Enable gNMI translib for management framework")
 )
 
 func main() {

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -28,7 +28,7 @@ var (
 	allowNoClientCert = flag.Bool("allow_no_client_auth", false, "When set, telemetry server will request but not require a client certificate.")
 	jwtRefInt         = flag.Uint64("jwt_refresh_int", 900, "Seconds before JWT expiry the token can be refreshed.")
 	jwtValInt         = flag.Uint64("jwt_valid_int", 3600, "Seconds that JWT token is valid for.")
-	gnmi_translib     = flag.Bool("gnmi_translib", gnmi.TRANSLIB_ENABLED, "Enable gNMI translib for management framework")
+	gnmi_translib_write = flag.Bool("gnmi_translib_write", gnmi.ENABLE_TRANSLIB_WRITE, "Enable gNMI translib write for management framework")
 )
 
 func main() {
@@ -36,7 +36,7 @@ func main() {
 	flag.Parse()
 
 	var defUserAuth gnmi.AuthTypes
-	if *gnmi_translib {
+	if *gnmi_translib_write {
 		//In read/write mode we want to enable auth by default.
 		defUserAuth = gnmi.AuthTypes{"password": true, "cert": false, "jwt": true}
 	}else {
@@ -60,7 +60,7 @@ func main() {
 
 	cfg := &gnmi.Config{}
 	cfg.Port = int64(*port)
-	cfg.TranslibEnable = bool(*gnmi_translib)
+	cfg.EnableTranslibWrite = bool(*gnmi_translib_write)
 	cfg.LogLevel = 3
 	var opts []grpc.ServerOption
 
@@ -136,7 +136,7 @@ func main() {
 	cfg := &gnmi.Config{}
 	cfg.Port = int64(*port)
 	cfg.UserAuth = userAuth
-	cfg.TranslibEnable = bool(*gnmi_translib)
+	cfg.EnableTranslibWrite = bool(*gnmi_translib_write)
 
 	gnmi.GenerateJwtSecretKey()
 }

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -27,9 +27,8 @@ var (
 	allowNoClientCert = flag.Bool("allow_no_client_auth", false, "When set, telemetry server will request but not require a client certificate.")
 	jwtRefInt         = flag.Uint64("jwt_refresh_int", 900, "Seconds before JWT expiry the token can be refreshed.")
 	jwtValInt         = flag.Uint64("jwt_valid_int", 3600, "Seconds that JWT token is valid for.")
-	mgmtEnable        = flag.Bool("mgmtEnable", gnmi.READ_WRITE_MODE, "Enable gNMI write mode for management framework")
+	gnmi_translib     = flag.Bool("gnmi_translib", gnmi.READ_WRITE_MODE, "Enable gNMI translib for management framework")
 	telemetryEnable   = flag.Bool("telemetryEnable", true, "Enable gNMI telemetry interface")
-	mixedEnable       = flag.Bool("mixedEnable", true, "Enable gNMI mixed config interface")
 )
 
 func main() {
@@ -37,7 +36,7 @@ func main() {
 	flag.Parse()
 
 	var defUserAuth gnmi.AuthTypes
-	if *mgmtEnable {
+	if *gnmi_translib {
 		//In read/write mode we want to enable auth by default.
 		defUserAuth = gnmi.AuthTypes{"password": true, "cert": false, "jwt": true}
 	}else {
@@ -61,9 +60,8 @@ func main() {
 
 	cfg := &gnmi.Config{}
 	cfg.Port = int64(*port)
-	cfg.MgmtEnable = bool(*mgmtEnable)
+	cfg.TranslibEnable = bool(*gnmi_translib)
 	cfg.TelemetryEnable = bool(*telemetryEnable)
-	cfg.MixedEnable = bool(*mixedEnable)
 	var opts []grpc.ServerOption
 
 	if !*noTLS {
@@ -133,9 +131,8 @@ func main() {
 	cfg := &gnmi.Config{}
 	cfg.Port = int64(*port)
 	cfg.UserAuth = userAuth
-	cfg.MgmtEnable = bool(*mgmtEnable)
+	cfg.TranslibEnable = bool(*gnmi_translib)
 	cfg.TelemetryEnable = bool(*telemetryEnable)
-	cfg.MixedEnable = bool(*mixedEnable)
 
 	gnmi.GenerateJwtSecretKey()
 }

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-        userAuth = gnmi.AuthTypes{"password": false, "cert": false, "jwt": false}
+	userAuth = gnmi.AuthTypes{"password": false, "cert": false, "jwt": false}
 	port = flag.Int("port", -1, "port to listen on")
 	// Certificate files.
 	caCert            = flag.String("ca_crt", "", "CA certificate for client certificate validation. Optional.")
@@ -27,6 +27,9 @@ var (
 	allowNoClientCert = flag.Bool("allow_no_client_auth", false, "When set, telemetry server will request but not require a client certificate.")
 	jwtRefInt         = flag.Uint64("jwt_refresh_int", 900, "Seconds before JWT expiry the token can be refreshed.")
 	jwtValInt         = flag.Uint64("jwt_valid_int", 3600, "Seconds that JWT token is valid for.")
+	mgmtEnable        = flag.Bool("mgmtEnable", gnmi.READ_WRITE_MODE, "Enable gNMI write mode for management framework")
+	telemetryEnable   = flag.Bool("telemetryEnable", true, "Enable gNMI telemetry interface")
+	mixedEnable       = flag.Bool("mixedEnable", true, "Enable gNMI mixed config interface")
 )
 
 func main() {
@@ -34,7 +37,7 @@ func main() {
 	flag.Parse()
 
 	var defUserAuth gnmi.AuthTypes
-	if gnmi.READ_WRITE_MODE {
+	if *mgmtEnable {
 		//In read/write mode we want to enable auth by default.
 		defUserAuth = gnmi.AuthTypes{"password": true, "cert": false, "jwt": true}
 	}else {
@@ -58,6 +61,9 @@ func main() {
 
 	cfg := &gnmi.Config{}
 	cfg.Port = int64(*port)
+	cfg.MgmtEnable = bool(*mgmtEnable)
+	cfg.TelemetryEnable = bool(*telemetryEnable)
+	cfg.MixedEnable = bool(*mixedEnable)
 	var opts []grpc.ServerOption
 
 	if !*noTLS {
@@ -127,6 +133,9 @@ func main() {
 	cfg := &gnmi.Config{}
 	cfg.Port = int64(*port)
 	cfg.UserAuth = userAuth
+	cfg.MgmtEnable = bool(*mgmtEnable)
+	cfg.TelemetryEnable = bool(*telemetryEnable)
+	cfg.MixedEnable = bool(*mixedEnable)
 
 	gnmi.GenerateJwtSecretKey()
 }


### PR DESCRIPTION
Signed-off-by: Gang Lv ganglv@microsoft.com

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
PR for sonic-buildimage
https://github.com/sonic-net/sonic-buildimage/pull/11780

#### Why I did it
I will add a future env var ENABLE_NATIVE_WRITE which is another kind of gnmi write mode.
So, I need to rename TELEMETRY_WRITABLE and READ_WRITE_MODE to avoid conflict.

#### How I did it
Rename compile env var and build tag.

#### How to verify it
Run unit test for sonic-gnmi.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

