### PR TITLE
Test tools for running telemetry servers and clients locally

### DIFF
--- a/sonic_db_config/db_config.go
+++ b/sonic_db_config/db_config.go
@@ -203,6 +203,10 @@ func DbGetNamespaceAndConfigFile(ns_to_cfgfile_map map[string]string) {
 	} else if errors.Is(err, os.ErrNotExist) {
 		// Ref: https://stackoverflow.com/questions/23452157/how-do-i-check-for-specific-types-of-error-among-those-returned-by-ioutil-readfi
 		ns_to_cfgfile_map[SONIC_DEFAULT_NAMESPACE] = SONIC_DB_CONFIG_FILE
+		// Tests can override the file path via an env variable
+		if f, ok := os.LookupEnv("DB_CONFIG_PATH"); ok {
+			ns_to_cfgfile_map[SONIC_DEFAULT_NAMESPACE] = f
+		}
 		sonic_db_multi_namespace = false
 	} else {
 		panic(err)

--- a/tools/test/env.sh
+++ b/tools/test/env.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -e
+
+. $(dirname ${BASH_SOURCE})/../../../sonic-mgmt-common/tools/test/env.sh \
+    --dest=${TOPDIR}/build/test \
+    --dbconfig-in=${TOPDIR}/testdata/database_config.json \

--- a/tools/test/get.sh
+++ b/tools/test/get.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -e
+
+function print_usage() {
+cat <<EOM
+usage: $(basename $0) [OPTIONS] PATH* [-- [gnmi_get args]]
+
+OPTIONS:
+  -host HOST        Server IP address (default 127.0.0.1)
+  -port PORT        Server port (default 8080)
+  -proto            Use PROTO encoding
+  -user USER:PASS   Username and password for authentication
+  -origin ORIGIN    Origin to be prefixed to subsequent paths
+
+EOM
+}
+
+TOPDIR=$(git rev-parse --show-toplevel)
+BINDIR=${TOPDIR}/build/bin
+gnmi_get=$(realpath --relative-to ${PWD} ${BINDIR}/gnmi_get)
+
+if [[ ! -f ${gnmi_get} ]]; then
+    echo "error: gNMI tools are not compiled"
+    echo "Please run 'make telemetry' and try again"
+    exit 1
+fi
+
+HOST=localhost
+PORT=8080
+ARGS=()
+PATHS=()
+ORIGN=
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+    -h|-help|--help)
+        print_usage
+        exit 0;;
+    -H|-host|--host)
+        HOST=$2
+        shift 2;;
+    -p|-port|--port)
+        PORT=$2
+        shift 2;;
+    -u|-user|--user)
+        ARGS+=( -username "${2%%:*}" -password "${2#*:}" )
+        shift 2;;
+    -proto|--proto)
+        ARGS+=( -encoding PROTO )
+        shift;;
+    -origin|--origin)
+        ORIGN=$2
+        shift 2;;
+    [/_a-zA-Z]*)
+        PATHS+=( -xpath "/${ORIGN}:${1#/}" )
+        shift;;
+    --)
+        shift
+        ARGS+=( "$@" )
+        break;;
+    *)
+        echo "error: unknown option: $1"
+        print_usage
+        exit 1;;
+    esac
+done
+
+ARGS+=( -insecure )
+[[ "$@" =~ -(also)?log*  ]] || ARGS+=( -logtostderr )
+[[ "$@" =~ -target_addr* ]] || ARGS+=( -target_addr ${HOST}:${PORT} )
+
+set -x
+${gnmi_get} "${ARGS[@]}" "${PATHS[@]}"

--- a/tools/test/set.sh
+++ b/tools/test/set.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -e
+
+function print_usage() {
+cat <<EOM
+usage: $(basename $0) [OPTIONS] OPERATION* [-- [gnmi_set args]]
+
+OPTIONS:
+  -host HOST          Server IP address (default 127.0.0.1)
+  -port PORT          Server port (default 8080)
+  -user USER:PASS     Username and password for authentication
+  -origin ORIGIN      Origin to be prefixed to subsequent paths
+
+OPERATION: (can be repeated)
+  -delete  PATH       Delete path
+  -update  PATH JSON  Update path and json value
+  -replace PATH JSON  Replace path and json value
+
+EOM
+}
+
+TOPDIR=$(git rev-parse --show-toplevel)
+BINDIR=${TOPDIR}/build/bin
+gnmi_set=$(realpath --relative-to ${PWD} ${BINDIR}/gnmi_set)
+
+if [[ ! -f ${gnmi_set} ]]; then
+    echo "error: gNMI tools are not compiled"
+    echo "Please run 'make telemetry' and try again"
+    exit 1
+fi
+
+HOST=localhost
+PORT=8080
+ARGS=()
+ORIGIN=
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+    -h|-help|--help)
+        print_usage
+        exit 0;;
+    -H|-host|--host)
+        HOST=$2
+        shift 2;;
+    -p|-port|--port)
+        PORT=$2
+        shift 2;;
+    -u|-user|--user)
+        ARGS+=( -username "${2%%:*}" -password "${2#*:}" )
+        shift 2;;
+    -origin|--origin)
+        ORIGIN=$2
+        shift 2;;
+    -D|-delete|--delete)
+        ARGS+=( -delete "/${ORIGIN}:${2#/}" )
+        shift 2;;
+    -U|-update|--update)
+        F=$(mktemp -t 'u_XXXXX.json')
+        echo "$3" > $F
+        ARGS+=( -update "/${ORIGIN}:${2#/}:@$F" )
+        shift 3;;
+    -R|-replace|--replace)
+        F=$(mktemp -t 'r_XXXXX.json')
+        echo "$3" > $F
+        ARGS+=( -replace "/${ORIGIN}:${2#/}:@$F" )
+        shift 3;;
+    --)
+        shift
+        ARGS+=( "$@" )
+        break;;
+    *)
+        echo "error: unknown option: $1"
+        print_usage
+        exit 1;;
+    esac
+done
+
+ARGS+=( -insecure )
+[[ "$@" =~ -(also)?log*  ]] || ARGS+=( -logtostderr )
+[[ "$@" =~ -target_addr* ]] || ARGS+=( -target_addr ${HOST}:${PORT} )
+
+set -x
+${gnmi_set} "${ARGS[@]}"

--- a/tools/test/subscribe.sh
+++ b/tools/test/subscribe.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+set -e
+
+function print_usage() {
+echo "usage: $(basename $0) [OPTIONS] [MODE] PATH*"
+echo ""
+echo "MODE (one of):"
+echo "  -onchange         ON_CHANGE subscription"
+echo "  -sample SECS      SAMPLE subscription with sample interval seconds"
+echo "  -target-defined   TARGET_DEFINED subscription"
+echo "  -once             ONCE subscription (default mode)"
+echo "  -poll SECS        POLL subscription with poll interval seconds"
+echo ""
+echo "OPTIONS:"
+echo "  -host HOST        Server IP address (default 127.0.0.1)"
+echo "  -port PORT        Server port (default 8080)"
+echo "  -user NAME:PASS   Username and password for authentication"
+echo "  -proto            Request PROTO encoded notifications"
+echo "  -brief            Display compact output -- {path, value} lines"
+echo "  -heartbeat SECS   Set heartbeat_interval value in seconds"
+echo "  -noredundant      Set suppress_redundant flag"
+echo ""
+}
+
+TOPDIR=$(git rev-parse --show-toplevel || echo ${PWD})
+BINDIR=${TOPDIR}/build/bin
+GNMCLI=$(realpath --relative-to ${PWD} ${BINDIR}/gnmi_cli)
+
+if [[ ! -f ${GNMCLI} ]]; then
+    >&2 echo "error: gNMI tools were not compiled"
+    >&2 echo "Please run 'make telemetry' and try again"
+    exit 1
+fi
+
+HOST=localhost
+PORT=8080
+ARGS=()
+PATHS=()
+DISP=proto
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+    -h|-help|--help)
+        print_usage
+        exit 0;;
+    -once)
+        ARGS+=( -query_type once )
+        shift;;
+    -onchange|-on-change|-on_change)
+        ARGS+=( -query_type streaming )
+        ARGS+=( -streaming_type ON_CHANGE )
+        shift;;
+    -sample)
+        ARGS+=( -query_type streaming )
+        ARGS+=( -streaming_type SAMPLE )
+        ARGS+=( -streaming_sample_interval $2 )
+        shift 2;;
+    -td|-target-defined|-target_defined)
+        ARGS+=( -query_type streaming )
+        ARGS+=( -streaming_type TARGET_DEFINED )
+        shift;;
+    -poll)
+        ARGS+=( -query_type polling )
+        ARGS+=( -polling_interval $2s )
+        shift 2;;
+    -pass)
+        ARGS+=( -with_user_pass )
+        shift;;
+    -proto)
+        ARGS+=( -encoding PROTO )
+        shift;;
+    -heartbeat|-heartbeat_interval)
+        ARGS+=( -heartbeat_interval $2 )
+        shift 2;;
+    -noredundant|-suppress_redundant)
+        ARGS+=( -suppress_redundant )
+        shift;;
+    -H|-host)
+        HOST=$2
+        shift 2;;
+    -p|-port)
+        PORT=$2
+        shift 2;;
+    -u|-user)
+        ARGS+=( -username "${2%%:*}" -password "${2#*:}" )
+        shift 2;;
+    -brief)
+        DISP=single
+        shift;;
+    [/_a-zA-Z]*)
+        PATHS+=( "$1" )
+        shift;;
+    *)
+        echo "error: unknown option: $1"
+        print_usage
+        exit 1;;
+    esac
+done
+
+if [[ -z ${PATHS} ]]; then
+    echo "error: At least one path required"
+    exit 1
+fi
+
+ARGS+=( -insecure )
+ARGS+=( -logtostderr )
+ARGS+=( -address ${HOST}:${PORT} )
+ARGS+=( -display_type ${DISP} )
+ARGS+=( -target OC_YANG )
+ARGS+=( -timestamp on )
+ARGS+=( -query $(IFS=,; echo "${PATHS[*]}") )
+
+set -x
+${GNMCLI} "${ARGS[@]}"

--- a/tools/test/telemetry.sh
+++ b/tools/test/telemetry.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -e
+
+TOPDIR=$(git rev-parse --show-toplevel || echo ${PWD})
+ARGV=()
+
+for V in "$@"; do
+    case "$V" in
+    -port|--port|-port=*|--port=*) HAS_PORT=1 ;;
+    -v|--v|-v=*|--v=*) HAS_V=1 ;;
+    -*logto*|--*logto*|-log_dir*|--log_dir*) HAS_LOG=1;;
+    -server_crt|--server_crt|-server_crt=*|--server_crt=*) HAS_CERT=1 ;;
+    -server_key|--server_key|-server_key=*|--server_key=*) HAS_CERT=1 ;;
+    -client_auth|--client_auth|-client_auth=*|--client_auth=*) HAS_AUTH=1 ;;
+    esac
+    ARGV+=( $V )
+done
+
+source ${TOPDIR}/tools/test/env.sh
+
+TELEMETRY_BIN=${TOPDIR}/build/bin/telemetry
+if [[ ! -f ${TELEMETRY_BIN} ]]; then
+    >&2 echo "error: Telemetry server not compiled"
+    >&2 echo "Please run 'make telemetry' and try again"
+    exit 1
+fi
+
+EXTRA_ARGS=()
+[[ -z ${HAS_PORT} ]] && EXTRA_ARGS+=( -port 8080 )
+[[ -z ${HAS_LOG}  ]] && EXTRA_ARGS+=( -logtostderr )
+[[ -z ${HAS_V} ]]    && EXTRA_ARGS+=( -v 2 )
+[[ -z ${HAS_CERT} ]] && EXTRA_ARGS+=( -insecure )
+[[ -z ${HAS_AUTH} ]] && EXTRA_ARGS+=( -client_auth none )
+
+EXTRA_ARGS+=( -allow_no_client_auth )
+
+set -x
+${TELEMETRY_BIN} "${EXTRA_ARGS[@]}" "${ARGV[@]}"


### PR DESCRIPTION
Requires https://github.com/sonic-net/sonic-mgmt-common/pull/69

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Most of the gNMI functionalities can be verified on any development server by running redis, telemetry server, and clients locally. Helps quick testing/debugging of changes before preparing the full build..

#### How I did it

1) Added wrapper scripts to launch the server and client binaries from build/bin directory. These scripts prepare necessary environment (as required by translib) and fill default arguments whenever possible.. These scripts are not packaged in the docker image.

2) Enhanced the db_config parser to allow overriding database_config.json path through an env variable DB_CONFIG_PATH (same as the translib test tools). This helps running test tools on shared servers, where default paths are not accessible. Test server launcher script sets this variable. It will not be set in the telemetry docker -- uses the default file paths.
 
#### How to verify it

- Run `tools/test/telemetry.sh` to start the telemetry server locally
- Run `tools/test/set.sh -update /openconfig-acl:acl/acl-sets/acl-set '{"acl-set": [{"name": "TEST", "type": "ACL_IPV4", "config": {"name": "TEST", "type": "ACL_IPV4", "description": "foo"}}]}'` to verify a set operation
- Run `tools/test/get.sh /openconfig-acl:acl/acl-sets` to verify a get operation
- Run `tools/test/set.sh -delete /openconfig-acl:acl/acl-sets/acl-set[name=TEST][type=ACL_IPV4]` to verify delete
- Run `tools/test/subscribe.sh -sample 20 /openconfig-acl:acl/acl-sets` to start a subscribe client

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

