### PR TITLE
Events client: Ensure all go routines exit upon client disconnect.

### DIFF
--- a/sonic_data_client/events_client.go
+++ b/sonic_data_client/events_client.go
@@ -330,9 +330,9 @@ func (evtc *EventClient) StreamRun(q *queue.PriorityQueue, stop chan struct{}, w
     evtc.channel = stop
 
     go get_events(evtc)
-    c.w.Add(1)
+    evtc.wg.Add(1)
     go update_stats(evtc)
-    c.w.Add(1)
+    evtc.wg.Add(1)
 
     for {
         select {

--- a/sonic_data_client/events_client.go
+++ b/sonic_data_client/events_client.go
@@ -149,6 +149,8 @@ func compute_latency(evtc *EventClient) {
 }
 
 func update_stats(evtc *EventClient) {
+    defer evtc.wg.Done()
+
     /* Wait for any update */
     db_counters := make(map[string]uint64)
     var wr_counters *map[string]uint64 = nil
@@ -259,6 +261,8 @@ func C_deinit_subs(h unsafe.Pointer) {
 }
 
 func get_events(evtc *EventClient) {
+    defer evtc.wg.Done()
+
     str_ptr := C.malloc(C.sizeof_char * C.size_t(EVENT_BUFFSZ)) 
     defer C.free(unsafe.Pointer(str_ptr))
 
@@ -326,7 +330,9 @@ func (evtc *EventClient) StreamRun(q *queue.PriorityQueue, stop chan struct{}, w
     evtc.channel = stop
 
     go get_events(evtc)
+    c.w.Add(1)
     go update_stats(evtc)
+    c.w.Add(1)
 
     for {
         select {


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The go routines don't get a formal exit, that breaks proper client disconnect from eventd.

#### How I did it
Add the go routines into waitgroup and invoke done upon proper exit.

#### How to verify it
Via logs is the easy way.
Start a gnmi client and stop. Note in telemetry log the spew from go routines for proper exit.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

