### PR TITLE
Recover from potential panic when doing map to JSON serialization (#161)

### DIFF
--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -2626,6 +2626,24 @@ func TestTableData2MsiUseKey(t *testing.T) {
     }
 }
 
+func TestRecoverFromJSONSerializationPanic(t *testing.T) {
+    panicMarshal := func(v interface{}) ([]byte, error) {
+        panic("json.Marshal panics and is unable to serialize JSON")
+    }
+    mock := gomonkey.ApplyFunc(json.Marshal, panicMarshal)
+    defer mock.Reset()
+
+    tblPath := sdc.CreateTablePath("STATE_DB", "NEIGH_STATE_TABLE", "|", "10.0.0.57")
+    msi := make(map[string]interface{})
+    sdc.TableData2Msi(&tblPath, true, nil, &msi)
+
+    typedValue, err := sdc.Msi2TypedValue(msi)
+    if typedValue != nil && err != nil {
+        t.Errorf("Test should recover from panic and have nil TypedValue/Error after attempting JSON serialization")
+    }
+
+}
+
 func init() {
 	// Enable logs at UT setup
 	flag.Lookup("v").Value.Set("10")

--- a/sonic_data_client/db_client.go
+++ b/sonic_data_client/db_client.go
@@ -270,6 +270,7 @@ func (c *DbClient) PollRun(q *queue.PriorityQueue, poll chan struct{}, w *sync.W
 		for gnmiPath, tblPaths := range c.pathG2S {
 			val, err := tableData2TypedValue(tblPaths, nil)
 			if err != nil {
+				log.V(2).Infof("Unable to create gnmi TypedValue due to err: %v", err)
 				return
 			}
 
@@ -654,6 +655,12 @@ func makeJSON_redis(msi *map[string]interface{}, key *string, op *string, mfv ma
 // emitJSON marshalls map[string]interface{} to JSON byte stream.
 func emitJSON(v *map[string]interface{}) ([]byte, error) {
 	//j, err := json.MarshalIndent(*v, "", indentString)
+	defer func() {
+		if r := recover(); r != nil {
+			log.V(2).Infof("Recovered from panic: %v", r)
+			log.V(2).Infof("Current state of map to be serialized is: %v", *v)
+		}
+	}()
 	j, err := json.Marshal(*v)
 	if err != nil {
 		return nil, fmt.Errorf("JSON marshalling error: %v", err)
@@ -692,9 +699,12 @@ func TableData2Msi(tblPath *tablePath, useKey bool, op *string, msi *map[string]
 		dbkeys = []string{tblPath.tableName + tblPath.delimitor + tblPath.tableKey}
 	}
 
+	log.V(4).Infof("dbkeys to be pulled from redis %v", dbkeys)
+
 	// Asked to use jsonField and jsonTableKey in the final json value
 	if tblPath.jsonField != "" && tblPath.jsonTableKey != "" {
 		val, err := redisDb.HGet(dbkeys[0], tblPath.field).Result()
+		log.V(4).Infof("Data pulled for key %s and field %s: %s", dbkeys[0], tblPath.field, val)
 		if err != nil {
 			log.V(3).Infof("redis HGet failed for %v %v", tblPath, err)
 			// ignore non-existing field which was derived from virtual path
@@ -712,7 +722,7 @@ func TableData2Msi(tblPath *tablePath, useKey bool, op *string, msi *map[string]
 			log.V(2).Infof("redis HGetAll failed for  %v, dbkey %s", tblPath, dbkey)
 			return err
 		}
-
+		log.V(4).Infof("Data pulled for dbkey %s: %v", dbkey, fv)
 		if tblPath.jsonTableKey != "" { // If jsonTableKey was prepared, use it
 			err = makeJSON_redis(msi, &tblPath.jsonTableKey, op, fv)
 		} else if (tblPath.tableKey != "" && !useKey) || tblPath.tableName == dbkey {
@@ -733,11 +743,15 @@ func TableData2Msi(tblPath *tablePath, useKey bool, op *string, msi *map[string]
 	return nil
 }
 
-func msi2TypedValue(msi map[string]interface{}) (*gnmipb.TypedValue, error) {
+func Msi2TypedValue(msi map[string]interface{}) (*gnmipb.TypedValue, error) {
+	log.V(4).Infof("State of map after adding redis data %v", msi)
 	jv, err := emitJSON(&msi)
 	if err != nil {
 		log.V(2).Infof("emitJSON err %s for  %v", err, msi)
 		return nil, fmt.Errorf("emitJSON err %s for  %v", err, msi)
+	}
+	if jv == nil { // json and err is nil because panic potentially happened
+		return nil, fmt.Errorf("emitJSON failed to grab json value of map due to potential panic")
 	}
 	return &gnmipb.TypedValue{
 		Value: &gnmipb.TypedValue_JsonIetfVal{
@@ -769,6 +783,7 @@ func tableData2TypedValue(tblPaths []tablePath, op *string) (*gnmipb.TypedValue,
 					log.V(2).Infof("redis HGet failed for %v", tblPath)
 					return nil, err
 				}
+				log.V(4).Infof("Data pulled for key %s and field %s: %s", key, tblPath.field, val)
 				// TODO: support multiple table paths
 				return &gnmipb.TypedValue{
 					Value: &gnmipb.TypedValue_StringVal{
@@ -776,13 +791,12 @@ func tableData2TypedValue(tblPaths []tablePath, op *string) (*gnmipb.TypedValue,
 					}}, nil
 			}
 		}
-
 		err := TableData2Msi(&tblPath, useKey, nil, &msi)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return msi2TypedValue(msi)
+	return Msi2TypedValue(msi)
 }
 
 func enqueueFatalMsg(c *DbClient, msg string) {
@@ -851,7 +865,7 @@ func dbFieldMultiSubscribe(c *DbClient, gnmiPath *gnmipb.Path, onChange bool, in
 	}
 
 	sendVal := func(msi map[string]interface{}) error {
-		val, err := msi2TypedValue(msi)
+		val, err := Msi2TypedValue(msi)
 		if err != nil {
 			enqueueFatalMsg(c, err.Error())
 			return err
@@ -1099,7 +1113,7 @@ func dbTableKeySubscribe(c *DbClient, gnmiPath *gnmipb.Path, interval time.Durat
 
 	// Helper to send hash data over the stream
 	sendMsiData := func(msiData map[string]interface{}) error {
-		val, err := msi2TypedValue(msiData)
+		val, err := Msi2TypedValue(msiData)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
It is possible that in some edge cases, json.Marshal is unable to serialize map to JSON and panics. I am adding some additional logging at a higher log level and the ability for the function to recover from the panic with a deferred recover function.

Add deferred recover function when JSON serialization is done and drop the query when unable to provide a JSON to gnmi TypedValue. Add additional logging to give more context of state of map as well as data retrieved from Redis.

UT

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

