### PR TITLE
Fix bug in consecutive client connections

### DIFF
--- a/gnmi_server/client_subscribe.go
+++ b/gnmi_server/client_subscribe.go
@@ -54,7 +54,7 @@ func (c *Client) setLogLevel(lvl int) {
 }
 
 func (c *Client) setConnectionManager(threshold int) {
-	if connectionManager != nil && threshold == connectionManager.GetThreshold() { // test scenario where threshold is changed dynamically
+	if connectionManager != nil && threshold == connectionManager.GetThreshold() {
 		return
 	}
 	connectionManager = &ConnectionManager {

--- a/gnmi_server/client_subscribe.go
+++ b/gnmi_server/client_subscribe.go
@@ -54,7 +54,7 @@ func (c *Client) setLogLevel(lvl int) {
 }
 
 func (c *Client) setConnectionManager(threshold int) {
-	if connectionManager != nil {
+	if connectionManager != nil && threshold == connectionManager.GetThreshold() { // test scenario where threshold is changed dynamically
 		return
 	}
 	connectionManager = &ConnectionManager {

--- a/gnmi_server/client_subscribe.go
+++ b/gnmi_server/client_subscribe.go
@@ -54,6 +54,9 @@ func (c *Client) setLogLevel(lvl int) {
 }
 
 func (c *Client) setConnectionManager(threshold int) {
+	if connectionManager != nil {
+		return
+	}
 	connectionManager = &ConnectionManager {
 		connections: make(map[string]struct{}),
 		threshold:   threshold,

--- a/gnmi_server/connection_manager.go
+++ b/gnmi_server/connection_manager.go
@@ -21,6 +21,10 @@ type ConnectionManager struct {
 	threshold    int
 }
 
+func (cm *ConnectionManager) GetThreshold() int {
+	return cm.threshold
+}
+
 func (cm *ConnectionManager) PrepareRedis() {
 	ns := sdcfg.GetDbDefaultNamespace()
 	rclient = redis.NewClient(&redis.Options{

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -2929,7 +2929,7 @@ func TestClientConnections(t *testing.T) {
 
     var clients []*cacheclient.CacheClient
 
-    for _, tt := range tests {
+    for i, tt := range tests {
         t.Run(tt.desc, func(t *testing.T) {
             q := tt.q
             q.Addrs = []string{"127.0.0.1:8081"}

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -2955,7 +2955,7 @@ func TestClientConnections(t *testing.T) {
                 if err == nil && i == len(tests) - 1 { // reject third
                     t.Errorf("Expecting rejection message as no connections are allowed")
                 }
-                if err != nil && i < len(tests) = 1 { // accept first two
+                if err != nil && i < len(tests) - 1 { // accept first two
                     t.Errorf("Expecting accepts for first two connections")
                 }
             }()

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -54,6 +54,8 @@ import (
 	gnoi_system_pb "github.com/openconfig/gnoi/system"
 	"github.com/agiledragon/gomonkey/v2"
 	"github.com/godbus/dbus/v5"
+	cacheclient "github.com/openconfig/gnmi/client"
+
 )
 
 var clientTypes = []string{gclient.Type}
@@ -147,7 +149,7 @@ func createRejectServer(t *testing.T, port int64) *Server {
 	}
 
 	opts := []grpc.ServerOption{grpc.Creds(credentials.NewTLS(tlsCfg))}
-	cfg := &Config{Port: port, EnableTranslibWrite: true,  Threshold: -1}
+	cfg := &Config{Port: port, EnableTranslibWrite: true,  Threshold: 2}
 	s, err := NewServer(cfg, opts)
 	if err != nil {
 		t.Fatalf("Failed to create gNMI server: %v", err)
@@ -2925,6 +2927,8 @@ func TestClientConnections(t *testing.T) {
         },
     }
 
+    var clients []*cacheclient.CacheClient
+
     for _, tt := range tests {
         t.Run(tt.desc, func(t *testing.T) {
             q := tt.q
@@ -2946,13 +2950,22 @@ func TestClientConnections(t *testing.T) {
             go func() {
                 defer wg.Done()
                 c := client.New()
-                if err := c.Subscribe(context.Background(), q); err == nil {
+                clients = append(clients, c)
+                err := c.Subscribe(context.Background(), q)
+                if err == nil && i == len(tests) - 1 { // reject third
                     t.Errorf("Expecting rejection message as no connections are allowed")
+                }
+                if err != nil && i < len(tests) = 1 { // accept first two
+                    t.Errorf("Expecting accepts for first two connections")
                 }
             }()
 
             wg.Wait()
         })
+    }
+
+    for _, cacheClient := range(clients) {
+        cacheClient.Close()
     }
 }
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Bug in which connection manager is reset once being initialized and also improve UT

Accept 2 connections, reject third

#### How I did it

Code fix

#### How to verify it

UT

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

