### PR TITLE
[202012] Fix sonic-mgmt-common version in pipeline build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,7 @@ check_gotest:
 	sudo cp ./testdata/database_config.json ${DBDIR}
 	sudo mkdir -p /usr/models/yang || true
 	sudo find $(MGMT_COMMON_DIR)/models -name '*.yang' -exec cp {} /usr/models/yang/ \;
+	sudo cp -R $(MGMT_COMMON_DIR)/build/cvl/schema /usr/sbin/
 	sudo $(GO) test -coverprofile=coverage-config.txt -covermode=atomic -v github.com/Azure/sonic-telemetry/sonic_db_config
 	sudo $(GO) test -coverprofile=coverage-gnmi.txt -covermode=atomic -mod=vendor $(BLD_FLAGS) -v github.com/Azure/sonic-telemetry/gnmi_server
 	sudo $(GO) test -coverprofile=coverage-dialcout.txt -covermode=atomic -mod=vendor $(BLD_FLAGS) -v github.com/Azure/sonic-telemetry/dialout/dialout_client

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,6 +38,7 @@ stages:
       DIFF_COVER_CHECK_THRESHOLD: 80
       DIFF_COVER_ENABLE: 'true'
       DIFF_COVER_WORKING_DIRECTORY: $(System.DefaultWorkingDirectory)/sonic-gnmi
+      SONIC_MGMT_COMMON_VER: origin/202012
 
     container:
       image: sonicdev-microsoft.azurecr.io:443/sonic-slave-buster:latest
@@ -100,6 +101,8 @@ stages:
         ls -l
 
         pushd sonic-mgmt-common
+
+        git checkout --detach $(SONIC_MGMT_COMMON_VER)
 
         NO_TEST_BINS=1 dpkg-buildpackage -rfakeroot -b -us -uc
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Pipeline was always using latest from sonic-mgmt-common master branch for compilation. It can fail whenever there is a major change in sonic-mgmt-common.

#### How I did it

Updated the pipeline build step to checkout 202012 branch of sonic-mgmt-common

#### How to verify it

Pipeline build

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

