### PR TITLE
Remove LOGLEVEL DB since is no longer used

### DIFF
--- a/doc/grpc_telemetry.md
+++ b/doc/grpc_telemetry.md
@@ -30,7 +30,6 @@ In SONiC, most of the critical network and system data is stored in redisDB. Bas
 |APPL_DB    |  0 |   Application running data |
 |ASIC_DB    |  1 |   ASIC configuration and state data
 |COUNTERS_DB | 2 |   Counter data for port, lag, queue
-|LOGLEVEL_DB | 3 |   Log level control for SONiC modules
 |CONFIG_DB   | 4 |   Source of truth for SONiC configuration
 |FLEX_COUNTER_DB| 5 | For PFC watch dog counters control and other plugin extensions
 |STATE_DB       | 6 | Configuration state for object in CONFIG_DB

--- a/proto/sonic.pb.go
+++ b/proto/sonic.pb.go
@@ -20,7 +20,6 @@ const (
 	Target_APPL_DB     Target = 0
 	Target_ASIC_DB     Target = 1
 	Target_COUNTERS_DB Target = 2
-	Target_LOGLEVEL_DB Target = 3
 	Target_CONFIG_DB   Target = 4
 	// PFC_WD_DB shares the the same db number with FLEX_COUNTER_DB
 	Target_PFC_WD_DB       Target = 5
@@ -34,7 +33,6 @@ var Target_name = map[int32]string{
 	0: "APPL_DB",
 	1: "ASIC_DB",
 	2: "COUNTERS_DB",
-	3: "LOGLEVEL_DB",
 	4: "CONFIG_DB",
 	5: "PFC_WD_DB",
 	// Duplicate value: 5: "FLEX_COUNTER_DB",
@@ -45,7 +43,6 @@ var Target_value = map[string]int32{
 	"APPL_DB":         0,
 	"ASIC_DB":         1,
 	"COUNTERS_DB":     2,
-	"LOGLEVEL_DB":     3,
 	"CONFIG_DB":       4,
 	"PFC_WD_DB":       5,
 	"FLEX_COUNTER_DB": 5,

--- a/proto/sonic.proto
+++ b/proto/sonic.proto
@@ -11,7 +11,6 @@ enum Target {
   APPL_DB         = 0;
   ASIC_DB         = 1;
   COUNTERS_DB     = 2;
-  LOGLEVEL_DB     = 3;
   CONFIG_DB       = 4;
   // PFC_WD_DB shares the the same db number with FLEX_COUNTER_DB
   PFC_WD_DB       = 5;

--- a/testdata/database_config.json
+++ b/testdata/database_config.json
@@ -22,11 +22,6 @@
             "separator": ":",
             "instance" : "redis"
         },
-        "LOGLEVEL_DB" : {
-            "id" : 3,
-            "separator": ":",
-            "instance" : "redis"
-        },
         "CONFIG_DB" : {
             "id" : 4,
             "separator": "|",

--- a/testdata/database_config_asic0.json
+++ b/testdata/database_config_asic0.json
@@ -22,11 +22,6 @@
             "separator": ":",
             "instance" : "redis"
         },
-        "LOGLEVEL_DB" : {
-            "id" : 3,
-            "separator": ":",
-            "instance" : "redis"
-        },
         "CONFIG_DB" : {
             "id" : 4,
             "separator": "|",


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
This PR is part of the following HLD:
Persistent loglevel HLD: https://github.com/sonic-net/SONiC/pull/1041

#### Why I did it
After the Logger tables moved from the LOGLEVEL_DB to the CONFIG_DB and the jinja2_cache was deleted the LOGLEVEL_DB is not in use.
#### How I did it
Removed the LOGLEVEL_DB from the SONiC code

#### How to verify it
All tests were passed

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

