### PR TITLE
Backport Add key to on change updates (#138) to 202205

### DIFF
--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -2598,6 +2598,26 @@ func TestBulkSet(t *testing.T) {
 
 }
 
+func TestTableData2MsiUseKey(t *testing.T) {
+    tblPath := sdc.CreateTablePath("STATE_DB", "NEIGH_STATE_TABLE", "|", "10.0.0.57")
+    newMsi := make(map[string]interface{})
+    sdc.TableData2Msi(&tblPath, true, nil, &newMsi)
+    newMsiData, _ := json.MarshalIndent(newMsi, "", "  ")
+    t.Logf(string(newMsiData))
+    expectedMsi := map[string]interface{} {
+        "10.0.0.57": map[string]interface{} {
+            "peerType": "e-BGP",
+	    "state": "Established",
+        },
+    }
+    expectedMsiData, _ := json.MarshalIndent(expectedMsi, "", "  ")
+    t.Logf(string(expectedMsiData))
+
+    if !reflect.DeepEqual(newMsi, expectedMsi) {
+        t.Errorf("Msi data does not match for use key = true")
+    }
+}
+
 func init() {
 	// Enable logs at UT setup
 	flag.Lookup("v").Value.Set("10")

--- a/sonic_data_client/db_client.go
+++ b/sonic_data_client/db_client.go
@@ -74,6 +74,15 @@ var IntervalTicker = func(interval time.Duration) <-chan time.Time {
 	return time.After(interval)
 }
 
+func CreateTablePath(dbName string, tableName string, delimitor string, tableKey string) tablePath {
+	var tblPath tablePath
+	tblPath.dbName = dbName
+	tblPath.tableName = tableName
+	tblPath.delimitor = delimitor
+	tblPath.tableKey = tableKey
+	return tblPath
+}
+
 type tablePath struct {
 	dbNamespace string
 	dbName      string
@@ -653,11 +662,11 @@ func emitJSON(v *map[string]interface{}) ([]byte, error) {
 	return j, nil
 }
 
-// tableData2Msi renders the redis DB data to map[string]interface{}
+// TableData2Msi renders the redis DB data to map[string]interface{}
 // which may be marshaled to JSON format
 // If only table name provided in the tablePath, find all keys in the table, otherwise
 // Use tableName + tableKey as key to get all field value paires
-func tableData2Msi(tblPath *tablePath, useKey bool, op *string, msi *map[string]interface{}) error {
+func TableData2Msi(tblPath *tablePath, useKey bool, op *string, msi *map[string]interface{}) error {
 	redisDb := Target2RedisDb[tblPath.dbNamespace][tblPath.dbName]
 
 	var pattern string
@@ -768,7 +777,7 @@ func tableData2TypedValue(tblPaths []tablePath, op *string) (*gnmipb.TypedValue,
 			}
 		}
 
-		err := tableData2Msi(&tblPath, useKey, nil, &msi)
+		err := TableData2Msi(&tblPath, useKey, nil, &msi)
 		if err != nil {
 			return nil, err
 		}
@@ -1023,7 +1032,7 @@ func dbSingleTableKeySubscribe(c *DbClient, rsd redisSubData, updateChannel chan
 			} else if subscr.Payload == "hset" {
 				//op := "SET"
 				if tblPath.tableKey != "" {
-					err = tableData2Msi(&tblPath, false, nil, &newMsi)
+					err = TableData2Msi(&tblPath, false, nil, &newMsi)
 					if err != nil {
 						enqueueFatalMsg(c, err.Error())
 						return
@@ -1035,7 +1044,7 @@ func dbSingleTableKeySubscribe(c *DbClient, rsd redisSubData, updateChannel chan
 						continue
 					}
 					tblPath.tableKey = subscr.Channel[prefixLen:]
-					err = tableData2Msi(&tblPath, false, nil, &newMsi)
+					err = TableData2Msi(&tblPath, true, nil, &newMsi)
 					if err != nil {
 						enqueueFatalMsg(c, err.Error())
 						return
@@ -1144,7 +1153,7 @@ func dbTableKeySubscribe(c *DbClient, gnmiPath *gnmipb.Path, interval time.Durat
 		}
 		log.V(2).Infof("Psubscribe succeeded for %v: %v", tblPath, subscr)
 
-		err = tableData2Msi(&tblPath, false, nil, &msiAll)
+		err = TableData2Msi(&tblPath, false, nil, &msiAll)
 		if err != nil {
 			handleFatalMsg(err.Error())
 			return


### PR DESCRIPTION
Key is missing in on change updates

Current:

root@efb973f6ce02:~# python /root/gnxi/gnmi_cli_py/py_gnmicli.py -g -t X -p 50051 -m subscribe -x NEIGH_STATE_TABLE -xt STATE_DB -o ndastreamingservertest --subscribe_mode 0 --submode 1 --interval 0 --update_count 2 --create_connections 1

```
2023-07-20 22:05:25.146156 response received:
sync_response: true

2023-07-20 22:05:31.271959 response received:
update {
  timestamp: 1689890731162239986
  prefix {
    target: "STATE_DB"
  }
  update {
    path {
      elem {
        name: "NEIGH_STATE_TABLE"
      }
    }
    val {
      json_ietf_val: "{\"peerType\":\"e-BGP\",\"state\":\"Active\"}"
    }
  }
}
```

Changed:

```
2023-07-20 22:01:56.251096 response received:
sync_response: true

2023-07-20 22:02:15.558270 response received:
update {
  timestamp: 1689890542962488225
  prefix {
    target: "STATE_DB"
  }
  update {
    path {
      elem {
        name: "NEIGH_STATE_TABLE"
      }
    }
    val {
      json_ietf_val: "{\"10.0.0.57\":{\"peerType\":\"e-BGP\",\"state\":\"Active\"}}"
    }
  }
}
```

Set use key value to true

E2E test (sonic-mgmt test case)

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

