### PR TITLE
Add keep alive policies to close idle client connections

### DIFF
--- a/gnmi_server/server.go
+++ b/gnmi_server/server.go
@@ -25,6 +25,7 @@ import (
 	"net"
 	"strings"
 	"sync"
+	"time"
 )
 
 var (

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -3060,12 +3060,11 @@ func TestConnectionsKeepAlive(t *testing.T) {
         },
     }
     for _, tt := range(tests) {
-        t.Run(tt.desc, func(t *testing.T) {
-            for i := 0; i < 10; i++ {
+        for i := 0; i < 5; i++ {
+            t.Run(tt.desc, func(t *testing.T) {
                 q := tt.q
                 q.Addrs = []string{"127.0.0.1:8081"}
                 c := client.New()
-                t.Logf("Num go routines after new client: %d", runtime.NumGoroutine())
                 wg := new(sync.WaitGroup)
                 wg.Add(1)
 
@@ -3079,10 +3078,9 @@ func TestConnectionsKeepAlive(t *testing.T) {
                 wg.Wait()
                 t.Logf("Num go routines after client subscribe: %d", runtime.NumGoroutine())
                 time.Sleep(10 * time.Second)
-                t.Logf("Num go routines after sleep, should be less: %d", runtime.NumGoroutine())
-
-            }
-        })
+                t.Logf("Num go routines after sleep, should be less, as keepalive should  close connections: %d", runtime.NumGoroutine())
+            })
+        }
     }
 }
 

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -211,8 +211,8 @@ func createKeepAliveServer(t *testing.T, port int64) *Server {
 	}
 
 	keep_alive_params := keepalive.ServerParameters{
-		MaxConnectionIdle: 3 * time.Second,
-		MaxConnectionAge:  5 * time.Second,
+		MaxConnectionIdle: 1 * time.Second,
+		MaxConnectionAge:  1 * time.Second,
 		MaxConnectionAgeGrace: 1 * time.Second,
 	}
 	server_opts := []grpc.ServerOption{
@@ -3065,7 +3065,7 @@ func TestConnectionsKeepAlive(t *testing.T) {
                 q := tt.q
                 q.Addrs = []string{"127.0.0.1:8081"}
                 c := client.New()
-                t.Logf("Num go routines: %d", runtime.NumGoroutine())
+                t.Logf("Num go routines after new client: %d", runtime.NumGoroutine())
                 wg := new(sync.WaitGroup)
                 wg.Add(1)
 
@@ -3077,7 +3077,10 @@ func TestConnectionsKeepAlive(t *testing.T) {
                 }()
 
                 wg.Wait()
-                t.Logf("Num go routines: %d", runtime.NumGoroutine())
+                t.Logf("Num go routines after client subscribe: %d", runtime.NumGoroutine())
+                time.Sleep(2 * time.Second)
+                t.Logf("Num go routines after sleep: %d", runtime.NumGoroutine())
+
             }
         })
     }

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -3061,7 +3061,7 @@ func TestConnectionsKeepAlive(t *testing.T) {
     }
     for _, tt := range(tests) {
         t.Run(tt.desc, func(t *testing.T) {
-            for i := 0; i < 50; i++ {
+            for i := 0; i < 10; i++ {
                 q := tt.q
                 q.Addrs = []string{"127.0.0.1:8081"}
                 c := client.New()
@@ -3078,8 +3078,8 @@ func TestConnectionsKeepAlive(t *testing.T) {
 
                 wg.Wait()
                 t.Logf("Num go routines after client subscribe: %d", runtime.NumGoroutine())
-                time.Sleep(2 * time.Second)
-                t.Logf("Num go routines after sleep: %d", runtime.NumGoroutine())
+                time.Sleep(10 * time.Second)
+                t.Logf("Num go routines after sleep, should be less: %d", runtime.NumGoroutine())
 
             }
         })

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -205,18 +205,10 @@ func createKeepAliveServer(t *testing.T, port int64) *Server {
 	}
 
 	opts := []grpc.ServerOption{grpc.Creds(credentials.NewTLS(tlsCfg))}
-	keep_alive_enforcement := keepalive.EnforcementPolicy{
-		MinTime:            5 * time.Second,
-		PermitWithoutStream: true,
-	}
-
 	keep_alive_params := keepalive.ServerParameters{
 		MaxConnectionIdle: 1 * time.Second,
-		MaxConnectionAge:  1 * time.Second,
-		MaxConnectionAgeGrace: 1 * time.Second,
 	}
 	server_opts := []grpc.ServerOption{
-		grpc.KeepaliveEnforcementPolicy(keep_alive_enforcement),
 		grpc.KeepaliveParams(keep_alive_params),
 	}
 	server_opts = append(server_opts, opts[0])

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -3076,9 +3076,14 @@ func TestConnectionsKeepAlive(t *testing.T) {
                 }()
 
                 wg.Wait()
-                t.Logf("Num go routines after client subscribe: %d", runtime.NumGoroutine())
+                after_subscribe := runtime.NumGoroutine()
+                t.Logf("Num go routines after client subscribe: %d", after_subscribe)
                 time.Sleep(10 * time.Second)
-                t.Logf("Num go routines after sleep, should be less, as keepalive should  close connections: %d", runtime.NumGoroutine())
+                after_sleep := runtime.NumGoroutine()
+                t.Logf("Num go routines after sleep, should be less, as keepalive should close idle connections: %d", after_sleep)
+                if after_sleep > after_subscribe {
+                    t.Errorf("Expecting goroutine after sleep to be less than or equal to after subscribe, after_subscribe: %d, after_sleep: %d", after_subscribe, after_sleep)
+                }
             })
         }
     }

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -12,6 +12,7 @@ import (
 	log "github.com/golang/glog"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/keepalive"
 
 	gnmi "github.com/sonic-net/sonic-gnmi/gnmi_server"
 	testcert "github.com/sonic-net/sonic-gnmi/testdata/tls"
@@ -32,6 +33,7 @@ var (
 	gnmi_translib_write = flag.Bool("gnmi_translib_write", gnmi.ENABLE_TRANSLIB_WRITE, "Enable gNMI translib write for management framework")
 	gnmi_native_write   = flag.Bool("gnmi_native_write", gnmi.ENABLE_NATIVE_WRITE, "Enable gNMI native write")
 	threshold         = flag.Int("threshold", 100, "max number of client connections")
+	idle_conn_duration = flag.Int("idle_conn_duration", 5, "Seconds before server closes idle connections")
 )
 
 func main() {
@@ -61,9 +63,16 @@ func main() {
 
 	switch {
 	case *threshold < 0:
-		log.Errorf("threshold must be > 0.")
+		log.Errorf("threshold must be >= 0.")
 		return
 	}
+
+	switch {
+	case *idle_conn_duration < 0:
+		log.Errorf("idle_conn_duration must be >= 0, 0 meaning inf")
+		return
+	}
+
 	gnmi.JwtRefreshInt = time.Duration(*jwtRefInt*uint64(time.Second))
 	gnmi.JwtValidInt = time.Duration(*jwtValInt*uint64(time.Second))
 
@@ -73,6 +82,7 @@ func main() {
 	cfg.EnableNativeWrite = bool(*gnmi_native_write)
 	cfg.LogLevel = 3
 	cfg.Threshold = int(*threshold)
+	cfg.IdleConnDuration = int(*idle_conn_duration)
 	var opts []grpc.ServerOption
 
 	if val, err := strconv.Atoi(getflag("v")); err == nil {
@@ -146,7 +156,16 @@ func main() {
 		}
 	}
 
+	keep_alive_params := keepalive.ServerParameters{
+		MaxConnectionIdle: time.Duration(cfg.IdleConnDuration) * time.Second, // duration in which idle connection will be closed, default is inf
+	}
+
 	opts = []grpc.ServerOption{grpc.Creds(credentials.NewTLS(tlsCfg))}
+
+	if cfg.IdleConnDuration > 0 { // non inf case
+		opts = append(opts, grpc.KeepaliveParams(keep_alive_params))
+	}
+
 	cfg.UserAuth = userAuth
 
 	gnmi.GenerateJwtSecretKey()


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

In integration test, we have a gnmi client running in PTF docker that is creating 5000 consecutive subscribe requests, sample mode, in which after receiving a single update, the client is no longer making rPC requests. The connection is still alive on the server-side and you can see below the top 3 goroutines balloon up all the way to ~1784 alive connections, which causes a high memory utilization alert inside the telemetry container. 

Inside sonic-gnmi code, I tested with simple http server that profiles the current process using pprof. Pprof will capture state of the process every few seconds (heap size, alloc, goroutine, etc). From the beginning of the process, when there were fewer client connections, we could see the top 3 connections at around ~500, but near the end see that it goes to 1784. Proof that these connections are still being held alive even after client is finished gathering data. 

The reason why we don't see this issue as much in production is that the default keep alive for the server is 2 hours, meaning idle connections will eventually start to close at around 2 hours, releasing this allocated memory.  



#### How I did it

[Issue #1269 · grpc/grpc-go (github.com)](https://github.com/grpc/grpc-go/issues/1269)
[Issue #2086 · grpc/grpc-go (github.com)](https://github.com/grpc/grpc-go/issues/2086)

From researching similar issues in github.com/grpc/grpc-go, we find that we can close idle connections after some specific time by setting MaxConnectionIdle

Refer: https://github.com/grpc/grpc-go/blob/master/keepalive/keepalive.go#L50

#### How to verify it

End to end integration test

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

