### PR TITLE
Return Grpc.Internal error once there's socker read timeout issue occurs in streaming subscribe under routing flap case

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,22 @@
+name: Semgrep
+
+on:
+  pull_request: {}
+  push:
+    branches:
+      - master
+      - '201[7-9][0-1][0-9]'
+      - '202[0-9][0-1][0-9]'
+
+jobs:
+  semgrep:
+    if: github.repository_owner == 'sonic-net'
+    name: Semgrep
+    runs-on: ubuntu-latest
+    container:
+      image: returntocorp/semgrep
+    steps:
+      - uses: actions/checkout@v3
+      - run: semgrep ci
+        env:
+           SEMGREP_RULES: p/default

--- a/gnmi_server/client_subscribe.go
+++ b/gnmi_server/client_subscribe.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net"
 	"sync"
+	"strings"
 
 	"github.com/Workiva/go-datastructures/queue"
 	log "github.com/golang/glog"
@@ -207,6 +208,10 @@ func (c *Client) Run(stream gnmipb.GNMI_SubscribeServer) (err error) {
 	c.Close()
 	// Wait until all child go routines exited
 	c.w.Wait()
+	if strings.Contains(err.Error(), "i/o timeout") {
+		return grpc.Errorf(codes.Internal, "%s", err)
+	}
+
 	return grpc.Errorf(codes.InvalidArgument, "%s", err)
 }
 

--- a/sonic_data_client/db_client.go
+++ b/sonic_data_client/db_client.go
@@ -80,6 +80,7 @@ var IntervalTicker = func(interval time.Duration) <-chan time.Time {
 }
 
 var NeedMock bool = false
+var MockFail int = 0
 var intervalTickerMutex sync.Mutex
 
 // Define a new function to set the IntervalTicker variable
@@ -742,6 +743,12 @@ func tableData2Msi(tblPath *tablePath, useKey bool, op *string, msi *map[string]
 		makeJSON_redis(msi, &tblPath.jsonTableKey, op, fv)
 		log.V(6).Infof("Added json key %v fv %v ", tblPath.jsonTableKey, fv)
 		return nil
+	}
+
+	if MockFail == 1 {
+		MockFail++
+		fmt.Println("Mock sleep for redis timeout")
+		time.Sleep(30 * time.Second)
 	}
 
 	for idx, dbkey := range dbkeys {


### PR DESCRIPTION
Currently streaming telemetry subscribe will hit some error under routing flap case if it subscribes APPL_DB ROUTE_TABLE, this change will return explicit error code to client without any handling.

pubsub notification to avoid inconsistency introduced by other concurrent cmd
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
When there's DB table flapping happens, like APPL_DB ROUTE_Table, current gnmi server has some performance issue which will result in below error
"read unix @->/var/run/redis/redis.sock: i/o timeout"

We should need to fix this systemically. Now the fix is to return explicit error code as Internal error to client, and later we will do some optimization, and add some retry strategy into the redis function call.

#### How I did it
Return Grpc.Internal error to the client

#### How to verify it
verified via gnmi_cli, meanwhile some tests which introduces bgp flapping.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

