### PR TITLE
[202205] Backport divide by zero fix, logs to gnmi_get, md5 checksum logging, excessive log issue

### DIFF
--- a/gnmi_server/server.go
+++ b/gnmi_server/server.go
@@ -295,7 +295,7 @@ func (s *Server) Get(ctx context.Context, req *gnmipb.GetRequest) (*gnmipb.GetRe
 
 	paths := req.GetPath()
 	extensions := req.GetExtension()
-        target = prefix.GetTarget()
+	target = prefix.GetTarget()
 	log.V(2).Infof("GetRequest paths: %v", paths)
 
 	var dc sdc.Client

--- a/gnmi_server/server.go
+++ b/gnmi_server/server.go
@@ -295,8 +295,8 @@ func (s *Server) Get(ctx context.Context, req *gnmipb.GetRequest) (*gnmipb.GetRe
 
 	paths := req.GetPath()
 	extensions := req.GetExtension()
-	target = prefix.GetTarget()
-	log.V(5).Infof("GetRequest paths: %v", paths)
+        target = prefix.GetTarget()
+	log.V(2).Infof("GetRequest paths: %v", paths)
 
 	var dc sdc.Client
 

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+        "sync"
 	"strings"
 
 	testcert "github.com/Azure/sonic-telemetry/testdata/tls"
@@ -39,9 +40,11 @@ import (
 	sdc "github.com/Azure/sonic-telemetry/sonic_data_client"
 	sdcfg "github.com/Azure/sonic-telemetry/sonic_db_config"
 	"github.com/Azure/sonic-telemetry/test_utils"
+        linuxproc "github.com/c9s/goprocinfo/linux"
 	gclient "github.com/jipanyang/gnmi/client/gnmi"
 	"github.com/jipanyang/gnxi/utils/xpath"
 	gnoi_system_pb "github.com/openconfig/gnoi/system"
+	"github.com/agiledragon/gomonkey/v2"
 )
 
 var clientTypes = []string{gclient.Type}
@@ -2403,6 +2406,84 @@ func TestGNOI(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCPUUtilization(t *testing.T) {
+    mock := gomonkey.ApplyFunc(sdc.PollStats, func() {
+	var i uint64
+	for i = 0; i < 3000; i++ {
+		sdc.WriteStatsToBuffer(&linuxproc.Stat{})
+	}
+    })
+
+    defer mock.Reset()
+    s := createServer(t, 8081)
+    go runServer(t, s)
+    defer s.s.Stop()
+
+    tests := []struct {
+        desc    string
+	q       client.Query
+	want    []client.Notification
+	poll    int
+    }{
+        {
+            desc: "poll query for CPU Utilization",
+	    poll: 10,
+	    q: client.Query{
+                Target: "OTHERS",
+		Type:    client.Poll,
+		Queries: []client.Path{{"platform", "cpu"}},
+		TLS:     &tls.Config{InsecureSkipVerify: true},
+	    },
+	    want: []client.Notification{
+                client.Connected{},
+		client.Sync{},
+	    },
+        },
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.desc, func(t *testing.T) {
+            q := tt.q
+	    q.Addrs = []string{"127.0.0.1:8081"}
+            c := client.New()
+            var gotNoti []client.Notification
+            q.NotificationHandler = func(n client.Notification) error {
+                if nn, ok := n.(client.Update); ok {
+                    nn.TS = time.Unix(0, 200)
+		    gotNoti = append(gotNoti, nn)
+                } else {
+                    gotNoti = append(gotNoti, n)
+	        }
+                return nil
+            }
+
+            wg := new(sync.WaitGroup)
+            wg.Add(1)
+
+            go func() {
+                defer wg.Done()
+                if err := c.Subscribe(context.Background(), q); err != nil {
+                    t.Errorf("c.Subscribe(): got error %v, expected nil", err)
+                }
+            }()
+
+            wg.Wait()
+
+            for i := 0; i < tt.poll; i++ {
+                if err := c.Poll(); err != nil {
+                    t.Errorf("c.Poll(): got error %v, expected nil", err)
+                }
+	    }
+
+            if len(gotNoti) == 0 {
+                t.Errorf("expected non zero notifications")
+            }
+
+            c.Close()
+        })
+    }
 }
 
 func TestBundleVersion(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.12
 require (
 	github.com/Azure/sonic-mgmt-common v0.0.0-00010101000000-000000000000
 	github.com/Workiva/go-datastructures v1.0.50
+	github.com/agiledragon/gomonkey/v2 v2.8.0
 	github.com/c9s/goprocinfo v0.0.0-20191125144613-4acdd056c72d
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/go-redis/redis v6.15.6+incompatible

--- a/sonic_data_client/db_client.go
+++ b/sonic_data_client/db_client.go
@@ -1188,7 +1188,7 @@ func dbTableKeySubscribe(c *DbClient, gnmiPath *gnmipb.Path, interval time.Durat
 
 		select {
 		case updatedTable := <-updateChannel:
-			log.V(1).Infof("update received: %v", updatedTable)
+			log.V(6).Infof("update received: %v", updatedTable)
 			if interval == 0 {
 				// on-change mode, send the updated data.
 				if err := sendMsiData(updatedTable); err != nil {
@@ -1202,7 +1202,7 @@ func dbTableKeySubscribe(c *DbClient, gnmiPath *gnmipb.Path, interval time.Durat
 				}
 			}
 		case <-intervalTicker:
-			log.V(1).Infof("ticker received: %v", len(msiAll))
+			log.V(6).Infof("ticker received: %v", len(msiAll))
 
 			if err := sendMsiData(msiAll); err != nil {
 				handleFatalMsg(err.Error())
@@ -1212,7 +1212,7 @@ func dbTableKeySubscribe(c *DbClient, gnmiPath *gnmipb.Path, interval time.Durat
 			// Clear the payload so that next time it will send only updates
 			if updateOnly {
 				msiAll = make(map[string]interface{})
-				log.V(1).Infof("msiAll cleared: %v", len(msiAll))
+				log.V(6).Infof("msiAll cleared: %v", len(msiAll))
 			}
 
 		case <-c.channel:

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -3,6 +3,7 @@ package main
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"crypto/md5"
 	"flag"
 	"io/ioutil"
 	"time"
@@ -79,6 +80,9 @@ func main() {
 			}
 			certificate, err = tls.LoadX509KeyPair(*serverCert, *serverKey)
 			if err != nil {
+				currentTime := time.Now().UTC()
+				log.Infof("Server Cert md5 checksum: %x at time %s", md5.Sum([]byte(*serverCert)), currentTime.String())
+				log.Infof("Server Key md5 checksum: %x at time %s", md5.Sum([]byte(*serverKey)), currentTime.String())
 				log.Exitf("could not load server key pair: %s", err)
 			}
 		}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Following commits that are being backported are important production livesite repair items

7bb6f80301446416c6117f0af03a3e12dfa17757 -> Update gnmi get path log level
3f413772fcaa2b044a58d5978badcb7f514a122f -> Log md5 checksum
b93c4acbc4c8fdbd4f8fd0b3ae20d53425eeceb9 -> divide by zero
399aea73f4c0bfbb3cf0daf9db5b41d27598c80c -> update log level for excessive logs

#### How I did it

git cherry-pick necessary commits




#### How to verify it

Pipeline

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

