### PR TITLE
Support empty protobytes

### DIFF
--- a/sonic_data_client/mixed_db_client.go
+++ b/sonic_data_client/mixed_db_client.go
@@ -722,7 +722,9 @@ func (c *MixedDbClient) handleTableData(tblPaths []tablePath) error {
 					} else {
 						return fmt.Errorf("Key %v: Unsupported value %v type %v", tblPath.tableKey, res, reflect.TypeOf(res))
 					}
-				} else if len(tblPath.protoValue) != 0 {
+				} else {
+					// protobytes can be empty
+					// If jsonValue is empty, use protoValue
 					vtable := make(map[string]interface{})
 					vtable["pb"] = tblPath.protoValue
 					outputData := ConvertDbEntry(vtable)
@@ -731,8 +733,6 @@ func (c *MixedDbClient) handleTableData(tblPaths []tablePath) error {
 						log.V(2).Infof("swsscommon update failed for  %v, value %v", tblPath, outputData)
 						return err
 					}
-				} else {
-					return fmt.Errorf("No valid value: %v", tblPath)
 				}
 			} else {
 				if len(tblPath.jsonValue) == 0 {


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
protobytes is empty for default value, and GNMI needs to support this scenario.

#### How I did it
If both json and proto are empty, use empty protobytes.

#### How to verify it
Run gnmi unit test.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

