### PR TITLE
[202205] Fix sonic-mgmt-common version to ec32690 in pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,6 +38,7 @@ stages:
       DIFF_COVER_CHECK_THRESHOLD: 80
       DIFF_COVER_ENABLE: 'true'
       DIFF_COVER_WORKING_DIRECTORY: $(System.DefaultWorkingDirectory)/sonic-gnmi
+      SONIC_MGMT_COMMON_VER: ec32690
 
     container:
       image: sonicdev-microsoft.azurecr.io:443/sonic-slave-bullseye:latest
@@ -100,6 +101,8 @@ stages:
         ls -l
 
         pushd sonic-mgmt-common
+
+        git checkout $(SONIC_MGMT_COMMON_VER)
 
         NO_TEST_BINS=1 dpkg-buildpackage -rfakeroot -b -us -uc
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Pipeline was always using latest from sonic-mgmt-common master branch for compilation. It can fail whenever there is a major change in sonic-mgmt-common.

#### How I did it

Updated the pipeline build step to checkout specific version of sonic-mgmt-common that would have been used by the 202205 image build. There is no 202205 branch in sonic-mgmt-common repo, hence hardcoding the commit id from the sonic-buildimage's submodule.

#### How to verify it

Pipeline build

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

