### PR TITLE
Fix random build failures due to syntax error in sonic_internal.proto

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,6 @@ export PATH := $(PATH):$(GOBIN):$(shell dirname $(GO))
 export CGO_LDFLAGS := -lswsscommon -lhiredis
 export CGO_CXXFLAGS := -I/usr/include/swss -w -Wall -fpermissive
 
-SRC_FILES=$(shell find . -name '*.go' | grep -v '_test.go' | grep -v '/tests/')
-TEST_FILES=$(wildcard *_test.go)
-TELEMETRY_TEST_DIR = build/tests/gnmi_server
-TELEMETRY_TEST_BIN = $(TELEMETRY_TEST_DIR)/server.test
 ifeq ($(ENABLE_TRANSLIB_WRITE),y)
 BLD_TAGS := gnmi_translib_write
 endif
@@ -39,7 +35,7 @@ GO_DEPS := vendor/.done
 PATCHES := $(wildcard patches/*.patch)
 PATCHES += $(shell find $(MGMT_COMMON_DIR)/patches -type f)
 
-all: sonic-gnmi $(TELEMETRY_TEST_BIN)
+all: sonic-gnmi
 
 go.mod:
 	$(GO) mod init github.com/sonic-net/sonic-gnmi
@@ -139,15 +135,6 @@ endif
 clean:
 	$(RM) -r build
 	$(RM) -r vendor
-
-$(TELEMETRY_TEST_BIN): $(TEST_FILES) $(SRC_FILES)
-	mkdir -p $(@D)
-	cp -r testdata $(@D)/
-ifeq ($(CONFIGURED_ARCH),armhf)
-	touch $@
-else
-	$(GO) test -mod=vendor $(BLD_FLAGS) -c -cover github.com/sonic-net/sonic-gnmi/gnmi_server -o $@
-endif
 
 install:
 	$(INSTALL) -D $(BUILD_DIR)/telemetry $(DESTDIR)/usr/sbin/telemetry

--- a/proto/sonic_internal.proto
+++ b/proto/sonic_internal.proto
@@ -5,6 +5,8 @@ import "github.com/openconfig/gnmi/proto/gnmi/gnmi.proto";
 
 package gnmi.sonic;
 
+option go_package = "./;gnmi_sonic";
+
 
 enum State {
   STOPPED = 0;
@@ -36,5 +38,5 @@ message Value {
   gnmi.Notification notification = 7;
 
   // Delete to be used to indicate that node was deleted
-  []gnmi.Path delete = 8;
+  repeated gnmi.Path delete = 8;
 }


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

PR #139 introduced a syntax error in sonic_internal.proto file. Looks like sonic_internal.pb.go was manually updated and not re-generated from the proto file. Hence the syntax error went unnoticed.

Now sonic_internal.pb.go re-generation is getting triggered randomly in some clones during docker build causing build failure. This build includes a make target that compiles gotest binary for *gnmi_server* package. All go files are prerequisites for this target. This triggers sonic_internal.pb.go target if sonic_internal.proto got a higher timestamp than sonic_internal.pb.go during git clone. Hence the random failure.

This gotest binary is never used now. Pipeline builds run the go tests directly on source packages. Hence we can remove this makefile target.

#### How I did it

* Fixed the syntax error in "delete" field definition in sonic_internal.proto file
* Removed the makefile target to compile gnmi_server test binary

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

