### PR TITLE
Update makefile to support armhf (#132)

### DIFF
--- a/swsscommon/Makefile
+++ b/swsscommon/Makefile
@@ -6,6 +6,10 @@ SWIG_FLAG = -go -cgo -c++ -intgosize 64
 ifeq ($(CONFIGURED_ARCH),arm64)
 SWIG_FLAG += -DSWIGWORDSIZE64
 endif
+ifeq ($(CONFIGURED_ARCH),armhf)
+SWIG_FLAG = -go -cgo -c++ -intgosize 32 -DSWIGWORDSIZE32
+endif
+
 
 .PHONY: all clean
 


### PR DESCRIPTION
Why I did it
Telemetry service crashed on armhf platform.

How I did it
Update makefile, and armhf is 32-bit.

How to verify it
Install new image on armhf platform, and telemetry service should be fine.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

