### PR TITLE
Install necessary debs instead of entire artifact in azp

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -70,7 +70,11 @@ stages:
         artifact: sonic-buildimage.vs
         runVersion: 'latestFromBranch'
         runBranch: 'refs/heads/master'
-      displayName: "Download sonic buildimage"
+        patterns: |
+            target/debs/bullseye/libyang-*.deb
+            target/debs/bullseye/libnl-*.deb
+            target/debs/bullseye/libhiredis-*.deb
+      displayName: "Download bullseye debs"
 
     - task: DownloadPipelineArtifact@2
       inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -71,9 +71,9 @@ stages:
         runVersion: 'latestFromBranch'
         runBranch: 'refs/heads/master'
         patterns: |
-            target/debs/bullseye/libyang-*.deb
-            target/debs/bullseye/libnl-*.deb
-            target/debs/bullseye/libhiredis-*.deb
+            target/debs/bullseye/libyang*.deb
+            target/debs/bullseye/libnl*.deb
+            target/debs/bullseye/libhiredis*.deb
       displayName: "Download bullseye debs"
 
     - task: DownloadPipelineArtifact@2


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

sonic-gnmi pipeline breaks with error: "System.IO.IOException: No space left on device : '/home/vsts/agents/3.220.5/_diag/Worker_20230719-220457-utc.log'"

#### How I did it

Only install necessary bullseye debs instead of entire artifact

#### How to verify it

Pipeline

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

