### PR TITLE
Add dataset for output of "df -h" into non-db-client

### DIFF
--- a/common_utils/context.go
+++ b/common_utils/context.go
@@ -51,6 +51,7 @@ const (
 	DBUS_DELETE_CHECKPOINT
 	DBUS_CONFIG_SAVE
 	DBUS_CONFIG_RELOAD
+	DBUS_DISK_UTILIZATION
 	COUNTER_SIZE
 )
 
@@ -82,6 +83,8 @@ func (c CounterType) String() string {
 		return "DBUS config save"
 	case DBUS_CONFIG_RELOAD:
 		return "DBUS config reload"
+	case DBUS_DISK_UTILIZATION:
+		return "DBUS disk utilization"
 	default:
 		return ""
 	}

--- a/sonic_data_client/non_db_client.go
+++ b/sonic_data_client/non_db_client.go
@@ -14,6 +14,7 @@ import (
 	linuxproc "github.com/c9s/goprocinfo/linux"
 	log "github.com/golang/glog"
 	gnmipb "github.com/openconfig/gnmi/proto/gnmi"
+	ssc "github.com/sonic-net/sonic-gnmi/sonic_service_client"
 )
 
 // Non db client is to Handle
@@ -101,6 +102,10 @@ var (
 			path:    []string{"OTHERS", "osversion", "build"},
 			getFunc: dataGetFunc(getBuildVersion),
 		},
+                { // Get disk utilization
+                        path:    []string{"OTHERS", "disk", "usage"},
+                        getFunc: dataGetFunc(getDiskUsage),
+                },
 	}
 )
 
@@ -329,6 +334,29 @@ func getBuildVersion() ([]byte, error) {
 		return b, err
 	}
 	log.V(4).Infof("getBuildVersion, output %v", string(b))
+	return b, nil
+}
+
+func getDiskUsage() ([]byte, error) {
+        var err error
+
+	var sc ssc.Service
+	sc, err = ssc.NewDbusClient()
+	if err != nil {
+		log.Errorf("Failed to create new dbus client")
+		return nil, err 
+	}
+	err, disk_util := sc.GetDiskUtilization()
+	if err != nil {
+		log.Errorf("Failed to get disk utilization %v", err)
+		return nil, err
+        }
+	b, err := json.Marshal(disk_util)
+	if err != nil {
+		log.V(2).Infof("%v", err)
+		return b, err
+	}
+	log.V(4).Infof("getDiskUsage, output %v", string(b))
 	return b, nil
 }
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Disk utilization output is currently missing in telemetry.
The disk utilization output by snmp is inaccurate - it reports for the snmp docker, and not the SONiC host machine.

#### How I did it
- Add path for gnmi to GET disk_utilization info
- Create sonic-host-services PR to add host service which reads output of `df -h` https://github.com/sonic-net/sonic-host-services/pull/29
- Connect gnmi GET disk_utilization API to dbus service
- Connect new host service which reads output of `df -h` to dbus service
- From gnmi GET API, call into dbus API that retrieves disk utilization info

#### How to verify it
Use gnmi_cli to read from the disk/usage path in OTHER dataset

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

