### PR TITLE
Limit client connections connecting to gnmi server

### DIFF
--- a/gnmi_server/client_subscribe.go
+++ b/gnmi_server/client_subscribe.go
@@ -37,7 +37,6 @@ const logLevelError int = 3
 const logLevelDebug int = 7
 const logLevelMax int = logLevelDebug
 
-var doOnce sync.Once
 var connectionManager *ConnectionManager
 
 // NewClient returns a new initialized client.

--- a/gnmi_server/connection_manager.go
+++ b/gnmi_server/connection_manager.go
@@ -1,10 +1,10 @@
 package gnmi
 
 import (
-	"fmt"
-	"io"
-	"net"
 	"sync"
+	"time"
+	"net"
+	"regexp"
 	log "github.com/golang/glog"
 )
 
@@ -20,25 +20,44 @@ func (cm *ConnectionManager) Count() int {
 	return len(cm.connections)
 }
 
-func (cm *ConnectionManager) Add(key string) (success bool) {
+func (cm *ConnectionManager) Add(addr net.Addr, query string) (string, bool) {
 	cm.mu.Lock()
 	defer cm.mu.Unlock()
-	if len(cm.connections) >= threshold {
+	if len(cm.connections) >= cm.threshold {
 		log.V(1).Infof("Cannot add another client connection as threshold is already at limit")
-		return false
+		return "", false
 	}
+	key := createKey(addr, query)
 	log.V(1).Infof("Adding client connection: %s", key)
-	cm.connections[key] = struct{}
-	log.V(1).Infof("Current number of existing connections: %d", len(cm.connections)
-	return true
+	cm.connections[key] = struct{}{}
+	log.V(1).Infof("Current number of existing connections: %d", len(cm.connections))
+	return key, true
 }
 
-func (cm *ConnectionManager) Remove(key string) (success bool) {
+func (cm *ConnectionManager) Remove(key string) (bool) {
 	cm.mu.Lock()
 	defer cm.mu.Unlock()
-	_, exists := cm.connections[key]; exists {
+	_, exists := cm.connections[key]
+	if exists {
 		log.V(1).Infof("Closing connection: %s", key)
 		delete(cm.connections, key)
 	}
 	return exists
+}
+
+func createKey(addr net.Addr, query string) string {
+	regexStr := "(?:target|element):\"([a-zA-Z0-9-_]*)\""
+	regex := regexp.MustCompile(regexStr)
+	matches := regex.FindAllStringSubmatch(query, -1)
+	// connectionKeyString will look like "10.0.0.1|OTHERS|proc|uptime|2017-07-04 00:47:20
+	connectionKey := addr.String() + "|"
+	for i := 0; i < len(matches); i++ {
+		if len(matches[i]) < 2 {
+			continue
+		}
+		connectionKey += matches[i][1] // index 1 contains the value we need
+		connectionKey += "|"
+	}
+	connectionKey += time.Now().UTC().Format(time.RFC3339)
+	return connectionKey
 }

--- a/gnmi_server/connection_manager.go
+++ b/gnmi_server/connection_manager.go
@@ -55,7 +55,6 @@ func (cm *ConnectionManager) Add(addr net.Addr, query string) (string, bool) {
 	cm.mu.Lock() // writing
 	cm.connections[key] = struct{}{}
 	cm.mu.Unlock()
-	log.V(1).Infof("Current number of existing connections: %d", len(cm.connections))
 	storeKeyRedis(key)
 	return key, true
 }

--- a/gnmi_server/connection_manager.go
+++ b/gnmi_server/connection_manager.go
@@ -1,0 +1,44 @@
+package gnmi
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	log "github.com/golang/glog"
+)
+
+type ConnectionManager struct {
+	connections  map[string]struct{}
+	mu           sync.Mutex
+	threshold    int
+}
+
+func (cm *ConnectionManager) Count() int {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+	return len(cm.connections)
+}
+
+func (cm *ConnectionManager) Add(key string) (success bool) {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+	if len(cm.connections) >= threshold {
+		log.V(1).Infof("Cannot add another client connection as threshold is already at limit")
+		return false
+	}
+	log.V(1).Infof("Adding client connection: %s", key)
+	cm.connections[key] = struct{}
+	log.V(1).Infof("Current number of existing connections: %d", len(cm.connections)
+	return true
+}
+
+func (cm *ConnectionManager) Remove(key string) (success bool) {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+	_, exists := cm.connections[key]; exists {
+		log.V(1).Infof("Closing connection: %s", key)
+		delete(cm.connections, key)
+	}
+	return exists
+}

--- a/gnmi_server/connection_manager.go
+++ b/gnmi_server/connection_manager.go
@@ -22,7 +22,7 @@ type ConnectionManager struct {
 }
 
 func (cm *ConnectionManager) PrepareRedis() {
-        ns := sdcfg.GetDbDefaultNamespace()
+	ns := sdcfg.GetDbDefaultNamespace()
 	rclient = redis.NewClient(&redis.Options{
 		Network:     "tcp",
 		Addr:        sdcfg.GetDbTcpAddr("STATE_DB", ns),

--- a/gnmi_server/server.go
+++ b/gnmi_server/server.go
@@ -243,7 +243,7 @@ func (s *Server) Subscribe(stream gnmipb.GNMI_SubscribeServer) error {
 	c := NewClient(pr.Addr)
 
 	c.setLogLevel(s.config.LogLevel)
-	c.setThreshold(s.config.Threshold)
+	c.setConnectionManager(s.config.Threshold)
 
 	s.cMu.Lock()
 	if oc, ok := s.clients[c.String()]; ok {

--- a/gnmi_server/server.go
+++ b/gnmi_server/server.go
@@ -48,6 +48,7 @@ type Config struct {
 	// for this Server.
 	Port     int64
 	LogLevel int
+	Threshold int
 	UserAuth AuthTypes
 	EnableTranslibWrite bool
 	EnableNativeWrite bool
@@ -242,6 +243,7 @@ func (s *Server) Subscribe(stream gnmipb.GNMI_SubscribeServer) error {
 	c := NewClient(pr.Addr)
 
 	c.setLogLevel(s.config.LogLevel)
+	c.setThreshold(s.config.Threshold)
 
 	s.cMu.Lock()
 	if oc, ok := s.clients[c.String()]; ok {

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -2831,7 +2831,7 @@ func TestClientConnections(t *testing.T) {
     tests := []struct {
         desc      string
 	q         client.Query
-	updates   []tablePathValue 
+	updates   []tablePathValue
 	wantNoti  []client.Notification
     }{
          {
@@ -2860,7 +2860,7 @@ func TestClientConnections(t *testing.T) {
                  client.Update{Path: []string{"COUNTERS", "Ethernet*"}, TS: time.Unix(0, 200), Val: countersEthernetWildcardJson}, client.Sync{},
                  client.Update{Path: []string{"COUNTERS", "Ethernet*"}, TS: time.Unix(0, 200), Val: countersEtherneWildcardJsonUpdate},
              },
-        }
+        },
     }
 
     for _, tt := range tests {

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -2898,7 +2898,7 @@ func TestClientConnections(t *testing.T) {
 
     t.Run(tests[0].desc, func(t *testing.T) {
         wg := new(sync.WaitGroup)
-        wg.Add(1)
+        wg.Add(len(tests[0].q))
 
         for i, q := range tests[0].q {
 	    q.Addrs = []string{"127.0.0.1:8081"}

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -2890,18 +2890,12 @@ func TestClientConnections(t *testing.T) {
 
             go func() {
                 defer wg.Done()
-                if err := c.Subscribe(context.Background(), q); err != nil {
-			t.Errorf("c.Subscribe(): received error: %v", err)
+                if err := c.Subscribe(context.Background(), q); err == nil {
+			t.Errorf("c.Subscribe(): should have received server capacity error")
                 }
             }()
 
             wg.Wait()
-
-            for i := 0; i < tt.poll; i++ {
-                if err := c.Poll(); err != nil {
-                    t.Errorf("c.Poll(): got error %v, expected nil", err)
-                }
-	    }
 
 	    c.Close()
         })

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -2905,16 +2905,15 @@ func TestClientConnections(t *testing.T) {
                 wg.Done()
                 runtime.UnlockOSThread()
             }()
+        }
+        time.Sleep(time.Millisecond * 10)
+        close(start)
+        wg.Wait()
 
-            time.Sleep(time.Millisecond * 10)
-            close(start)
-            wg.Wait()
-
-	    t.Logf("Accepted connections: %d", accepted)
-            t.Logf("Rejected connections: %d", rejected)
-            if accepted != 1 && rejected != 1 {
-                t.Errorf("Accepted and rejected counts should be 1")
-            }
+	t.Logf("Accepted connections: %d", accepted)
+        t.Logf("Rejected connections: %d", rejected)
+        if accepted != 1 && rejected != 1 {
+            t.Errorf("Accepted and rejected counts should be 1")
         }
     })
 }

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -108,7 +108,7 @@ func createServer(t *testing.T, port int64) *Server {
 	}
 
 	opts := []grpc.ServerOption{grpc.Creds(credentials.NewTLS(tlsCfg))}
-	cfg := &Config{Port: port, EnableTranslibWrite: true, EnableNativeWrite: true, Threshold: 100}
+	cfg := &Config{Port: port, EnableTranslibWrite: true, EnableNativeWrite: true}
 	s, err := NewServer(cfg, opts)
 	if err != nil {
 		t.Errorf("Failed to create gNMI server: %v", err)
@@ -2829,37 +2829,24 @@ func TestClientConnections(t *testing.T) {
     defer s.s.Stop()
 
     tests := []struct {
-        desc      string
-	q         client.Query
-	updates   []tablePathValue
-	wantNoti  []client.Notification
+        desc    string
+        q       client.Query
+        want    []client.Notification
+        poll    int
     }{
-         {
-             desc: "stream query for table key Ethernet* with new test_field field on Ethernet68",
-             q:    createCountersDbQueryOnChangeMode(t, "COUNTERS", "Ethernet*"),
-             updates: []tablePathValue{
-                 {
-                     dbName:    "COUNTERS_DB",
-                     tableName: "COUNTERS",
-                     tableKey:  "oid:0x1000000000039", // "Ethernet68": "oid:0x1000000000039",
-                     delimitor: ":",
-                     field:     "test_field",
-                     value:     "test_value",
-                 },
-                 { //Same value set should not trigger multiple updates
-                     dbName:    "COUNTERS_DB",
-                     tableName: "COUNTERS",
-                     tableKey:  "oid:0x1000000000039", // "Ethernet68": "oid:0x1000000000039",
-                     delimitor: ":",
-                     field:     "test_field",
-                     value:     "test_value",
-                 },
-             },
-             wantNoti: []client.Notification{
-                 client.Connected{},
-                 client.Update{Path: []string{"COUNTERS", "Ethernet*"}, TS: time.Unix(0, 200), Val: countersEthernetWildcardJson}, client.Sync{},
-                 client.Update{Path: []string{"COUNTERS", "Ethernet*"}, TS: time.Unix(0, 200), Val: countersEtherneWildcardJsonUpdate},
-             },
+        {
+            desc: "poll query for COUNTERS/Ethernet*",
+	    poll: 10,
+	    q: client.Query{
+                Target: "COUNTERS_DB",
+		Type:    client.Poll,
+		Queries: []client.Path{{"COUNTERS", "Ethernet*"}},
+		TLS:     &tls.Config{InsecureSkipVerify: true},
+	    },
+	    want: []client.Notification{
+                client.Connected{},
+		client.Sync{},
+	    },
         },
     }
 

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -2853,12 +2853,12 @@ func TestClientConnections(t *testing.T) {
 	poll    int
     }{
         {
-            desc: "poll query for DOCKER_STATS",
+            desc: "poll query for COUNTERS/Ethernet*",
 	    poll: 10,
 	    q: client.Query{
-                Target: "STATE_DB",
+                Target: "COUNTERS_DB",
 		Type:    client.Poll,
-		Queries: []client.Path{{"DOCKER_STATS"}},
+		Queries: []client.Path{{"COUNTERS", "Ethernet*"}},
 		TLS:     &tls.Config{InsecureSkipVerify: true},
 	    },
 	    want: []client.Notification{
@@ -2903,12 +2903,12 @@ func TestConnectionDataSet(t *testing.T) {
 	poll    int
     }{
         {
-            desc: "poll query for DOCKER_STATS",
+            desc: "poll query for COUNTERS/Ethernet*",
 	    poll: 10,
 	    q: client.Query{
-                Target: "STATE_DB",
+                Target: "COUNTERS_DB",
 		Type:    client.Poll,
-		Queries: []client.Path{{"DOCKER_STATS"}},
+		Queries: []client.Path{{"COUNTERS", "Ethernet*"}},
 		TLS:     &tls.Config{InsecureSkipVerify: true},
 	    },
 	    want: []client.Notification{
@@ -2950,8 +2950,8 @@ func TestConnectionDataSet(t *testing.T) {
             }
 
 	    for key, _ := range resultMap {
-                if !strings.Contains(key, "127.0.0.1|STATE_DB|DOCKER_STATS") {
-                    t.Errorf("key is expected to contain correct ip addr and query, received: %s", key)
+                if !strings.Contains(key, "COUNTERS_DB|COUNTERS|Ethernet*") {
+                    t.Errorf("key is expected to contain correct query, received: %s", key)
 		}
             }
 

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -2890,6 +2890,12 @@ func TestClientConnections(t *testing.T) {
 	client.New(),
     }
 
+    namespace := sdcfg.GetDbDefaultNamespace()
+    rclient := getRedisClientN(t, 6, namespace)
+    defer rclient.Close()
+
+    prepareStateDb(t, namespace)
+
     t.Run(tests[0].desc, func(t *testing.T) {
         for i, q := range tests[0].q {
 	    q.Addrs = []string{"127.0.0.1:8081"}
@@ -2920,6 +2926,17 @@ func TestClientConnections(t *testing.T) {
             }()
 
             wg.Wait()
+
+            resultMap, err := rclient.HGetAll("TELEMETRY_CONNECTIONS").Result()
+
+            if resultMap == nil {
+		    t.Errorf("result Map is nil, expected non nil, err: %v", err)
+	    }
+            t.Logf("After iteration")
+	    for key, _ := range resultMap {
+                t.Logf("key: %s", key)
+            }
+
         }
     })
 

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -2829,25 +2829,36 @@ func TestClientConnections(t *testing.T) {
     defer s.s.Stop()
 
     tests := []struct {
-        desc    string
-	q       client.Query
-	want    []client.Notification
-	poll    int
+        desc      string
+	q         client.Query
+	updates   []tablePathValue 
+	wantNoti  []client.Notification
     }{
-        {
-            desc: "poll query for COUNTERS/Ethernet*",
-	    poll: 10,
-	    q: client.Query{
-                Target: "COUNTERS_DB",
-		Type:    client.Poll,
-		Queries: []client.Path{{"COUNTERS", "Ethernet*"}},
-		TLS:     &tls.Config{InsecureSkipVerify: true},
-	    },
-	    want: []client.Notification{
-                client.Connected{},
-		client.Sync{},
-	    },
-        },
+         desc: "stream query for table key Ethernet* with new test_field field on Ethernet68",
+         q:    createCountersDbQueryOnChangeMode(t, "COUNTERS", "Ethernet*"),
+         updates: []tablePathValue{
+             {
+                 dbName:    "COUNTERS_DB",
+                 tableName: "COUNTERS",
+                 tableKey:  "oid:0x1000000000039", // "Ethernet68": "oid:0x1000000000039",
+                 delimitor: ":",
+                 field:     "test_field",
+                 value:     "test_value",
+             },
+             { //Same value set should not trigger multiple updates
+                 dbName:    "COUNTERS_DB",
+                 tableName: "COUNTERS",
+                 tableKey:  "oid:0x1000000000039", // "Ethernet68": "oid:0x1000000000039",
+                 delimitor: ":",
+                 field:     "test_field",
+                 value:     "test_value",
+             },
+         },
+         wantNoti: []client.Notification{
+             client.Connected{},
+             client.Update{Path: []string{"COUNTERS", "Ethernet*"}, TS: time.Unix(0, 200), Val: countersEthernetWildcardJson}, client.Sync{},
+             client.Update{Path: []string{"COUNTERS", "Ethernet*"}, TS: time.Unix(0, 200), Val: countersEtherneWildcardJsonUpdate},
+         },
     }
 
     for _, tt := range tests {
@@ -2866,7 +2877,6 @@ func TestClientConnections(t *testing.T) {
                         t.Errorf("c.Subscribe(): did not receive server capacity error")
                     }
                 }()
-
                 wg.Wait()
 	    }
             for _, client := range clients {

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -134,7 +134,7 @@ func createReadServer(t *testing.T, port int64) *Server {
 	return s
 }
 
-func createRejectServer(t *testing.T, port in64) *Server {
+func createRejectServer(t *testing.T, port int64) *Server {
 	certificate, err := testcert.NewCert()
 	if err != nil {
 		t.Errorf("could not load server key pair: %s", err)
@@ -2922,7 +2922,7 @@ func TestConnectionDataSet(t *testing.T) {
     defer rclient.Close()
 
     for _, tt := range tests {
-        prepareStateDb(t, namspace)
+        prepareStateDb(t, namespace)
         t.Run(tt.desc, func(t *testing.T) {
             q := tt.q
 	    q.Addrs = []string{"127.0.0.1:8081"}
@@ -2940,7 +2940,7 @@ func TestConnectionDataSet(t *testing.T) {
 
             wg.Wait()
 
-            resultMap := rclient.HGetAll("TELEMETRY_CONNECTIONS")
+            resultMap := rclient.HGetAll("TELEMETRY_CONNECTIONS").Result()
 
 	    if len(resultMap) != 1 {
                 t.Errorf("result for TELEMETRY_CONNECTIONS should be 1")

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -2940,8 +2940,11 @@ func TestConnectionDataSet(t *testing.T) {
 
             wg.Wait()
 
-            resultMap := rclient.HGetAll("TELEMETRY_CONNECTIONS").Result()
+            resultMap, err := rclient.HGetAll("TELEMETRY_CONNECTIONS").Result()
 
+            if resultMap == nil {
+		    t.Errorf("result Map is nil, expected non nil, err: %v", err)
+	    }
 	    if len(resultMap) != 1 {
                 t.Errorf("result for TELEMETRY_CONNECTIONS should be 1")
             }

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -107,7 +107,7 @@ func createServer(t *testing.T, port int64) *Server {
 	}
 
 	opts := []grpc.ServerOption{grpc.Creds(credentials.NewTLS(tlsCfg))}
-	cfg := &Config{Port: port, EnableTranslibWrite: true, EnableNativeWrite: true}
+	cfg := &Config{Port: port, EnableTranslibWrite: true, EnableNativeWrite: true, Threshold: 100}
 	s, err := NewServer(cfg, opts)
 	if err != nil {
 		t.Errorf("Failed to create gNMI server: %v", err)

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -147,7 +147,7 @@ func createLowThresholdServer(t *testing.T, port int64) *Server {
 	}
 
 	opts := []grpc.ServerOption{grpc.Creds(credentials.NewTLS(tlsCfg))}
-	cfg := &Config{Port: port, EnableTranslibWrite: true,  Threshold: 2}
+	cfg := &Config{Port: port, EnableTranslibWrite: true,  Threshold: 1}
 	s, err := NewServer(cfg, opts)
 	if err != nil {
 		t.Fatalf("Failed to create gNMI server: %v", err)

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -2912,7 +2912,7 @@ func TestClientConnections(t *testing.T) {
 
 	    t.Logf("Accepted connections: %d", accepted)
             t.Logf("Rejected connections: %d", rejected)
-            if accepted != && rejected != 1 {
+            if accepted != 1 && rejected != 1 {
                 t.Errorf("Accepted and rejected counts should be 1")
             }
         })

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -108,7 +108,7 @@ func createServer(t *testing.T, port int64) *Server {
 	}
 
 	opts := []grpc.ServerOption{grpc.Creds(credentials.NewTLS(tlsCfg))}
-	cfg := &Config{Port: port, EnableTranslibWrite: true, EnableNativeWrite: true}
+	cfg := &Config{Port: port, EnableTranslibWrite: true, EnableNativeWrite: true, Threshold: 1}
 	s, err := NewServer(cfg, opts)
 	if err != nil {
 		t.Errorf("Failed to create gNMI server: %v", err)

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -2853,12 +2853,12 @@ func TestClientConnections(t *testing.T) {
 	poll    int
     }{
         {
-            desc: "poll query for DOCKER_STATS",
+            desc: "poll query for COUNTERS/Ethernet*",
 	    poll: 10,
 	    q: client.Query{
-                Target: "STATE_DB",
+                Target: "COUNTERS_DB",
 		Type:    client.Poll,
-		Queries: []client.Path{{"DOCKER_STATS"}},
+		Queries: []client.Path{{"COUNTERS", "Ethernet*"}},
 		TLS:     &tls.Config{InsecureSkipVerify: true},
 	    },
 	    want: []client.Notification{

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -2855,7 +2855,7 @@ func TestClientConnections(t *testing.T) {
         poll    int
     }{
         {
-            desc: "Accept first two requests, reject third",
+            desc: "Accept first request, reject next",
             poll: 10,
             q: client.Query{
                 Target: "OTHERS",

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -2915,8 +2915,8 @@ func TestClientConnections(t *testing.T) {
             if accepted != 1 && rejected != 1 {
                 t.Errorf("Accepted and rejected counts should be 1")
             }
-        })
-    }
+        }
+    })
 }
 
 func TestConnectionDataSet(t *testing.T) {

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -2850,7 +2850,7 @@ func TestClientConnections(t *testing.T) {
 
     tests := []struct {
         desc    string
-        q       []client.Query
+        q       client.Query
         want    []client.Notification
         poll    int
     }{
@@ -2900,7 +2900,7 @@ func TestClientConnections(t *testing.T) {
                     atomic.AddInt32(&accepted, 1)
                 } else {
                     t.Logf("Error received: %v", err)
-                    atomic.addInt32(&rejected, 1)
+                    atomic.AddInt32(&rejected, 1)
                 }
                 wg.Done()
                 runtime.UnlockOSThread()

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -2834,31 +2834,33 @@ func TestClientConnections(t *testing.T) {
 	updates   []tablePathValue 
 	wantNoti  []client.Notification
     }{
-         desc: "stream query for table key Ethernet* with new test_field field on Ethernet68",
-         q:    createCountersDbQueryOnChangeMode(t, "COUNTERS", "Ethernet*"),
-         updates: []tablePathValue{
-             {
-                 dbName:    "COUNTERS_DB",
-                 tableName: "COUNTERS",
-                 tableKey:  "oid:0x1000000000039", // "Ethernet68": "oid:0x1000000000039",
-                 delimitor: ":",
-                 field:     "test_field",
-                 value:     "test_value",
+         {
+             desc: "stream query for table key Ethernet* with new test_field field on Ethernet68",
+             q:    createCountersDbQueryOnChangeMode(t, "COUNTERS", "Ethernet*"),
+             updates: []tablePathValue{
+                 {
+                     dbName:    "COUNTERS_DB",
+                     tableName: "COUNTERS",
+                     tableKey:  "oid:0x1000000000039", // "Ethernet68": "oid:0x1000000000039",
+                     delimitor: ":",
+                     field:     "test_field",
+                     value:     "test_value",
+                 },
+                 { //Same value set should not trigger multiple updates
+                     dbName:    "COUNTERS_DB",
+                     tableName: "COUNTERS",
+                     tableKey:  "oid:0x1000000000039", // "Ethernet68": "oid:0x1000000000039",
+                     delimitor: ":",
+                     field:     "test_field",
+                     value:     "test_value",
+                 },
              },
-             { //Same value set should not trigger multiple updates
-                 dbName:    "COUNTERS_DB",
-                 tableName: "COUNTERS",
-                 tableKey:  "oid:0x1000000000039", // "Ethernet68": "oid:0x1000000000039",
-                 delimitor: ":",
-                 field:     "test_field",
-                 value:     "test_value",
+             wantNoti: []client.Notification{
+                 client.Connected{},
+                 client.Update{Path: []string{"COUNTERS", "Ethernet*"}, TS: time.Unix(0, 200), Val: countersEthernetWildcardJson}, client.Sync{},
+                 client.Update{Path: []string{"COUNTERS", "Ethernet*"}, TS: time.Unix(0, 200), Val: countersEtherneWildcardJsonUpdate},
              },
-         },
-         wantNoti: []client.Notification{
-             client.Connected{},
-             client.Update{Path: []string{"COUNTERS", "Ethernet*"}, TS: time.Unix(0, 200), Val: countersEthernetWildcardJson}, client.Sync{},
-             client.Update{Path: []string{"COUNTERS", "Ethernet*"}, TS: time.Unix(0, 200), Val: countersEtherneWildcardJsonUpdate},
-         },
+        }
     }
 
     for _, tt := range tests {

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -108,7 +108,7 @@ func createServer(t *testing.T, port int64) *Server {
 	}
 
 	opts := []grpc.ServerOption{grpc.Creds(credentials.NewTLS(tlsCfg))}
-	cfg := &Config{Port: port, EnableTranslibWrite: true, EnableNativeWrite: true, Threshold: 1}
+	cfg := &Config{Port: port, EnableTranslibWrite: true, EnableNativeWrite: true, Threshold: -1}
 	s, err := NewServer(cfg, opts)
 	if err != nil {
 		t.Errorf("Failed to create gNMI server: %v", err)

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -31,6 +31,7 @@ var (
 	jwtValInt         = flag.Uint64("jwt_valid_int", 3600, "Seconds that JWT token is valid for.")
 	gnmi_translib_write = flag.Bool("gnmi_translib_write", gnmi.ENABLE_TRANSLIB_WRITE, "Enable gNMI translib write for management framework")
 	gnmi_native_write   = flag.Bool("gnmi_native_write", gnmi.ENABLE_NATIVE_WRITE, "Enable gNMI native write")
+	threshold         = flag.Int("threshold", 100, "max number of client connections")
 )
 
 func main() {
@@ -57,6 +58,12 @@ func main() {
 		log.Errorf("port must be > 0.")
 		return
 	}
+
+	switch {
+	case *threshold <= 0:
+		log.Errorf("threshold must be > 0.")
+		return
+	}
 	gnmi.JwtRefreshInt = time.Duration(*jwtRefInt*uint64(time.Second))
 	gnmi.JwtValidInt = time.Duration(*jwtValInt*uint64(time.Second))
 
@@ -65,6 +72,7 @@ func main() {
 	cfg.EnableTranslibWrite = bool(*gnmi_translib_write)
 	cfg.EnableNativeWrite = bool(*gnmi_native_write)
 	cfg.LogLevel = 3
+	cfg.Threshold = int(*threshold)
 	var opts []grpc.ServerOption
 
 	if val, err := strconv.Atoi(getflag("v")); err == nil {

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -60,7 +60,7 @@ func main() {
 	}
 
 	switch {
-	case *threshold <= 0:
+	case *threshold < 0:
 		log.Errorf("threshold must be > 0.")
 		return
 	}

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -3,6 +3,7 @@ package main
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"crypto/md5"
 	"flag"
 	"io/ioutil"
 	"strconv"
@@ -90,6 +91,9 @@ func main() {
 			}
 			certificate, err = tls.LoadX509KeyPair(*serverCert, *serverKey)
 			if err != nil {
+				currentTime := time.Now().UTC()
+				log.Infof("Server Cert md5 checksum: %x at time %s", md5.Sum([]byte(*serverCert)), currentTime.String())
+				log.Infof("Server Key md5 checksum: %x at time %s", md5.Sum([]byte(*serverKey)), currentTime.String())
 				log.Exitf("could not load server key pair: %s", err)
 			}
 		}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Incident in which client kept creating connections resulting in memory utilization alert

#### How I did it

Implemented threshold feature such that there is a total amount of 100 connections allowed and no more.

#### How to verify it

End to end test/UT

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

