### PR TITLE
Ygot diff tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,7 @@ check_gotest:
 	sudo CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" $(GO) test -coverprofile=coverage-dialcout.txt -covermode=atomic -mod=vendor $(BLD_FLAGS) -v github.com/sonic-net/sonic-gnmi/dialout/dialout_client
 	sudo CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" $(GO) test -race -coverprofile=coverage-data.txt -covermode=atomic -mod=vendor -v github.com/sonic-net/sonic-gnmi/sonic_data_client
 	sudo CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" $(GO) test -race -coverprofile=coverage-dbus.txt -covermode=atomic -mod=vendor -v github.com/sonic-net/sonic-gnmi/sonic_service_client
+	sudo CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" $(GO) test -coverprofile=coverage-translutils.txt -covermode=atomic -mod=vendor -v ./transl_utils
 	$(GO) get github.com/axw/gocov/...
 	$(GO) get github.com/AlekSi/gocov-xml
 	$(GO) mod vendor

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ check_gotest:
 	sudo CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" $(GO) test -coverprofile=coverage-dialcout.txt -covermode=atomic -mod=vendor $(BLD_FLAGS) -v github.com/sonic-net/sonic-gnmi/dialout/dialout_client
 	sudo CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" $(GO) test -race -coverprofile=coverage-data.txt -covermode=atomic -mod=vendor -v github.com/sonic-net/sonic-gnmi/sonic_data_client
 	sudo CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" $(GO) test -race -coverprofile=coverage-dbus.txt -covermode=atomic -mod=vendor -v github.com/sonic-net/sonic-gnmi/sonic_service_client
-	sudo CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" $(GO) test -coverprofile=coverage-translutils.txt -covermode=atomic -mod=vendor -v ./transl_utils
+	sudo CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" $(GO) test -coverprofile=coverage-translutils.txt -covermode=atomic -mod=vendor -v github.com/sonic-net/sonic-gnmi/transl_utils
 	$(GO) get github.com/axw/gocov/...
 	$(GO) get github.com/AlekSi/gocov-xml
 	$(GO) mod vendor

--- a/transl_utils/ygot_diff.go
+++ b/transl_utils/ygot_diff.go
@@ -314,9 +314,6 @@ func getElemName(f *reflect.StructField) string {
 // newPathElem creates a new gnmi.PathElem object for the given
 // node name and an optional key object.
 func newPathElem(name string, keyObj *reflect.Value) *gnmi.PathElem {
-	if len(name) == 0 {
-		return nil
-	}
 	pElem := &gnmi.PathElem{Name: name}
 	if keyObj != nil {
 		var err error

--- a/transl_utils/ygot_diff.go
+++ b/transl_utils/ygot_diff.go
@@ -1,0 +1,336 @@
+////////////////////////////////////////////////////////////////////////////////
+//                                                                            //
+//  Copyright 2021 Broadcom. The term Broadcom refers to Broadcom Inc. and/or //
+//  its subsidiaries.                                                         //
+//                                                                            //
+//  Licensed under the Apache License, Version 2.0 (the "License");           //
+//  you may not use this file except in compliance with the License.          //
+//  You may obtain a copy of the License at                                   //
+//                                                                            //
+//     http://www.apache.org/licenses/LICENSE-2.0                             //
+//                                                                            //
+//  Unless required by applicable law or agreed to in writing, software       //
+//  distributed under the License is distributed on an "AS IS" BASIS,         //
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  //
+//  See the License for the specific language governing permissions and       //
+//  limitations under the License.                                            //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+package transl_utils
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/Azure/sonic-mgmt-common/translib/ocbinds"
+	"github.com/openconfig/gnmi/errlist"
+	"github.com/openconfig/gnmi/proto/gnmi"
+	"github.com/openconfig/ygot/ygot"
+)
+
+// DiffOptions holds the optional parameters foi Diff API.
+type DiffOptions struct {
+	// RecordAll indicates if all attributes of modified GoStruct
+	// should be recorded - even if the values are same.
+	RecordAll bool
+}
+
+// DiffResults holds updated {path, value} pairs and deleted paths
+// resolved by the Diff API.
+type DiffResults struct {
+	Update []*gnmi.Update
+	Delete []*gnmi.Path
+}
+
+// Diff compares original and modified ygot structs; returns
+// the changes as a DiffResults.
+// Works with translib generated ygot structs only.
+func Diff(original, modified ygot.GoStruct, opts DiffOptions) (DiffResults, error) {
+	var yd ygotDiff
+	yd.DiffOptions = opts
+	yd.errors.Separator = "\n"
+	if original != nil && reflect.TypeOf(original) != reflect.TypeOf(modified) {
+		return yd.DiffResults, fmt.Errorf("Type mismatch")
+	}
+
+	yd.forStruct(reflect.ValueOf(original), reflect.ValueOf(modified))
+	return yd.DiffResults, yd.errors.Err()
+}
+
+// ygotDiff is a utility to compare ygot structs.
+type ygotDiff struct {
+	DiffOptions
+	DiffResults
+	prefix []*gnmi.PathElem // current prefix
+	errors errlist.List
+}
+
+func (yd *ygotDiff) forStruct(v1, v2 reflect.Value) {
+	if !v1.IsValid() || v1.IsNil() {
+		if v2.IsValid() && !v2.IsNil() {
+			yd.recordUpdates(v2.Interface())
+		}
+		return
+	}
+	if !v2.IsValid() || v2.IsNil() {
+		yd.recordDeletePath(nil)
+		return
+	}
+
+	v1 = v1.Elem()
+	v2 = v2.Elem()
+	st := v1.Type()
+
+	for i := v1.NumField() - 1; i >= 0; i-- {
+		f1 := v1.Field(i)
+		f2 := v2.Field(i)
+		ft := st.Field(i)
+
+		switch ft.Type.Kind() {
+		case reflect.Ptr: // leaf or container
+			if ft.Type.Elem().Kind() == reflect.Struct {
+				yd.pushPrefix(getElemName(&ft), nil)
+				yd.forStruct(f1, f2)
+				yd.popPrefix()
+			} else {
+				yd.forLeaf(&ft, unboxPtr(f1), unboxPtr(f2))
+			}
+		case reflect.Map: // list
+			yd.forList(&ft, &f1, &f2)
+		case reflect.Slice: // leaf-list
+			yd.forLeafList(&ft, &f1, &f2)
+		case reflect.Int64: // enum
+			yd.forEnum(&ft, f1.Int(), f2.Int())
+		case reflect.Interface: // union
+			yd.forUnion(&ft, &f1, &f2)
+		case reflect.Bool: // empty leaf
+			yd.forLeaf(&ft, f1.Bool(), f2.Bool())
+		default:
+			yd.recordError("Unexpected type %v for field %s", ft.Type.Kind(), ft.Name)
+		}
+	}
+}
+
+// forList compares ygot lists. Both m1 and m2 are assumed
+// to be map values.
+func (yd *ygotDiff) forList(f *reflect.StructField, m1, m2 *reflect.Value) {
+	listName := getElemName(f)
+	for iter := m1.MapRange(); iter.Next(); {
+		v1 := iter.Value()
+		if v2 := m2.MapIndex(iter.Key()); v2.IsValid() {
+			// Instance present in both m1 and m2. Compare them
+			yd.pushPrefix(listName, &v2)
+			yd.forStruct(v1, v2)
+			yd.popPrefix()
+		} else {
+			// Instance deleted in m2
+			suffix := newPathElem(listName, &v1)
+			yd.recordDeletePath(suffix)
+		}
+	}
+	// Look for new instances in m2 (that are not in m1)
+	for iter := m2.MapRange(); iter.Next(); {
+		if v1 := m1.MapIndex(iter.Key()); !v1.IsValid() {
+			v2 := iter.Value()
+			yd.pushPrefix(listName, &v2)
+			yd.recordUpdates(v2.Interface())
+			yd.popPrefix()
+		}
+	}
+}
+
+func (yd *ygotDiff) forUnion(f *reflect.StructField, v1, v2 *reflect.Value) {
+	if v2.IsNil() {
+		if !v1.IsNil() {
+			yd.recordDelete(f)
+		}
+		return
+	}
+	if yd.RecordAll || v1.IsNil() {
+		yd.recordUpdate(f, v2.Interface())
+		return
+	}
+
+	// Union is modeled as an interface wrapping a struct pointer
+	u1 := v1.Elem().Elem().Interface()
+	u2 := v2.Elem().Elem().Interface()
+	if u1 != u2 {
+		yd.recordUpdate(f, v2.Interface())
+	}
+}
+
+func (yd *ygotDiff) forEnum(f *reflect.StructField, v1, v2 int64) {
+	if v2 == 0 {
+		if v1 != 0 {
+			yd.recordDelete(f)
+		}
+		return
+	}
+	if !yd.RecordAll && v1 == v2 {
+		return
+	}
+
+	//TODO avoid directly referring to ocbinds
+	enumDef, ok := ocbinds.ΛEnum[f.Type.Name()][v2]
+	if !ok {
+		yd.recordError("%s is not a GoEnum", f.Type.Name())
+	} else {
+		yd.recordUpdate(f, enumDef.Name)
+	}
+}
+
+func (yd *ygotDiff) forLeaf(f *reflect.StructField, v1, v2 interface{}) {
+	if v2 == nil {
+		if v1 != nil {
+			yd.recordDelete(f)
+		}
+	} else if yd.RecordAll || v1 != v2 {
+		yd.recordUpdate(f, v2)
+	}
+}
+
+func (yd *ygotDiff) forLeafList(f *reflect.StructField, v1, v2 *reflect.Value) {
+	var len1, len2 int
+	if !v1.IsNil() {
+		len1 = v1.Len()
+	}
+	if !v2.IsNil() {
+		len2 = v2.Len()
+	}
+	if len2 == 0 {
+		if len1 != 0 {
+			yd.recordDelete(f)
+		}
+		return
+	}
+	if yd.RecordAll || len1 != len2 {
+		yd.recordUpdate(f, v2.Interface())
+		return
+	}
+	for i := 0; i < len1; i++ {
+		if v1.Index(i).Interface() != v2.Index(i).Interface() {
+			yd.recordUpdate(f, v2.Interface())
+			return
+		}
+	}
+}
+
+// recordUpdates records an update for of the set fields of a GoStruct.
+// Object v should be a GoStruct.
+func (yd *ygotDiff) recordUpdates(v interface{}) {
+	s, ok := v.(ygot.GoStruct)
+	if !ok {
+		yd.recordError("%T is not a ygot.GoStruct", v)
+		return
+	}
+
+	msg, err := ygot.TogNMINotifications(s, 0,
+		ygot.GNMINotificationsConfig{UsePathElem: true})
+	if err != nil {
+		yd.recordError("TogNMINotifications failed; %v", err)
+		return
+	}
+
+	for _, m := range msg {
+		for _, u := range m.Update {
+			elems := make([]*gnmi.PathElem, 0, len(yd.prefix)+len(u.Path.Elem))
+			elems = append(elems, yd.prefix...)
+			u.Path.Elem = append(elems, u.Path.Elem...)
+		}
+		yd.Update = append(yd.Update, m.Update...)
+	}
+}
+
+// recordUpdate records an update for the GoStruct field f, value v.
+// Uses ygot.EncodeTypedValue API to construct a gnmi.TypedValue from
+// the value v.
+func (yd *ygotDiff) recordUpdate(f *reflect.StructField, v interface{}) {
+	tv, err := ygot.EncodeTypedValue(v, gnmi.Encoding_JSON)
+	if err != nil {
+		yd.recordError("EncodeTypedValue failed; %v", err)
+		return
+	}
+
+	suffix := newPathElem(getElemName(f), nil)
+	u := &gnmi.Update{
+		Path: yd.newPath(suffix),
+		Val:  tv,
+	}
+	yd.Update = append(yd.Update, u)
+}
+
+func (yd *ygotDiff) recordDelete(f *reflect.StructField) {
+	suffix := newPathElem(getElemName(f), nil)
+	yd.recordDeletePath(suffix)
+}
+
+func (yd *ygotDiff) recordDeletePath(suffix *gnmi.PathElem) {
+	yd.Delete = append(yd.Delete, yd.newPath(suffix))
+}
+
+func (yd *ygotDiff) recordError(f string, args ...interface{}) {
+	p, _ := ygot.PathToString(&gnmi.Path{Elem: yd.prefix})
+	yd.errors.Add(fmt.Errorf(p+": "+f, args...))
+}
+
+// newPath returns a new *gnmi.Path by joining the path elements
+// yd.prefix and an optional suffix.
+func (yd *ygotDiff) newPath(suffix *gnmi.PathElem) *gnmi.Path {
+	n := len(yd.prefix)
+	if suffix != nil {
+		n++
+	}
+
+	elems := make([]*gnmi.PathElem, n)
+	copy(elems, yd.prefix)
+	if suffix != nil {
+		elems[len(yd.prefix)] = suffix
+	}
+
+	return &gnmi.Path{Elem: elems}
+}
+
+// pushPrefix appends a new path element to the prefix.
+func (yd *ygotDiff) pushPrefix(name string, keyObj *reflect.Value) {
+	yd.prefix = append(yd.prefix, newPathElem(name, keyObj))
+}
+
+// popPrefix removes last path element from the prefix.
+func (yd *ygotDiff) popPrefix() {
+	yd.prefix = yd.prefix[:len(yd.prefix)-1]
+}
+
+// getElemName returns the path element name for a ygot struct field f.
+// It panic if there is no 'path' tag, which should never happen.
+func getElemName(f *reflect.StructField) string {
+	name, ok := f.Tag.Lookup("path")
+	if !ok {
+		panic(f.Name + " has no path tag")
+	}
+	return name
+}
+
+// newPathElem creates a new gnmi.PathElem object for the given
+// node name and an optional key object.
+func newPathElem(name string, keyObj *reflect.Value) *gnmi.PathElem {
+	if len(name) == 0 {
+		return nil
+	}
+	pElem := &gnmi.PathElem{Name: name}
+	if keyObj != nil {
+		var err error
+		pElem.Key, err = ygot.PathKeyFromStruct(*keyObj)
+		if err != nil {
+			panic("ygot.PathKeyFromStruct failed: " + err.Error())
+		}
+	}
+	return pElem
+}
+
+func unboxPtr(v reflect.Value) interface{} {
+	if v.IsNil() {
+		return nil
+	}
+	return v.Elem().Interface()
+}

--- a/transl_utils/ygot_diff_bench_test.go
+++ b/transl_utils/ygot_diff_bench_test.go
@@ -1,0 +1,172 @@
+////////////////////////////////////////////////////////////////////////////////
+//                                                                            //
+//  Copyright 2021 Broadcom. The term Broadcom refers to Broadcom Inc. and/or //
+//  its subsidiaries.                                                         //
+//                                                                            //
+//  Licensed under the Apache License, Version 2.0 (the "License");           //
+//  you may not use this file except in compliance with the License.          //
+//  You may obtain a copy of the License at                                   //
+//                                                                            //
+//     http://www.apache.org/licenses/LICENSE-2.0                             //
+//                                                                            //
+//  Unless required by applicable law or agreed to in writing, software       //
+//  distributed under the License is distributed on an "AS IS" BASIS,         //
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  //
+//  See the License for the specific language governing permissions and       //
+//  limitations under the License.                                            //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+package transl_utils
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/Azure/sonic-mgmt-common/translib/ocbinds"
+	"github.com/openconfig/ygot/ygot"
+	"github.com/openconfig/ygot/ytypes"
+)
+
+var (
+	benchSize        string
+	useCommunityDiff bool
+)
+
+func TestMain(m *testing.M) {
+	flag.StringVar(&benchSize, "benchsize", "", "Benchmark size")
+	flag.BoolVar(&useCommunityDiff, "ygot.Diff", false, "Use community ygot.Diff API for diffs")
+	flag.Parse()
+
+	if benchSize == "" && hasFlag("test.bench") {
+		benchSize = "1x1"
+	}
+	if benchSize != "" {
+		setFlag("test.run", "^$")
+		setFlag("test.bench", ".")
+		setFlag("test.benchmem", "true")
+		initBenchmarkTests()
+	}
+
+	os.Exit(m.Run())
+}
+
+func hasFlag(name string) bool {
+	f := flag.Lookup(name)
+	return f.Value.String() != f.DefValue
+}
+
+func setFlag(name, value string) {
+	if !hasFlag(name) {
+		flag.Set(name, value)
+	}
+}
+
+var (
+	aclX ygot.GoStruct // reference ACL tree
+	aclY ygot.GoStruct // clone of aclX with 1 attr changed
+	aclZ ygot.GoStruct // same size as aclX, but with all attr changed
+	acl0 ygot.GoStruct // with no ACLs
+)
+
+func initBenchmarkTests() {
+	var m, n uint32
+	if x, err := fmt.Sscanf(benchSize, "%dx%d", &m, &n); x != 2 || err != nil {
+		panic("Invalid benchSize: " + benchSize)
+	}
+
+	fmt.Printf("Using benchSize=%dx%d, communityDiff=%v\n", m, n, useCommunityDiff)
+
+	aclX = buildACL(1, m, 1, n, "foo-", "ACCEPT", "IP_TCP", "1.0.0.0/8", "0.0.0.0/0")
+	aclZ = buildACL(1, m, 1, n, "bar-", "REJECT", "IP_UDP", "2.0.0.0/8", "1.2.3.4/32")
+	acl0 = buildACL(0, 0, 0, 0, "", "", "", "", "")
+
+	aclY, _ = ygot.DeepCopy(aclX)
+	deleteNodes(aclY, "/acl/acl-sets/acl-set[name=ACL-1][type=ACL_IPV4]/state/description")
+}
+
+func buildACL(aclIdStart, numAcls, ruleIdStart, numRules uint32, descr, action, proto, sip, dip string) ygot.GoStruct {
+	ruleIpv4 := fmt.Sprintf(`"protocol":"%s", "source-address":"%s", "destination-address":"%s"`, proto, sip, dip)
+	b := new(bytes.Buffer)
+	b.WriteString(`{"acl":{"acl-sets":{"acl-set":[`)
+	for i := uint32(0); i < numAcls; i++ {
+		aclN := aclIdStart + i
+		aclT := "ACL_IPV4"
+		fmt.Fprintf(b, `%s{"name":"ACL-%d", "type":"%s", `, sep(i), aclN, aclT)
+		fmt.Fprintf(b, `"config":{"name":"ACL-%d", "type":"%s","description":"%s%d"}, `, aclN, aclT, descr, aclN)
+		fmt.Fprintf(b, `"state":{"name":"ACL-%d", "type":"%s","description":"%s%d"}, `, aclN, aclT, descr, aclN)
+		fmt.Fprintf(b, `"acl-entries":{"acl-entry":[`)
+		for j := uint32(0); j < numRules; j++ {
+			seqN := ruleIdStart + j
+			fmt.Fprintf(b, `%s{"sequence-id":%d, `, sep(j), seqN)
+			fmt.Fprintf(b, `"config":{"sequence-id":%d, "description":"%s%d.%d"}, `, seqN, descr, aclN, seqN)
+			fmt.Fprintf(b, `"state":{"sequence-id":%d, "description":"%s%d.%d"}, `, seqN, descr, aclN, seqN)
+			fmt.Fprintf(b, `"actions":{"config":{"forwarding-action":"ACCEPT"},"state":{"forwarding-action":"ACCEPT"}}, `)
+			fmt.Fprintf(b, `"ipv4":{"config":{%s},"state":{%s}}}`, ruleIpv4, ruleIpv4)
+		}
+		b.WriteString(`]}}`)
+	}
+	b.WriteString(`]}}}`)
+
+	root := &ocbinds.Device{}
+	err := ocbinds.Unmarshal(b.Bytes(), root)
+	if err != nil {
+		if f, err := ioutil.TempFile("", "payload-*"); err == nil {
+			f.Write(b.Bytes())
+			f.Close()
+			fmt.Println("Faulty payload saved at", f.Name())
+		}
+		panic("ocbinds.Unmarshal failed; err=" + err.Error())
+	}
+	return root
+}
+
+func deleteNodes(s ygot.GoStruct, paths ...string) {
+	schema := ocbinds.SchemaTree[reflect.TypeOf(s).Elem().Name()]
+	for _, pathStr := range paths {
+		p, _ := ygot.StringToStructuredPath(pathStr)
+		ytypes.DeleteNode(schema, s, p)
+	}
+}
+
+func sep(index uint32) string {
+	if index == 0 {
+		return ""
+	}
+	return ", "
+}
+
+func benchmarkDiff(b *testing.B, x, y ygot.GoStruct) {
+	for i := 0; i < b.N; i++ {
+		if useCommunityDiff {
+			ygot.Diff(x, y)
+		} else {
+			Diff(x, y, DiffOptions{})
+		}
+	}
+}
+
+func BenchmarkAclDiff_nochange(b *testing.B) {
+	benchmarkDiff(b, aclX, aclX)
+}
+
+func BenchmarkAclDiff_onechange(b *testing.B) {
+	benchmarkDiff(b, aclX, aclY)
+}
+
+func BenchmarkAclDiff_allchange(b *testing.B) {
+	benchmarkDiff(b, aclX, aclZ)
+}
+
+func BenchmarkAclDiff_addall(b *testing.B) {
+	benchmarkDiff(b, acl0, aclX)
+}
+
+func BenchmarkAclDiff_delall(b *testing.B) {
+	benchmarkDiff(b, aclX, acl0)
+}

--- a/transl_utils/ygot_diff_test.go
+++ b/transl_utils/ygot_diff_test.go
@@ -1,0 +1,599 @@
+////////////////////////////////////////////////////////////////////////////////
+//                                                                            //
+//  Copyright 2021 Broadcom. The term Broadcom refers to Broadcom Inc. and/or //
+//  its subsidiaries.                                                         //
+//                                                                            //
+//  Licensed under the Apache License, Version 2.0 (the "License");           //
+//  you may not use this file except in compliance with the License.          //
+//  You may obtain a copy of the License at                                   //
+//                                                                            //
+//     http://www.apache.org/licenses/LICENSE-2.0                             //
+//                                                                            //
+//  Unless required by applicable law or agreed to in writing, software       //
+//  distributed under the License is distributed on an "AS IS" BASIS,         //
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  //
+//  See the License for the specific language governing permissions and       //
+//  limitations under the License.                                            //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+package transl_utils
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strings"
+	"testing"
+
+	"github.com/Azure/sonic-mgmt-common/translib/ocbinds"
+	"github.com/openconfig/gnmi/proto/gnmi"
+	"github.com/openconfig/ygot/ygot"
+)
+
+// diffData holds ygot diff info (updates and deletes) and
+// provides methods to compare them.
+type diffData struct {
+	updates map[string]string
+	deletes map[string]bool
+}
+
+func (dd *diffData) Update(p string, v interface{}) {
+	if dd.updates == nil {
+		dd.updates = make(map[string]string)
+	}
+	dd.updates[p] = fmt.Sprintf("%v", v)
+}
+
+func (dd *diffData) Updates(prefix string, data map[string]interface{}) {
+	for p, v := range data {
+		dd.Update(pathJoin(prefix, p), v)
+	}
+}
+
+func (dd *diffData) Delete(p string) {
+	if dd.deletes == nil {
+		dd.deletes = make(map[string]bool)
+	}
+	dd.deletes[p] = true
+}
+
+func (dd *diffData) Deletes(prefix string, paths ...string) {
+	for _, p := range paths {
+		dd.Delete(pathJoin(prefix, p))
+	}
+}
+
+func (dd *diffData) YgotDiff(t *testing.T, s1, s2 ygot.GoStruct, opts DiffOptions) {
+	yd, err := Diff(s1, s2, opts)
+	if err != nil {
+		t.Fatalf("Diff failed; %v", err)
+	}
+	for _, u := range yd.Update {
+		p, _ := ygot.PathToString(u.Path)
+		dd.Update(p, tvToStr(u.Val))
+	}
+	for _, d := range yd.Delete {
+		p, _ := ygot.PathToString(d)
+		dd.Delete(p)
+	}
+}
+
+func (dd *diffData) Compare(t *testing.T, exp *diffData) {
+	for p, v := range dd.updates {
+		if u, ok := exp.updates[p]; !ok {
+			t.Errorf("Update <\"%s\", %v> not expected", p, v)
+		} else if v != u {
+			t.Errorf("Update <\"%s\", %v> does not match %v", p, v, u)
+		}
+	}
+	for p, v := range exp.updates {
+		if _, ok := dd.updates[p]; !ok {
+			t.Errorf("Update <\"%s\", %v> not found", p, v)
+		}
+	}
+	for p := range dd.deletes {
+		if _, ok := exp.deletes[p]; !ok {
+			t.Errorf("Delete \"%s\" not expected", p)
+		}
+	}
+	for p := range exp.deletes {
+		if _, ok := dd.deletes[p]; !ok {
+			t.Errorf("Delete \"%s\" not found", p)
+		}
+	}
+}
+
+func pathJoin(p, s string) string {
+	return strings.TrimSuffix(p, "/") + "/" + strings.TrimPrefix(s, "/")
+}
+
+func tvToStr(tv *gnmi.TypedValue) string {
+	switch x := tv.Value.(type) {
+	case *gnmi.TypedValue_StringVal:
+		return x.StringVal
+	case *gnmi.TypedValue_LeaflistVal:
+		var values []string
+		for _, v := range x.LeaflistVal.Element {
+			values = append(values, tvToStr(v))
+		}
+		return strings.Join(values, ",")
+	}
+
+	// stringify TypedValue into "field: value" format
+	// and extract the value part..
+	s := fmt.Sprintf("%v", tv)
+	t := strings.SplitN(s, ":", 2)
+	return strings.TrimSpace(t[1])
+}
+
+func loadJSON(t *testing.T, v string) ygot.GoStruct {
+	root := &ocbinds.Device{}
+	err := ocbinds.Unmarshal([]byte(v), root)
+	if err != nil {
+		if f, err := ioutil.TempFile("", "payload-*"); err == nil {
+			f.Write([]byte(v))
+			f.Close()
+			t.Log("Faulty payload saved at ", f.Name())
+		}
+		t.Fatalf("ocbinds.Unmarshal failed; err=%v", err)
+	}
+	return root
+}
+
+func TestAcl_nodiff(t *testing.T) {
+	a1 := loadJSON(t, `
+	{"acl":{"acl-sets":{"acl-set":[
+		{"name": "ACL1", "type": "ACL_IPV4",
+			"config":{"name": "ACL1", "type": "ACL_IPV4", "description": "Hello, world!"}
+		}
+	]}}}`)
+	a2 := loadJSON(t, `
+	{"acl":{"acl-sets":{"acl-set":[
+		{"name": "ACL1", "type": "ACL_IPV4",
+			"config":{"name": "ACL1", "type": "ACL_IPV4", "description": "Hello, world!"}
+		}
+	]}}}`)
+
+	var dif, exp diffData
+	dif.YgotDiff(t, a1, a2, DiffOptions{})
+	dif.Compare(t, &exp)
+}
+
+func TestAcl_add1acl(t *testing.T) {
+	a1 := loadJSON(t, `
+	{"acl":{"acl-sets":{"acl-set":[
+		{"name": "ACL1", "type": "ACL_IPV4",
+			"config":{"name": "ACL1", "type": "ACL_IPV4", "description": "Hello, world!"}
+		}
+	]}}}`)
+	a2 := loadJSON(t, `
+	{"acl":{"acl-sets":{"acl-set":[
+		{"name": "ACL1", "type": "ACL_IPV4",
+			"config":{"name": "ACL1", "type": "ACL_IPV4", "description": "Hello, world!"}
+		},
+		{"name": "ACL2", "type": "ACL_IPV6",
+			"config":{"name": "ACL2", "type": "ACL_IPV6", "description": "foo/bar"},
+			"state":{"name": "ACL2", "type": "ACL_IPV6"}
+		}
+	]}}}`)
+
+	var dif, exp diffData
+	dif.YgotDiff(t, a1, a2, DiffOptions{})
+	exp.Updates("/acl/acl-sets/acl-set[name=ACL2][type=ACL_IPV6]",
+		map[string]interface{}{
+			"name":               "ACL2",
+			"type":               "ACL_IPV6",
+			"config/name":        "ACL2",
+			"config/type":        "ACL_IPV6",
+			"config/description": "foo/bar",
+			"state/name":         "ACL2",
+			"state/type":         "ACL_IPV6",
+		})
+	dif.Compare(t, &exp)
+}
+
+func TestAcl_del1acl(t *testing.T) {
+	a1 := loadJSON(t, `
+	{"acl":{"acl-sets":{"acl-set":[
+		{"name": "ACL1", "type": "ACL_IPV4",
+			"config":{"name": "ACL1", "type": "ACL_IPV4", "description": "Hello, world!"}
+		},
+		{"name": "ACL2", "type": "ACL_IPV6",
+			"config":{"name": "ACL2", "type": "ACL_IPV6", "description": "foo/bar"},
+			"state":{"name": "ACL2", "type": "ACL_IPV6"}
+		}
+	]}}}`)
+	a2 := loadJSON(t, `
+	{"acl":{"acl-sets":{"acl-set":[
+		{"name": "ACL1", "type": "ACL_IPV4",
+			"config":{"name": "ACL1", "type": "ACL_IPV4", "description": "Hello, world!"}
+		}
+	]}}}`)
+
+	var dif, exp diffData
+	dif.YgotDiff(t, a1, a2, DiffOptions{})
+	exp.Delete("/acl/acl-sets/acl-set[name=ACL2][type=ACL_IPV6]")
+	dif.Compare(t, &exp)
+}
+
+func TestAcl_mod1del1(t *testing.T) {
+	a1 := loadJSON(t, `
+	{"acl":{"acl-sets":{"acl-set":[
+		{"name": "ACL1", "type": "ACL_IPV4",
+			"config":{"name": "ACL1", "type": "ACL_IPV4", "description": "Hello, world!"},
+			"state":{"name": "ACL1", "type": "ACL_IPV4", "description": "Hello, world!"}
+		},
+		{"name": "ACL2", "type": "ACL_IPV6",
+			"config":{"name": "ACL2", "type": "ACL_IPV6", "description": "foo/bar"}
+		}
+	]}}}`)
+	a2 := loadJSON(t, `
+	{"acl":{"acl-sets":{"acl-set":[
+		{"name": "ACL1", "type": "ACL_IPV4",
+			"config":{"name": "ACL1", "type": "ACL_IPV4", "description": "foo/bar"},
+			"state":{"name": "ACL1", "type": "ACL_IPV4"}
+		}
+	]}}}`)
+
+	var dif, exp diffData
+	dif.YgotDiff(t, a1, a2, DiffOptions{})
+	exp.Update("/acl/acl-sets/acl-set[name=ACL1][type=ACL_IPV4]/config/description", "foo/bar")
+	exp.Delete("/acl/acl-sets/acl-set[name=ACL1][type=ACL_IPV4]/state/description")
+	exp.Delete("/acl/acl-sets/acl-set[name=ACL2][type=ACL_IPV6]")
+	dif.Compare(t, &exp)
+}
+
+func TestAcl_add1rule(t *testing.T) {
+	a1 := loadJSON(t, `
+	{"acl":{"acl-sets":{"acl-set":[
+		{"name": "ACL1", "type": "ACL_IPV4",
+			"config":{"name": "ACL1", "type": "ACL_IPV4", "description": "Hello, world!"}
+		}
+	]}}}`)
+	a2 := loadJSON(t, `
+	{"acl":{"acl-sets":{"acl-set":[
+		{"name": "ACL1", "type": "ACL_IPV4",
+			"config":{"name": "ACL1", "type": "ACL_IPV4", "description": "Hello, world!"},
+			"acl-entries": { "acl-entry":[
+				{"sequence-id": 101,
+					"config": {"sequence-id":101, "description": "rule101"},
+					"state":  {"sequence-id":101},
+					"actions":{"config":{"forwarding-action": "ACCEPT"}},
+					"ipv4": {
+						"config":{"protocol":"IP_TCP", "source-address": "101.0.0.0/8"},
+						"state":{"protocol":"IP_TCP", "source-address": "101.0.0.0/8"}
+					}
+				}
+			]}
+		}
+	]}}}`)
+
+	var dif, exp diffData
+	dif.YgotDiff(t, a1, a2, DiffOptions{})
+	exp.Updates("/acl/acl-sets/acl-set[name=ACL1][type=ACL_IPV4]/acl-entries/acl-entry[sequence-id=101]",
+		map[string]interface{}{
+			"sequence-id":                      101,
+			"config/sequence-id":               101,
+			"config/description":               "rule101",
+			"state/sequence-id":                101,
+			"actions/config/forwarding-action": "ACCEPT",
+			"ipv4/config/protocol":             "IP_TCP",
+			"ipv4/config/source-address":       "101.0.0.0/8",
+			"ipv4/state/protocol":              "IP_TCP",
+			"ipv4/state/source-address":        "101.0.0.0/8",
+		})
+	dif.Compare(t, &exp)
+}
+
+func TestAcl_modrules(t *testing.T) {
+	a1 := loadJSON(t, `
+	{"acl":{"acl-sets":{"acl-set":[
+		{"name": "ACL1", "type": "ACL_IPV4",
+			"config":{"name": "ACL1", "type": "ACL_IPV4"},
+			"acl-entries": { "acl-entry":[
+				{"sequence-id": 101,
+					"config": {"sequence-id": 101, "description": "rule101"},
+					"actions":{"config":{"forwarding-action": "ACCEPT"}},
+					"ipv4": {
+						"config":{"protocol": "IP_TCP", "source-address": "101.0.0.0/8"},
+						"state": {"protocol": "IP_TCP", "source-address": "101.0.0.0/8"}
+					}
+				},
+				{"sequence-id": 102,
+					"config": {"sequence-id": 102},
+					"ipv4":   {"config":{"protocol": "IP_UDP", "source-address": "102.0.0.0/8"}}
+				},
+				{"sequence-id": 103,
+					"config": {"sequence-id": 103},
+					"ipv4":   {"config":{"source-address": "103.0.0.0/8"}}
+				},
+				{"sequence-id": 104,
+					"config": {"sequence-id": 104}
+				},
+				{"sequence-id": 105,
+					"config": {"sequence-id": 105},
+					"ipv4":   {"config":{"protocol": 95, "source-address": "105.0.0.0/8"}}
+				},
+				{"sequence-id": 106,
+					"config": {"sequence-id": 106},
+					"ipv4":   {"config":{"protocol": 96, "source-address": "106.0.0.0/8"}}
+				},
+				{"sequence-id": 107,
+					"config": {"sequence-id": 107},
+					"ipv4":   {"config":{"protocol": "IP_GRE", "source-address": "107.0.0.0/8"}}
+				},
+				{"sequence-id": 108,
+					"config": {"sequence-id": 108},
+					"ipv4":   {"config":{"protocol": 98, "source-address": "108.0.0.0/8"}}
+				}
+			]}
+		}
+	]}}}`)
+	a2 := loadJSON(t, `
+	{"acl":{"acl-sets":{"acl-set":[
+		{"name": "ACL1", "type": "ACL_IPV4",
+			"config":{"name": "ACL1", "type": "ACL_IPV4", "description": "Hello, world!"},
+			"acl-entries": { "acl-entry":[
+				{"sequence-id": 101,
+					"config": {"sequence-id": 101},
+					"state":  {"sequence-id": 101},
+					"actions":{"config":{"forwarding-action": "REJECT"}},
+					"ipv4":   {"config":{"protocol": "IP_UDP", "source-address": "101.0.0.0/8"}}
+				},
+				{"sequence-id": 102,
+					"config": {"sequence-id": 102},
+					"ipv4":   {"config":{"source-address": "102.0.0.0/8"}}
+				},
+				{"sequence-id": 103,
+					"config": {"sequence-id": 103},
+					"ipv4":   {"config":{"protocol": "IP_TCP", "source-address": "103.0.0.0/8"}}
+				},
+				{"sequence-id": 105,
+					"config": {"sequence-id": 105},
+					"ipv4":   {"config":{"protocol": "IP_GRE", "source-address": "105.0.0.0/8"}}
+				},
+				{"sequence-id": 106,
+					"config": {"sequence-id": 106},
+					"ipv4":   {"config":{"protocol": 66, "source-address": "106.0.0.0/8"}}
+				},
+				{"sequence-id": 107,
+					"config": {"sequence-id": 107},
+					"ipv4":   {"config":{"protocol": 97, "source-address": "107.0.0.0/8"}}
+				},
+				{"sequence-id": 108,
+					"config": {"sequence-id": 108},
+					"ipv4":   {"config":{"source-address": "108.0.0.0/8"}}
+				},
+				{"sequence-id": 300,
+					"config": {"sequence-id": 300, "description": "rule300"}
+				}
+			]}
+		}
+	]}}}`)
+
+	var dif, exp diffData
+	dif.YgotDiff(t, a1, a2, DiffOptions{})
+	exp.Updates("/acl/acl-sets/acl-set[name=ACL1][type=ACL_IPV4]",
+		map[string]interface{}{
+			"config/description": "Hello, world!",
+		})
+	exp.Updates("/acl/acl-sets/acl-set[name=ACL1][type=ACL_IPV4]/acl-entries",
+		map[string]interface{}{
+			"acl-entry[sequence-id=101]/state/sequence-id":                101,
+			"acl-entry[sequence-id=101]/actions/config/forwarding-action": "REJECT",
+			"acl-entry[sequence-id=101]/ipv4/config/protocol":             "IP_UDP",
+			"acl-entry[sequence-id=103]/ipv4/config/protocol":             "IP_TCP",
+			"acl-entry[sequence-id=105]/ipv4/config/protocol":             "IP_GRE",
+			"acl-entry[sequence-id=106]/ipv4/config/protocol":             66,
+			"acl-entry[sequence-id=107]/ipv4/config/protocol":             97,
+			"acl-entry[sequence-id=300]/sequence-id":                      300,
+			"acl-entry[sequence-id=300]/config/sequence-id":               300,
+			"acl-entry[sequence-id=300]/config/description":               "rule300",
+		})
+	exp.Deletes("/acl/acl-sets/acl-set[name=ACL1][type=ACL_IPV4]/acl-entries",
+		"acl-entry[sequence-id=101]/config/description",
+		"acl-entry[sequence-id=101]/ipv4/state",
+		"acl-entry[sequence-id=102]/ipv4/config/protocol",
+		"acl-entry[sequence-id=104]",
+		"acl-entry[sequence-id=108]/ipv4/config/protocol",
+	)
+	dif.Compare(t, &exp)
+}
+
+func TestAcl_RecordAll(t *testing.T) {
+	a1 := loadJSON(t, `
+	{"acl":{"acl-sets":{"acl-set":[
+		{"name": "ACL1", "type": "ACL_IPV4",
+			"config":{"name": "ACL1", "type": "ACL_IPV4", "description": "???"},
+			"state": {"name": "ACL1", "type": "ACL_IPV4"},
+			"acl-entries": { "acl-entry":[
+				{"sequence-id": 101,
+					"config": {"sequence-id": 101, "description": "rule101"},
+					"actions":{"config":{"forwarding-action": "ACCEPT"}},
+					"ipv4":   {"config":{"protocol": "IP_TCP", "source-address": "101.0.0.0/8"}}
+				},
+				{"sequence-id": 102,
+					"config": {"sequence-id": 102},
+					"actions":{"config":{"forwarding-action": "REJECT"}},
+					"ipv4":   {"config":{"protocol": "IP_UDP", "source-address": "102.0.0.0/8"}}
+				},
+				{"sequence-id": 103,
+					"config": {"sequence-id": 103}
+				},
+				{"sequence-id": 104,
+					"config": {"sequence-id": 104, "description": "rule104"},
+					"actions":{"config":{"forwarding-action": "ACCEPT"}},
+					"ipv4":   {"config":{"protocol": "IP_TCP", "source-address": "101.0.0.0/8"}}
+				}
+			]}
+		}
+	]}}}`)
+	a2 := loadJSON(t, `
+	{"acl":{"acl-sets":{"acl-set":[
+		{"name": "ACL1", "type": "ACL_IPV4",
+			"config":{"name": "ACL1", "type": "ACL_IPV4"},
+			"acl-entries": { "acl-entry":[
+				{"sequence-id": 101,
+					"config": {"sequence-id": 101, "description": "rule101"},
+					"actions":{"config":{"forwarding-action": "ACCEPT"}},
+					"ipv4":   {"config":{"protocol": "IP_TCP", "source-address": "101.0.0.0/8"}}
+				},
+				{"sequence-id": 102,
+					"config": {"sequence-id": 102},
+					"actions":{"config":{"forwarding-action": "DROP"}},
+					"ipv4":   {"config":{"protocol": "IP_GRE", "source-address": "2.2.2.2/32"}}
+				},
+				{"sequence-id": 103,
+					"config": {"sequence-id": 103, "description": "rule103"},
+					"actions":{"config":{"forwarding-action": "REJECT"}},
+					"ipv4":   {"config":{"protocol": "IP_UDP", "source-address": "103.0.0.0/8"}}
+				},
+				{"sequence-id": 104,
+					"config": {"sequence-id": 104},
+					"actions":{"config":{}},
+					"ipv4":   {"config":{}}
+
+				},
+				{"sequence-id": 300,
+					"config": {"sequence-id": 300, "description": "rule300"},
+					"actions":{"config":{}},
+					"ipv4":   {"config":{}}
+				}
+			]}
+		}
+	]}}}`)
+
+	var dif, exp diffData
+	dif.YgotDiff(t, a1, a2, DiffOptions{RecordAll: true})
+	exp.Updates("/acl/acl-sets/acl-set[name=ACL1][type=ACL_IPV4]",
+		map[string]interface{}{
+			"name":        "ACL1",
+			"type":        "ACL_IPV4",
+			"config/name": "ACL1",
+			"config/type": "ACL_IPV4",
+		})
+	exp.Updates("/acl/acl-sets/acl-set[name=ACL1][type=ACL_IPV4]/acl-entries",
+		map[string]interface{}{
+			"acl-entry[sequence-id=101]/sequence-id":                      101,
+			"acl-entry[sequence-id=101]/config/sequence-id":               101,
+			"acl-entry[sequence-id=101]/config/description":               "rule101",
+			"acl-entry[sequence-id=101]/actions/config/forwarding-action": "ACCEPT",
+			"acl-entry[sequence-id=101]/ipv4/config/protocol":             "IP_TCP",
+			"acl-entry[sequence-id=101]/ipv4/config/source-address":       "101.0.0.0/8",
+			"acl-entry[sequence-id=102]/sequence-id":                      102,
+			"acl-entry[sequence-id=102]/config/sequence-id":               102,
+			"acl-entry[sequence-id=102]/actions/config/forwarding-action": "DROP",
+			"acl-entry[sequence-id=102]/ipv4/config/protocol":             "IP_GRE",
+			"acl-entry[sequence-id=102]/ipv4/config/source-address":       "2.2.2.2/32",
+			"acl-entry[sequence-id=103]/sequence-id":                      103,
+			"acl-entry[sequence-id=103]/config/sequence-id":               103,
+			"acl-entry[sequence-id=103]/config/description":               "rule103",
+			"acl-entry[sequence-id=103]/actions/config/forwarding-action": "REJECT",
+			"acl-entry[sequence-id=103]/ipv4/config/protocol":             "IP_UDP",
+			"acl-entry[sequence-id=103]/ipv4/config/source-address":       "103.0.0.0/8",
+			"acl-entry[sequence-id=104]/sequence-id":                      104,
+			"acl-entry[sequence-id=104]/config/sequence-id":               104,
+			"acl-entry[sequence-id=300]/sequence-id":                      300,
+			"acl-entry[sequence-id=300]/config/sequence-id":               300,
+			"acl-entry[sequence-id=300]/config/description":               "rule300",
+		})
+	exp.Deletes("/acl/acl-sets/acl-set[name=ACL1][type=ACL_IPV4]",
+		"config/description",
+		"state",
+	)
+	exp.Deletes("/acl/acl-sets/acl-set[name=ACL1][type=ACL_IPV4]/acl-entries",
+		"acl-entry[sequence-id=104]/config/description",
+		"acl-entry[sequence-id=104]/actions/config/forwarding-action",
+		"acl-entry[sequence-id=104]/ipv4/config/protocol",
+		"acl-entry[sequence-id=104]/ipv4/config/source-address",
+	)
+	dif.Compare(t, &exp)
+}
+
+func TestAcl_LeafList(t *testing.T) {
+	a1 := loadJSON(t, `{"acl":{"acl-sets":{"acl-set":[
+		{"name": "ACL1", "type": "ACL_IPV4", "acl-entries": {"acl-entry": [
+		{"sequence-id": 1, "transport": {"config": {"tcp-flags": ["TCP_SYN", "TCP_FIN"]}}},
+		{"sequence-id": 2, "transport": {"config": {"tcp-flags": ["TCP_SYN", "TCP_FIN"]}}},
+		{"sequence-id": 3, "transport": {"config": {"tcp-flags": ["TCP_SYN", "TCP_FIN"]}}},
+		{"sequence-id": 4, "transport": {"config": {"tcp-flags": ["TCP_SYN", "TCP_FIN"]}}},
+		{"sequence-id": 5, "transport": {"config": {"tcp-flags": ["TCP_SYN", "TCP_FIN"]}}},
+		{"sequence-id": 6, "transport": {"config": {"tcp-flags": ["TCP_SYN", "TCP_FIN"]}}},
+		{"sequence-id": 7, "transport": {"config": {"tcp-flags": ["TCP_SYN", "TCP_FIN"]}}},
+		{"sequence-id": 8, "transport": {"config": {"tcp-flags": ["TCP_SYN", "TCP_FIN"]}}},
+		{"sequence-id": 9}
+		]}}]}}}`)
+	a2 := loadJSON(t, `{"acl":{"acl-sets":{"acl-set":[
+		{"name": "ACL1", "type": "ACL_IPV4", "acl-entries": {"acl-entry": [
+		{"sequence-id": 1, "transport": {"config": {"tcp-flags": ["TCP_SYN", "TCP_RST"]}}},
+		{"sequence-id": 2, "transport": {"config": {"tcp-flags": ["TCP_FIN", "TCP_SYN"]}}},
+		{"sequence-id": 3, "transport": {"config": {"tcp-flags": ["TCP_SYN"]}}},
+		{"sequence-id": 4, "transport": {"config": {"tcp-flags": ["TCP_SYN", "TCP_FIN", "TCP_ACK"]}}},
+		{"sequence-id": 5, "transport": {"config": {"tcp-flags": ["TCP_SYN", "TCP_FIN"]}}},
+		{"sequence-id": 6, "transport": {"config": {"tcp-flags": []}}},
+		{"sequence-id": 7, "transport": {"config": {}}},
+		{"sequence-id": 8},
+		{"sequence-id": 9, "transport": {"config": {"tcp-flags": ["TCP_SYN", "TCP_FIN"]}}},
+		{"sequence-id":10, "transport": {"config": {"tcp-flags": ["TCP_SYN", "TCP_FIN"]}}}
+		]}}]}}}`)
+
+	var dif, exp diffData
+	dif.YgotDiff(t, a1, a2, DiffOptions{})
+	exp.Updates("/acl/acl-sets/acl-set[name=ACL1][type=ACL_IPV4]/acl-entries",
+		map[string]interface{}{
+			"acl-entry[sequence-id=1]/transport/config/tcp-flags":  "TCP_SYN,TCP_RST",
+			"acl-entry[sequence-id=2]/transport/config/tcp-flags":  "TCP_FIN,TCP_SYN",
+			"acl-entry[sequence-id=3]/transport/config/tcp-flags":  "TCP_SYN",
+			"acl-entry[sequence-id=4]/transport/config/tcp-flags":  "TCP_SYN,TCP_FIN,TCP_ACK",
+			"acl-entry[sequence-id=9]/transport/config/tcp-flags":  "TCP_SYN,TCP_FIN",
+			"acl-entry[sequence-id=10]/sequence-id":                10,
+			"acl-entry[sequence-id=10]/transport/config/tcp-flags": "TCP_SYN,TCP_FIN",
+		})
+	exp.Deletes("/acl/acl-sets/acl-set[name=ACL1][type=ACL_IPV4]/acl-entries",
+		"acl-entry[sequence-id=6]/transport/config/tcp-flags",
+		"acl-entry[sequence-id=7]/transport/config/tcp-flags",
+		"acl-entry[sequence-id=8]/transport",
+	)
+	dif.Compare(t, &exp)
+}
+
+func TestAcl_LeafList_RecordAll(t *testing.T) {
+	a1 := loadJSON(t, `{"acl":{"acl-sets":{"acl-set":[
+		{"name": "ACL1", "type": "ACL_IPV4", "acl-entries": {"acl-entry": [
+		{"sequence-id": 1, "transport": {"config": {"tcp-flags": ["TCP_SYN", "TCP_FIN"]}}},
+		{"sequence-id": 2, "transport": {"config": {"tcp-flags": ["TCP_SYN", "TCP_FIN"]}}},
+		{"sequence-id": 3, "transport": {"config": {"tcp-flags": ["TCP_SYN", "TCP_FIN"]}}},
+		{"sequence-id": 4, "transport": {"config": {"tcp-flags": ["TCP_SYN", "TCP_FIN"]}}},
+		{"sequence-id": 5, "transport": {"config": {"tcp-flags": ["TCP_SYN", "TCP_FIN"]}}}
+		]}}]}}}`)
+	a2 := loadJSON(t, `{"acl":{"acl-sets":{"acl-set":[
+		{"name": "ACL1", "type": "ACL_IPV4", "acl-entries": {"acl-entry": [
+		{"sequence-id": 1, "transport": {"config": {"tcp-flags": ["TCP_SYN", "TCP_RST"]}}},
+		{"sequence-id": 2, "transport": {"config": {"tcp-flags": ["TCP_FIN", "TCP_SYN"]}}},
+		{"sequence-id": 3, "transport": {"config": {"tcp-flags": ["TCP_SYN"]}}},
+		{"sequence-id": 4, "transport": {"config": {"tcp-flags": ["TCP_SYN", "TCP_FIN", "TCP_ACK"]}}},
+		{"sequence-id": 5, "transport": {"config": {"tcp-flags": ["TCP_SYN", "TCP_FIN"]}}}
+		]}}]}}}`)
+
+	var dif, exp diffData
+	dif.YgotDiff(t, a1, a2, DiffOptions{RecordAll: true})
+	exp.Updates("/acl/acl-sets/acl-set[name=ACL1][type=ACL_IPV4]",
+		map[string]interface{}{
+			"name": "ACL1",
+			"type": "ACL_IPV4",
+		})
+	exp.Updates("/acl/acl-sets/acl-set[name=ACL1][type=ACL_IPV4]/acl-entries",
+		map[string]interface{}{
+			"acl-entry[sequence-id=1]/sequence-id":                1,
+			"acl-entry[sequence-id=1]/transport/config/tcp-flags": "TCP_SYN,TCP_RST",
+			"acl-entry[sequence-id=2]/sequence-id":                2,
+			"acl-entry[sequence-id=2]/transport/config/tcp-flags": "TCP_FIN,TCP_SYN",
+			"acl-entry[sequence-id=3]/sequence-id":                3,
+			"acl-entry[sequence-id=3]/transport/config/tcp-flags": "TCP_SYN",
+			"acl-entry[sequence-id=4]/sequence-id":                4,
+			"acl-entry[sequence-id=4]/transport/config/tcp-flags": "TCP_SYN,TCP_FIN,TCP_ACK",
+			"acl-entry[sequence-id=5]/sequence-id":                5,
+			"acl-entry[sequence-id=5]/transport/config/tcp-flags": "TCP_SYN,TCP_FIN",
+		})
+	dif.Compare(t, &exp)
+}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Subscription enhancements proposed in https://github.com/sonic-net/SONiC/pull/1287 requires gNMI server to create a SAMPLE notification message by comparing YGOT objects from two successive iterations. We observed that the standard `ygot.Diff` API takes more time and memory when the YGOT objects have multiple child objects. Hence developed an in-house diff API

#### How I did it

Performance issues of `ygot.Diff` API are mainly due to it flattening the YGOT objects into list of {leaf_path, leaf_value} pairs and then comparing those lists. The in-house `Diff` API avoids this flattening step. It traverses both YGOT object attributes together, compares the values inline and records the changes if any. Following table captures the time taken (in nanoseconds) by `ygot.Diff` and the in-house diff APIs for diffing two openconfig-acl objects. Size "MxN" stands for ygot object with M ACLs and N rules in each ACL. All values are in nanoseconds.

| Test case         | API           | size=10x10  | size=10x100  | size=100x1000 |
|-------------------|---------------|------------:|-------------:|--------------:|
| No changes        | ygot.Diff     |  9024089697 | 854023452896 |           OOM |
|                   | in-house Diff |     1784778 |     15460520 |    1757874254 |
| One attr changed  | ygot.Diff     |  9285911808 | 857292949475 |           OOM |
|                   | in-house Diff |     1547512 |     16506496 |    1786245108 |
| All attrs changed | ygot.Diff     |  9333680743 | 855581319202 |          OOM  |
|                   | in-house Diff |     3562498 |     34306626 |    3846524858 |
| Create all attrs  | ygot.Diff     |    80830018 |    858752644 |               |
|                   | in-house Diff |     7101530 |     74663888 |    8245685970 |
| Delete all attrs  | ygot.Diff     |    83082154 |    755762682 |               |
|                   | in-house Diff |      120232 |       125293 |        453306 |


#### How to verify it

Tested the functionality through gotests that handcraft two ygot objects, invoke the new Diff function and verify the results.
The gNMI server code to use this API is not ready as of now.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

