### PR TITLE
Fix threading issues in Event Client

### DIFF
--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -3205,7 +3205,7 @@ func TestClient(t *testing.T) {
 
         mutexIdx.RLock()
         event_index = 0
-        mutexIdxDone.RUnlock()
+        mutexIdx.RUnlock()
 
         mutexDeInit.RLock()
         deinit_done = false

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -3170,7 +3170,7 @@ func TestClient(t *testing.T) {
     defer mock5.Reset()
 
     mock6 := gomonkey.ApplyMethod(reflect.TypeOf(&queue.PriorityQueue{}), "Len", func(pq *queue.PriorityQueue) int {
-        return 0
+        return 150000 // Max size for pending events in PQ is 102400
     })
     defer mock6.Reset()
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Streaming events was not working due to incomplete fix for race condition brought in PR #100

Fix was not completed in last PR; issues:

1) Mutex Unlock was not being called as it was using defer statement inside a continuous for loop which was blocking all other go routines from accessing.
2) Mutex Lock was being used incorrectly as it should be only for when resource is being read not written to. Use RWMutex and RLock for writing to resource

#### How I did it

1) Added fix so that -race condition works and also "re enabled event client UT"
2) Added additional UT case for when events are dropped.

#### How to verify it

UT and pipeline

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

