### PR TITLE
Integrate ZMQ to GNMI to improve Dash GNMI API performance. 

### DIFF
--- a/gnmi_server/server.go
+++ b/gnmi_server/server.go
@@ -52,6 +52,7 @@ type Config struct {
 	UserAuth AuthTypes
 	EnableTranslibWrite bool
 	EnableNativeWrite bool
+	ZmqAddress string
 	IdleConnDuration int
 }
 
@@ -343,7 +344,7 @@ func (s *Server) Get(ctx context.Context, req *gnmipb.GetRequest) (*gnmipb.GetRe
 			return nil, err
 		}
 		if check := IsNativeOrigin(origin); check {
-			dc, err = sdc.NewMixedDbClient(paths, prefix, origin)
+			dc, err = sdc.NewMixedDbClient(paths, prefix, origin, s.config.ZmqAddress)
 		} else {
 			dc, err = sdc.NewTranslClient(prefix, paths, ctx, extensions)
 		}
@@ -410,7 +411,7 @@ func (s *Server) Set(ctx context.Context, req *gnmipb.SetRequest) (*gnmipb.SetRe
 			common_utils.IncCounter(common_utils.GNMI_SET_FAIL)
 			return nil, grpc.Errorf(codes.Unimplemented, "GNMI native write is disabled")
 		}
-		dc, err = sdc.NewMixedDbClient(paths, prefix, origin)
+		dc, err = sdc.NewMixedDbClient(paths, prefix, origin, s.config.ZmqAddress)
 	} else {
 		if s.config.EnableTranslibWrite == false {
 			common_utils.IncCounter(common_utils.GNMI_SET_FAIL)
@@ -485,7 +486,7 @@ func (s *Server) Capabilities(ctx context.Context, req *gnmipb.CapabilityRequest
 	var supportedModels []gnmipb.ModelData
 	dc, _ := sdc.NewTranslClient(nil, nil, ctx, extensions)
 	supportedModels = append(supportedModels, dc.Capabilities()...)
-	dc, _ = sdc.NewMixedDbClient(nil, nil, "")
+	dc, _ = sdc.NewMixedDbClient(nil, nil, "", s.config.ZmqAddress)
 	supportedModels = append(supportedModels, dc.Capabilities()...)
 
 	suppModels := make([]*gnmipb.ModelData, len(supportedModels))

--- a/sonic_data_client/client_test.go
+++ b/sonic_data_client/client_test.go
@@ -353,10 +353,18 @@ func TestNonDbClientGetError(t *testing.T) {
 	}
 }
 
+/*
+	Helper method for receive data from ZmqConsumerStateTable
+		consumer: Receive data from consumer
+		return:
+			true: data received
+			false: not receive any data after retry
+*/
 func ReceiveFromZmq(consumer swsscommon.ZmqConsumerStateTable) (bool) {
 	receivedData := swsscommon.NewKeyOpFieldsValuesQueue()
 	retry := 0;
 	for {
+		// sender's ZMQ may disconnect, wait and retry for reconnect 
 		time.Sleep(time.Duration(1000) * time.Millisecond)
 		consumer.Pops(receivedData)
 		if receivedData.Size() == 0 {

--- a/sonic_data_client/client_test.go
+++ b/sonic_data_client/client_test.go
@@ -407,10 +407,10 @@ func TestZmqReconnect(t *testing.T) {
 
 func TestRetryHelper(t *testing.T) {
 	// create ZMQ server
-	zmqServer := swsscommon.NewZmqServer("tcp://*:1234")
+	zmqServer := swsscommon.NewZmqServer("tcp://*:2234")
 
 	// create ZMQ client side
-	zmqAddress := "tcp://127.0.0.1:1234"
+	zmqAddress := "tcp://127.0.0.1:2234"
 	zmqClient := swsscommon.NewZmqClient(zmqAddress)
 	returnError := true
 	exeCount := 0

--- a/sonic_data_client/client_test.go
+++ b/sonic_data_client/client_test.go
@@ -407,10 +407,10 @@ func TestZmqReconnect(t *testing.T) {
 
 func TestRetryHelper(t *testing.T) {
 	// create ZMQ server
-	zmqServer := swsscommon.NewZmqServer("tcp://*:1234")
+	zmqServer := swsscommon.NewZmqServer("tcp://*:2234")
 
 	// create ZMQ client side
-	zmqAddress := "tcp://127.0.0.1:1234"
+	zmqAddress := "tcp://127.0.0.1:2234"
 	zmqClient := swsscommon.NewZmqClient(zmqAddress)
 
     RetryHelper(

--- a/sonic_data_client/client_test.go
+++ b/sonic_data_client/client_test.go
@@ -407,23 +407,30 @@ func TestZmqReconnect(t *testing.T) {
 
 func TestRetryHelper(t *testing.T) {
 	// create ZMQ server
-	zmqServer := swsscommon.NewZmqServer("tcp://*:2234")
+	zmqServer := swsscommon.NewZmqServer("tcp://*:1234")
 
 	// create ZMQ client side
-	zmqAddress := "tcp://127.0.0.1:2234"
+	zmqAddress := "tcp://127.0.0.1:1234"
 	zmqClient := swsscommon.NewZmqClient(zmqAddress)
-
+	returnError := true
+	exeCount := 0
     RetryHelper(
 		zmqClient,
 		func () (err error) {
-			if !zmqClient.IsConnected() {
+			exeCount++
+			if returnError {
+				returnError = false
 				return fmt.Errorf("connection_reset")
 			}
 			return nil
 	})
 
-	if !zmqClient.IsConnected() {
+	if exeCount == 1 {
 		t.Errorf("RetryHelper does not retry")
+	}
+
+	if exeCount > 2 {
+		t.Errorf("RetryHelper retry too much")
 	}
 
 	swsscommon.DeleteZmqServer(zmqServer)

--- a/sonic_data_client/mixed_db_client.go
+++ b/sonic_data_client/mixed_db_client.go
@@ -34,8 +34,8 @@ const APPL_DB_NAME string = "APPL_DB"
 const DASH_TABLE_PREFIX string = "DASH_"
 const SWSS_TIMEOUT uint = 0
 const MAX_RETRY_COUNT uint = 5
-const RETYRY_DELAY_MILLISECOND uint = 100
-const RETYRY_DELAY_FACTOR uint = 2
+const RETRY_DELAY_MILLISECOND uint = 100
+const RETRY_DELAY_FACTOR uint = 2
 const CHECK_POINT_PATH string = "/etc/sonic"
 
 const (
@@ -168,7 +168,7 @@ type ActionNeedRetry func() error
 
 func RetryHelper(zmqClient swsscommon.ZmqClient, action ActionNeedRetry) {
 	var retry uint = 0
-	var retry_delay = time.Duration(RETYRY_DELAY_MILLISECOND) * time.Millisecond
+	var retry_delay = time.Duration(RETRY_DELAY_MILLISECOND) * time.Millisecond
 	ConnectionResetErr := "connection_reset"
 	for {
 		err := action()
@@ -178,7 +178,7 @@ func RetryHelper(zmqClient swsscommon.ZmqClient, action ActionNeedRetry) {
 				time.Sleep(retry_delay)
 
 				zmqClient.Connect()
-				retry_delay *= time.Duration(RETYRY_DELAY_FACTOR)
+				retry_delay *= time.Duration(RETRY_DELAY_FACTOR)
 				retry++
 				continue
 			}

--- a/sonic_data_client/mixed_db_client.go
+++ b/sonic_data_client/mixed_db_client.go
@@ -35,6 +35,7 @@ const DASH_TABLE_PREFIX string = "DASH_"
 const SWSS_TIMEOUT uint = 0
 const MAX_RETRY_COUNT uint = 5
 const RETYRY_DELAY_MILLISECOND uint = 100
+const RETYRY_DELAY_FACTOR uint = 2
 const CHECK_POINT_PATH string = "/etc/sonic"
 
 const (
@@ -177,7 +178,7 @@ func RetryHelper(zmqClient swsscommon.ZmqClient, action ActionNeedRetry) {
 				time.Sleep(retry_delay)
 
 				zmqClient.Connect()
-				retry_delay *= time.Duration(2)
+				retry_delay *= time.Duration(RETYRY_DELAY_FACTOR)
 				retry++
 				continue
 			}
@@ -200,20 +201,20 @@ func (c *MixedDbClient) DbSetTable(table string, key string, values map[string]s
 
 	pt := c.GetTable(table)
 	RetryHelper(
-		c.zmqClient,
-		func () error {
-		return ProducerStateTableSetWrapper(pt, key, vec)
-	})
+				c.zmqClient,
+				func () error {
+					return ProducerStateTableSetWrapper(pt, key, vec)
+				})
 	return nil
 }
 
 func (c *MixedDbClient) DbDelTable(table string, key string) error {
 	pt := c.GetTable(table)
 	RetryHelper(
-		c.zmqClient,
-		func () error {
-		return ProducerStateTableDeleteWrapper(pt, key)
-	})
+				c.zmqClient,
+				func () error {
+					return ProducerStateTableDeleteWrapper(pt, key) 
+				})
 
 	return nil
 }

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -25,6 +25,7 @@ var (
 	caCert            = flag.String("ca_crt", "", "CA certificate for client certificate validation. Optional.")
 	serverCert        = flag.String("server_crt", "", "TLS server certificate")
 	serverKey         = flag.String("server_key", "", "TLS server private key")
+	zmqAddress        = flag.String("zmq_address", "", "Orchagent ZMQ address, when not set or empty string telemetry server will switch to Redis based communication channel.")
 	insecure          = flag.Bool("insecure", false, "Skip providing TLS cert and key, for testing only!")
 	noTLS             = flag.Bool("noTLS", false, "disable TLS, for testing only!")
 	allowNoClientCert = flag.Bool("allow_no_client_auth", false, "When set, telemetry server will request but not require a client certificate.")
@@ -81,6 +82,7 @@ func main() {
 	cfg.EnableTranslibWrite = bool(*gnmi_translib_write)
 	cfg.EnableNativeWrite = bool(*gnmi_native_write)
 	cfg.LogLevel = 3
+	cfg.ZmqAddress = *zmqAddress
 	cfg.Threshold = int(*threshold)
 	cfg.IdleConnDuration = int(*idle_conn_duration)
 	var opts []grpc.ServerOption


### PR DESCRIPTION
Integrate ZMQ to GNMI to improve Dash GNMI API performance. 

#### Why I did it
Currently Dash gnmi to orchagent communitcation using redis based channel, switch to ZMQ based change will improve performance. 

#### How I did it
Integrate ZMQ to gnmi service.

#### How to verify it
Manually test.
Add new UT.

#### Work item tracking
Microsoft ADO (number only): 17753835

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
Integrate ZMQ to GNMI to improve Dash GNMI API performance. 

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

