### PR TITLE
Fix gnmi_cli from hanging when receiving events

### DIFF
--- a/patches/0001-Updated-to-filter-and-write-to-file.patch
+++ b/patches/0001-Updated-to-filter-and-write-to-file.patch
@@ -99,11 +99,6 @@ index e851a4b..6d04a74 100644
 +
 +			if *expected_cnt > 0 {
 +				rcvd_cnt += 1
-+				if *expected_cnt <= rcvd_cnt {
-+					s := fmt.Sprintf("Received all. expected:%d rcvd:%d", *expected_cnt, rcvd_cnt)
-+					log.V(7).Infof("Writing to terminate: %v", s)
-+					term <- s
-+				}
 +			}
 +			displayHandle.Write(prefix)
 +			displayHandle.Write(b)
@@ -151,7 +146,17 @@ index e851a4b..6d04a74 100644
  
 +	go func() {
 +		if *streaming_timeout > 0 {
-+			time.Sleep(time.Duration(*streaming_timeout) * time.Second)
++			var sleep_cnt uint = 0
++			for sleep_cnt < *streaming_timeout {
++				time.Sleep(time.Second)
++				sleep_cnt += 1
++				if *expected_cnt <= rcvd_cnt {
++					s := fmt.Sprintf("Received all. expected:%d rcvd:%d", *expected_cnt, rcvd_cnt)
++					log.V(7).Infof("Writing to terminate: %v", s)
++					term <- s
++					return
++				}
++			}
 +			s := fmt.Sprintf("Timeout %d Secs", *streaming_timeout)
 +			log.V(7).Infof("Writing to terminate: %v", s)
 +			term <- s


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Intermittently, gnmi_cli will hang when receiving events

#### How I did it

Remove channel write away from cfg, but instead use goroutine to periodically check received count, and after timeout reaches, cancel context

#### How to verify it

Nightly tests

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

