### PR TITLE
Fix crash when retrieving cpu utilization

### DIFF
--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -2777,7 +2777,7 @@ func TestCPUUtilization(t *testing.T) {
         "OTHERS",
         []subscriptionQuery{
             {
-                Query:    []string{"platform", "cpu"},
+                Query:    []string{"platform/cpu"},
                 SubMode:  pb.SubscriptionMode_SAMPLE,
                 SampleInterval: uint64(10*time.Second),
             },

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -2830,7 +2830,9 @@ func TestCPUUtilization(t *testing.T) {
             }
 
             go func() {
-                c.Subscribe(context.Background(), q)
+                if err := c.Subscribe(context.Background(), q); err != nil {
+                    t.Errorf("c.Subscribe(): got error %v, expected nil", err)
+                }
             }()
 
             // wait for half second for subscribeRequest to sync

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -2748,7 +2748,15 @@ func TestCPUUtilization(t *testing.T) {
     mock := gomonkey.ApplyFunc(sdc.PollStats, func() {
 	var i uint64
 	for i = 0; i < 3000; i++ {
-		sdc.WriteStatsToBuffer(&linuxproc.Stat{}, i)
+		sdc.WriteStatsToBuffer(&linuxproc.Stat{
+			CPUStatAll: linuxproc.CPUStat{
+				User:		i,
+				Nice:		i,
+				System:		i,
+				IRQ:		i,
+				SoftIRQ:	i,
+			},
+		}, i)
 	}
     })
 

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -2797,12 +2797,12 @@ func TestCPUUtilization(t *testing.T) {
 	    q: client.Query{
                 Target: "OTHERS",
 		Type:    client.Poll,
-		Queries: []client.Path{{"platform", "cpu"}},
+		Queries: []client.Path{{"platform/cpu"}},
 		TLS:     &tls.Config{InsecureSkipVerify: true},
 	    },
 	    wantNoti: []client.Notification{
                 client.Connected{},
-		client.Update{Path: []string{"platform", "cpu"}, TS: time.Unix(0, 200), Val: map[string]interface{}{}},
+		// client.Update{Path: []string{"platform/cpu"}, TS: time.Unix(0, 200), Val: map[string]interface{}{}},
 		client.Sync{},
 	    },
         },

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"flag"
 	"fmt"
+        "sync"
 	"strings"
 	"unsafe"
 

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -2748,15 +2748,7 @@ func TestCPUUtilization(t *testing.T) {
     mock := gomonkey.ApplyFunc(sdc.PollStats, func() {
 	var i uint64
 	for i = 0; i < 3000; i++ {
-		sdc.WriteStatsToBuffer(&linuxproc.Stat{
-			CPUStatAll: linuxproc.CPUStat{
-				User:		i,
-				Nice:		i,
-				System:		i,
-				IRQ:		i,
-				SoftIRQ:	i,
-			},
-		}, i)
+		sdc.WriteStatsToBuffer(&linuxproc.Stat{})
 	}
     })
 

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -2827,14 +2827,14 @@ func TestCPUUtilization(t *testing.T) {
             }
 
             go func() {
-                time.Sleep(time.Second * 30)
+                time.Sleep(time.Second * 300)
                 if err := c.Subscribe(context.Background(), q); err != nil {
                     t.Errorf("c.Subscribe(): got error %v, expected nil", err)
                 }
             }()
 
             // wait for half a second for subscribeRequest to sync
-            time.Sleep(time.Second * 35)
+            time.Sleep(time.Second * 305)
 
             for i := 0; i < tt.poll; i++ {
                 if err := c.Poll(); err != nil {

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -2798,7 +2798,7 @@ func TestCPUUtilization(t *testing.T) {
 	    q: client.Query{
                 Target: "OTHERS",
 		Type:    client.Poll,
-		Queries: []client.Path{{"platform", "cpu"}},
+		Queries: []client.Path{{"platform/cpu"}},
 		TLS:     &tls.Config{InsecureSkipVerify: true},
 	    },
 	    wantNoti: []client.Notification{

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -2799,9 +2799,11 @@ func TestCPUUtilization(t *testing.T) {
             defer c.Close()
             var gotNoti []string
             q.NotificationHandler = func(n client.Notification) error {
+                t.Log("Inside of notification handler")
                 if nn, ok := n.(client.Update); ok {
                     nn.TS = time.Unix(0, 200)
                     str := fmt.Sprintf("%v", nn.Val)
+		    t.Log(str)
                     gotNoti = append(gotNoti, str)
                 }
                 return nil
@@ -2812,7 +2814,7 @@ func TestCPUUtilization(t *testing.T) {
             }()
 
             t.Log(len(gotNoti))
-	    t.Log(gotNoti[0])
+	    // t.Log(gotNoti[0])
         })
     }
     s.s.Stop()

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -2797,12 +2797,12 @@ func TestCPUUtilization(t *testing.T) {
 	    q: client.Query{
                 Target: "OTHERS",
 		Type:    client.Poll,
-		Queries: []client.Path{{"platform/cpu"}},
+		Queries: []client.Path{{"platform", "cpu"}},
 		TLS:     &tls.Config{InsecureSkipVerify: true},
 	    },
 	    wantNoti: []client.Notification{
                 client.Connected{},
-		// client.Update{Path: []string{"platform/cpu"}, TS: time.Unix(0, 200), Val: map[string]interface{}{}},
+		// client.Update{Path: []string{"platform", "cpu"}, TS: time.Unix(0, 200), Val: map[string]interface{}{}},
 		client.Sync{},
 	    },
         },

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -2835,8 +2835,8 @@ func TestCPUUtilization(t *testing.T) {
                 }
             }()
 
-            // wait for half second for subscribeRequest to sync
-            time.Sleep(time.Millisecond * 500)
+            // wait for 5 second for linuxproc.ReadStat buffer to fill
+            time.Sleep(time.Second * 5)
 
             for i := 0; i < tt.poll; i++ {
                 if err := c.Poll(); err != nil {

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -2767,7 +2767,7 @@ func TestCPUUtilization(t *testing.T) {
     })
 
     defer mock.Reset()
-    s := createAuthServer(t, 8081)
+    s := createServer(t, 8081)
     go runServer(t, s)
     defer s.s.Stop()
 

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -2820,9 +2820,6 @@ func TestCPUUtilization(t *testing.T) {
                 if nn, ok := n.(client.Update); ok {
                     nn.TS = time.Unix(0, 200)
 		    gotNoti = append(gotNoti, nn)
-		    //str := fmt.Sprintf("%v", nn.Val)
-		    //t.Log(str)
-                    //gotNoti = append(gotNoti, str)
                 } else {
                     gotNoti = append(gotNoti, n)
 	        }
@@ -2830,13 +2827,14 @@ func TestCPUUtilization(t *testing.T) {
             }
 
             go func() {
+                time.Sleep(time.Second * 300)
                 if err := c.Subscribe(context.Background(), q); err != nil {
                     t.Errorf("c.Subscribe(): got error %v, expected nil", err)
                 }
             }()
 
-            // wait for 5 second for linuxproc.ReadStat buffer to fill
-            time.Sleep(time.Second * 300)
+            // wait for half a second for subscribeRequest to sync
+            time.Sleep(time.Second * 305)
 
             for i := 0; i < tt.poll; i++ {
                 if err := c.Poll(); err != nil {

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -2744,19 +2744,18 @@ func TestAuthCapabilities(t *testing.T) {
 }
 
 func createCPUStat(increment uint64) (*linuxproc.Stat) {
-    var stat linuxproc.Stat = linuxproc.Stat{}
-    cpuStat := linuxproc.CPUStat{}
-    cpuStat.User = increment
-    cpuStat.Nice = increment
-    cpuStat.System = increment
-    cpuStat.IRQ = increment
-    cpuStat.SoftIRQ = increment
-    stat.CPUStatAll = cpuStat
-    return &stat
+    return &linuxproc.Stat{
+        CPUStatAll: linuxproc.CPUStat{
+            User:       increment,
+            Nice:       increment,
+            System:     increment,
+            IRQ:        increment,
+            SoftIRQ:    increment,
+        },
+    }
 }
 
 func TestCPUUtilization(t *testing.T) {
-    // will mock linuxproc.ReadStat
     var increment uint64 = 0
     mock := gomonkey.ApplyFunc(linuxproc.ReadStat, func(path string) (*linuxproc.Stat, error) {
         t.Log("mock linuxproc.ReadStat is called")
@@ -2834,16 +2833,17 @@ func TestCPUUtilization(t *testing.T) {
                 c.Subscribe(context.Background(), q)
             }()
 
+            // wait for half second for subscribeRequest to sync
+            time.Sleep(time.Millisecond * 500)
+
             for i := 0; i < tt.poll; i++ {
-                err := c.Poll()
-		if err != nil {
+                if err := c.Poll(); err != nil {
                     t.Errorf("c.Poll(): got error %v, expected nil", err)
                 }
 	    }
             t.Log(gotNoti)
         })
     }
-    s.s.Stop()
 }
 
 func TestClient(t *testing.T) {

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -2836,7 +2836,7 @@ func TestCPUUtilization(t *testing.T) {
             }()
 
             // wait for 5 second for linuxproc.ReadStat buffer to fill
-            time.Sleep(time.Second * 5)
+            time.Sleep(time.Second * 300)
 
             for i := 0; i < tt.poll; i++ {
                 if err := c.Poll(); err != nil {

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -2759,7 +2759,10 @@ func TestCPUUtilization(t *testing.T) {
     // will mock linuxproc.ReadStat
     var increment uint64 = 0
     mock := gomonkey.ApplyFunc(linuxproc.ReadStat, func(path string) (*linuxproc.Stat, error) {
+        t.Log("mock linuxproc.ReadStat is called")
+	t.Log(increment)
         stat := createCPUStat(increment)
+	t.Log(stat)
         increment += 1
         return stat, nil
     })

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -2809,7 +2809,7 @@ func TestCPUUtilization(t *testing.T) {
             }()
 
             t.Log(len(gotNoti))
-	    t.Log("got Noti first element: %v", gotNoti[0])
+	    t.Log(gotNoti[0])
         })
     }
     s.s.Stop()

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -2762,7 +2762,7 @@ func TestCPUUtilization(t *testing.T) {
 	t.Log(increment)
         stat := createCPUStat(increment)
 	t.Log(stat)
-        increment += 1
+        // increment += 1
         return stat, nil
     })
 
@@ -2827,14 +2827,14 @@ func TestCPUUtilization(t *testing.T) {
             }
 
             go func() {
-                time.Sleep(time.Second * 300)
+                time.Sleep(time.Second * 30)
                 if err := c.Subscribe(context.Background(), q); err != nil {
                     t.Errorf("c.Subscribe(): got error %v, expected nil", err)
                 }
             }()
 
             // wait for half a second for subscribeRequest to sync
-            time.Sleep(time.Second * 305)
+            time.Sleep(time.Second * 35)
 
             for i := 0; i < tt.poll; i++ {
                 if err := c.Poll(); err != nil {

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -2745,8 +2745,11 @@ func TestAuthCapabilities(t *testing.T) {
 }
 
 func TestCPUUtilization(t *testing.T) {
-    mock := gomonkey.ApplyFunc(linuxproc.ReadStat, func(path string) (*linuxproc.Stat, error) {
-        return &linuxproc.Stat{}, nil
+    mock := gomonkey.ApplyFunc(sdc.PollStats, func() {
+	var i uint64
+	for i = 0; i < 3000; i++ {
+		sdc.WriteStatsToBuffer(&linuxproc.Stat{}, i)
+	}
     })
 
     defer mock.Reset()
@@ -2797,8 +2800,6 @@ func TestCPUUtilization(t *testing.T) {
 
             go func() {
                 defer wg.Done()
-                // wait for stats buffer to contain 3000 obj
-                time.Sleep(time.Second * 300)
                 if err := c.Subscribe(context.Background(), q); err != nil {
                     t.Errorf("c.Subscribe(): got error %v, expected nil", err)
                 }

--- a/sonic_data_client/non_db_client.go
+++ b/sonic_data_client/non_db_client.go
@@ -136,7 +136,7 @@ func getCpuUtilPercents(cur, last *linuxproc.CPUStat) uint64 {
 	lastTotal := (last.User + last.Nice + last.System + last.Idle + last.IOWait + last.IRQ + last.SoftIRQ + last.Steal)
 	idleTicks := cur.Idle - last.Idle
 	totalTicks := curTotal - lastTotal
-	if totalTicks == 0 { // no change in cpu utilization
+	if totalTicks == 0 { // No change in CPU Utilization
             return 0
 	}
 	return 100 * (totalTicks - idleTicks) / totalTicks

--- a/sonic_data_client/non_db_client.go
+++ b/sonic_data_client/non_db_client.go
@@ -132,10 +132,14 @@ type cpuUtil struct {
 }
 
 func getCpuUtilPercents(cur, last *linuxproc.CPUStat) uint64 {
-	curTotal := (cur.User + cur.Nice + cur.System + cur.Idle + cur.IOWait + cur.IRQ + cur.SoftIRQ + cur.Steal + cur.Guest + cur.GuestNice)
-	lastTotal := (last.User + last.Nice + last.System + last.Idle + last.IOWait + last.IRQ + last.SoftIRQ + last.Steal + last.Guest + last.GuestNice)
+	curTotal := (cur.User + cur.Nice + cur.System + cur.Idle + cur.IOWait + cur.IRQ + cur.SoftIRQ + cur.Steal)
+	lastTotal := (last.User + last.Nice + last.System + last.Idle + last.IOWait + last.IRQ + last.SoftIRQ + last.Steal)
 	idleTicks := cur.Idle - last.Idle
 	totalTicks := curTotal - lastTotal
+	if totalTicks == 0 {
+		log.V(1).Infof("No change in cpu utilization, current total: %v and last total: %v", curTotal, lastTotal)
+		return 0
+	}
 	return 100 * (totalTicks - idleTicks) / totalTicks
 }
 

--- a/sonic_data_client/non_db_client.go
+++ b/sonic_data_client/non_db_client.go
@@ -335,9 +335,11 @@ func getBuildVersion() ([]byte, error) {
 	return b, nil
 }
 
-func WriteStatsToBuffer(stat *linuxproc.Stat, index uint64) {
+func WriteStatsToBuffer(stat *linuxproc.Stat) {
 	statsR.mu.Lock()
-	statsR.buff[index] = stat
+	statsR.buff[statsR.writeIdx] = stat
+	statsR.writeIdx++
+	statsR.writeIdx %= statsRingCap
 	statsR.mu.Unlock()
 }
 
@@ -349,9 +351,7 @@ func PollStats() {
 			continue
 		}
 
-		WriteStatsToBuffer(stat, statsR.writeIdx)
-		statsR.writeIdx++
-		statsR.writeIdx %= statsRingCap
+		WriteStatsToBuffer(stat)
 		time.Sleep(time.Millisecond * 100)
 	}
 

--- a/sonic_data_client/non_db_client.go
+++ b/sonic_data_client/non_db_client.go
@@ -136,9 +136,8 @@ func getCpuUtilPercents(cur, last *linuxproc.CPUStat) uint64 {
 	lastTotal := (last.User + last.Nice + last.System + last.Idle + last.IOWait + last.IRQ + last.SoftIRQ + last.Steal)
 	idleTicks := cur.Idle - last.Idle
 	totalTicks := curTotal - lastTotal
-	if totalTicks == 0 {
-		log.V(1).Infof("No change in cpu utilization, current total: %v and last total: %v", curTotal, lastTotal)
-		return 0
+	if totalTicks == 0 { // no change in cpu utilization
+            return 0
 	}
 	return 100 * (totalTicks - idleTicks) / totalTicks
 }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Fix crash in which there was a divide by zero error inside retrieving cpu utilization

`Dec   1 04:31:03 PHX70-0101-0719-14T1 telemetry#/supervisord: telemetry   #011/sonic/src/sonic-telemetry/sonic_data_client/non_db_client.go:139 +0x99`
`Dec   1 04:31:03 PHX70-0101-0719-14T1 telemetry#/supervisord: telemetry   github.com/Azure/sonic-telemetry/sonic_data_client.getCpuUtil`
`Dec   1 04:31:03 PHX70-0101-0719-14T1 telemetry#/supervisord: telemetry   #011/sonic/src/sonic-telemetry/sonic_data_client/non_db_client.go:221 +0x34`
`Dec   1 04:31:03 PHX70-0101-0719-14T1 telemetry#/supervisord: telemetry   (0xc000000006, 0xc002e0ae00, 0x1, 0x1, 0x0)`
`Dec   1 04:31:03 PHX70-0101-0719-14T1 telemetry#/supervisord: telemetry   github.com/Azure/sonic-telemetry/sonic_data_client.getCpuUtilStat(0x0)`
`Dec   1 04:31:03 PHX70-0101-0719-14T1 telemetry#/supervisord: telemetry goroutine   742 [running]:`
`Dec   1 04:31:03 PHX70-0101-0719-14T1 telemetry#/supervisord: telemetry   #011/sonic/src/sonic-telemetry/sonic_data_client/non_db_client.go:162 +0x2e6`
`Dec   1 04:31:03 PHX70-0101-0719-14T1 telemetry#/supervisord: telemetry   github.com/Azure/sonic-telemetry/sonic_data_client.(*NonDbClient).PollRun(0xc001bc42a0,   0xc00027eaf0, 0xc001bc83c0, 0xc001be8868, 0xc001be8880)`
`Dec   1 04:31:03 PHX70-0101-0719-14T1 telemetry#/supervisord: telemetry`
`Dec   1 04:31:03 PHX70-0101-0719-14T1 telemetry#/supervisord: telemetry   #011/sonic/src/sonic-telemetry/sonic_data_client/non_db_client.go:538 +0xd4`
`Dec   1 04:31:03 PHX70-0101-0719-14T1 telemetry#/supervisord: telemetry   #011/sonic/src/sonic-telemetry/gnmi_server/client_subscribe.go:146 +0x765`
`Dec   1 04:31:03 PHX70-0101-0719-14T1 telemetry#/supervisord: telemetry   github.com/Azure/sonic-telemetry/sonic_data_client.runGetterAndSend(0xc001bc42a0,   0xc001be8a00, 0x101cc08, 0x0, 0x0)`
`Dec   1 04:31:03 PHX70-0101-0719-14T1 telemetry#/supervisord: telemetry created by   github.com/Azure/sonic-telemetry/gnmi_server.(*Client).Run`
`Dec   1 04:31:03 PHX70-0101-0719-14T1 telemetry#/supervisord: telemetry   github.com/Azure/sonic-telemetry/sonic_data_client.getCpuUtilPercents(0xc00239c300,   0xc002e0aa30, 0x2)`
`Dec   1 04:31:03 PHX70-0101-0719-14T1 telemetry#/supervisord: telemetry panic:   runtime error: integer divide by zero`
`Dec   1 04:31:03 PHX70-0101-0719-14T1 telemetry#/supervisord: telemetry   #011/sonic/src/sonic-telemetry/sonic_data_client/non_db_client.go:499 +0x3c`

#### How I did it

Add edge case check and UT

#### How to verify it

Run UT

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

