### PR TITLE
Fix on change bug, missing key in updates

### DIFF
--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -2995,6 +2995,7 @@ func TestOnChangeNoMissingKey(t *testing.T) {
             },
         },
     }
+    namespace := sdcfg.GetDbDefaultNamespace()
     rclient := getRedisClient(t, namespace)
     defer rclient.Close()
     prepareDb(t, namespace)

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -2960,14 +2960,15 @@ func TestOnChangeNoMissingKey(t *testing.T) {
     go runServer(t, s)
     defer s.s.Stop()
 
-    q := createQueryOrFail(t, pb.SubscriptionList_STREAM, "STATE_DB",
+    q := createQueryOrFail(t,
+         pb.SubscriptionList_STREAM,
+	 "STATE_DB",
          []subscriptionQuery{
              {
-                 {
-                     Query: "NEIGH_STATE_TABLE",
-		     SubMode: pb.SubcriptionMode_ON_CHANGE,
-	         },
-             },
+                 Query: []string{"NEIGH_STATE_TABLE"},
+		 SubMode: pb.SubscriptionMode_ON_CHANGE,
+	     },
+         },
          false)
 
     q.Addrs = []string{"127.0.0.1:8081"}
@@ -3007,7 +3008,9 @@ func TestOnChangeNoMissingKey(t *testing.T) {
                 }
             }()
             time.Sleep(time.Millisecond * 2000)
-	    t.Errorf(gotNoti)
+	    for _, noti := range gotNoti {
+                t.Errorf(noti)
+            }
         })
     }
 }

--- a/sonic_data_client/db_client.go
+++ b/sonic_data_client/db_client.go
@@ -1089,7 +1089,7 @@ func dbSingleTableKeySubscribe(c *DbClient, rsd redisSubData, updateChannel chan
 						continue
 					}
 					tblPath.tableKey = subscr.Channel[prefixLen:]
-					err = tableData2Msi(&tblPath, false, nil, &newMsi)
+					err = tableData2Msi(&tblPath, true, nil, &newMsi)
 					if err != nil {
 						enqueueFatalMsg(c, err.Error())
 						return


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

When On change update notifications are sent, they are sent without key of path, which should not be the case

#### How I did it

Added key to update notifications

#### How to verify it

UT

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

