### PR TITLE
Fix COUNTERS/Ethernet*/Pfcwd query

### DIFF
--- a/sonic_data_client/virtual_db.go
+++ b/sonic_data_client/virtual_db.go
@@ -131,7 +131,7 @@ func getPfcwdMap() (map[string]map[string]string, error) {
 			return nil, err
 		}
 
-		keyName := fmt.Sprintf("PFC_WD_TABLE%v*", separator)
+		keyName := fmt.Sprintf("PFC_WD%v*", separator)
 		resp, err := redisDb.Keys(keyName).Result()
 		if err != nil {
 			log.V(1).Infof("redis get keys failed for %v in namsepace %v, key = %v, err: %v", dbName, namespace, keyName, err)
@@ -145,7 +145,7 @@ func getPfcwdMap() (map[string]map[string]string, error) {
 		}
 
 		for _, key := range resp {
-			name := key[13:]
+			name := key[7:]
 			pfcwdName_map[name] = make(map[string]string)
 		}
 

--- a/testdata/CONFIG_PFCWD_PORTS.txt
+++ b/testdata/CONFIG_PFCWD_PORTS.txt
@@ -3,166 +3,166 @@
         "3": "3",
         "4": "4"
     },
-    "PFC_WD_TABLE|Ethernet0": {
+    "PFC_WD|Ethernet0": {
         "action": "drop"
     },
-    "PFC_WD_TABLE|Ethernet1": {
+    "PFC_WD|Ethernet1": {
         "action": "drop"
     },
-    "PFC_WD_TABLE|Ethernet10": {
+    "PFC_WD|Ethernet10": {
         "action": "drop"
     },
-    "PFC_WD_TABLE|Ethernet11": {
+    "PFC_WD|Ethernet11": {
         "action": "drop"
     },
-    "PFC_WD_TABLE|Ethernet12": {
+    "PFC_WD|Ethernet12": {
         "action": "drop"
     },
-    "PFC_WD_TABLE|Ethernet13": {
+    "PFC_WD|Ethernet13": {
         "action": "drop"
     },
-    "PFC_WD_TABLE|Ethernet14": {
+    "PFC_WD|Ethernet14": {
         "action": "drop"
     },
-    "PFC_WD_TABLE|Ethernet15": {
+    "PFC_WD|Ethernet15": {
         "action": "drop"
     },
-    "PFC_WD_TABLE|Ethernet16": {
+    "PFC_WD|Ethernet16": {
         "action": "drop"
     },
-    "PFC_WD_TABLE|Ethernet17": {
+    "PFC_WD|Ethernet17": {
         "action": "drop"
     },
-    "PFC_WD_TABLE|Ethernet18": {
+    "PFC_WD|Ethernet18": {
         "action": "drop"
     },
-    "PFC_WD_TABLE|Ethernet19": {
+    "PFC_WD|Ethernet19": {
         "action": "drop"
     },
-    "PFC_WD_TABLE|Ethernet2": {
+    "PFC_WD|Ethernet2": {
         "action": "drop"
     },
-    "PFC_WD_TABLE|Ethernet20": {
+    "PFC_WD|Ethernet20": {
         "action": "drop"
     },
-    "PFC_WD_TABLE|Ethernet21": {
+    "PFC_WD|Ethernet21": {
         "action": "drop"
     },
-    "PFC_WD_TABLE|Ethernet22": {
+    "PFC_WD|Ethernet22": {
         "action": "drop"
     },
-    "PFC_WD_TABLE|Ethernet23": {
+    "PFC_WD|Ethernet23": {
         "action": "drop"
     },
-    "PFC_WD_TABLE|Ethernet24": {
+    "PFC_WD|Ethernet24": {
         "action": "drop"
     },
-    "PFC_WD_TABLE|Ethernet25": {
+    "PFC_WD|Ethernet25": {
         "action": "drop"
     },
-    "PFC_WD_TABLE|Ethernet26": {
+    "PFC_WD|Ethernet26": {
         "action": "drop"
     },
-    "PFC_WD_TABLE|Ethernet27": {
+    "PFC_WD|Ethernet27": {
         "action": "drop"
     },
-    "PFC_WD_TABLE|Ethernet28": {
+    "PFC_WD|Ethernet28": {
         "action": "drop"
     },
-    "PFC_WD_TABLE|Ethernet29": {
+    "PFC_WD|Ethernet29": {
         "action": "drop"
     },
-    "PFC_WD_TABLE|Ethernet3": {
+    "PFC_WD|Ethernet3": {
         "action": "drop"
     },
-    "PFC_WD_TABLE|Ethernet30": {
+    "PFC_WD|Ethernet30": {
         "action": "drop"
     },
-    "PFC_WD_TABLE|Ethernet31": {
+    "PFC_WD|Ethernet31": {
         "action": "drop"
     },
-    "PFC_WD_TABLE|Ethernet32": {
+    "PFC_WD|Ethernet32": {
         "action": "drop"
     },
-    "PFC_WD_TABLE|Ethernet33": {
+    "PFC_WD|Ethernet33": {
         "action": "drop"
     },
-    "PFC_WD_TABLE|Ethernet34": {
+    "PFC_WD|Ethernet34": {
         "action": "drop"
     },
-    "PFC_WD_TABLE|Ethernet35": {
+    "PFC_WD|Ethernet35": {
         "action": "drop"
     },
-    "PFC_WD_TABLE|Ethernet36": {
+    "PFC_WD|Ethernet36": {
         "action": "drop"
     },
-    "PFC_WD_TABLE|Ethernet37": {
+    "PFC_WD|Ethernet37": {
         "action": "drop"
     },
-    "PFC_WD_TABLE|Ethernet38": {
+    "PFC_WD|Ethernet38": {
         "action": "drop"
     },
-    "PFC_WD_TABLE|Ethernet39": {
+    "PFC_WD|Ethernet39": {
         "action": "drop"
     },
-    "PFC_WD_TABLE|Ethernet4": {
+    "PFC_WD|Ethernet4": {
         "action": "drop"
     },
-    "PFC_WD_TABLE|Ethernet40": {
+    "PFC_WD|Ethernet40": {
         "action": "drop"
     },
-    "PFC_WD_TABLE|Ethernet41": {
+    "PFC_WD|Ethernet41": {
         "action": "drop"
     },
-    "PFC_WD_TABLE|Ethernet42": {
+    "PFC_WD|Ethernet42": {
         "action": "drop"
     },
-    "PFC_WD_TABLE|Ethernet43": {
+    "PFC_WD|Ethernet43": {
         "action": "drop"
     },
-    "PFC_WD_TABLE|Ethernet44": {
+    "PFC_WD|Ethernet44": {
         "action": "drop"
     },
-    "PFC_WD_TABLE|Ethernet45": {
+    "PFC_WD|Ethernet45": {
         "action": "drop"
     },
-    "PFC_WD_TABLE|Ethernet46": {
+    "PFC_WD|Ethernet46": {
         "action": "drop"
     },
-    "PFC_WD_TABLE|Ethernet47": {
+    "PFC_WD|Ethernet47": {
         "action": "drop"
     },
-    "PFC_WD_TABLE|Ethernet48": {
+    "PFC_WD|Ethernet48": {
         "action": "drop"
     },
-    "PFC_WD_TABLE|Ethernet5": {
+    "PFC_WD|Ethernet5": {
         "action": "drop"
     },
-    "PFC_WD_TABLE|Ethernet52": {
+    "PFC_WD|Ethernet52": {
         "action": "drop"
     },
-    "PFC_WD_TABLE|Ethernet56": {
+    "PFC_WD|Ethernet56": {
         "action": "drop"
     },
-    "PFC_WD_TABLE|Ethernet6": {
+    "PFC_WD|Ethernet6": {
         "action": "drop"
     },
-    "PFC_WD_TABLE|Ethernet60": {
+    "PFC_WD|Ethernet60": {
         "action": "drop"
     },
-    "PFC_WD_TABLE|Ethernet64": {
+    "PFC_WD|Ethernet64": {
         "action": "drop"
     },
-    "PFC_WD_TABLE|Ethernet68": {
+    "PFC_WD|Ethernet68": {
         "action": "drop"
     },
-    "PFC_WD_TABLE|Ethernet7": {
+    "PFC_WD|Ethernet7": {
         "action": "drop"
     },
-    "PFC_WD_TABLE|Ethernet8": {
+    "PFC_WD|Ethernet8": {
         "action": "drop"
     },
-    "PFC_WD_TABLE|Ethernet9": {
+    "PFC_WD|Ethernet9": {
         "action": "drop"
     },
     "PORT_QOS_MAP|Ethernet0,Ethernet1,Ethernet2,Ethernet3,Ethernet4,Ethernet5,Ethernet6,Ethernet7,Ethernet8,Ethernet9,Ethernet10,Ethernet11,Ethernet12,Ethernet13,Ethernet14,Ethernet15,Ethernet16,Ethernet17,Ethernet18,Ethernet19,Ethernet20,Ethernet21,Ethernet22,Ethernet23,Ethernet24,Ethernet25,Ethernet26,Ethernet27,Ethernet28,Ethernet29,Ethernet30,Ethernet31,Ethernet32,Ethernet33,Ethernet34,Ethernet35,Ethernet36,Ethernet37,Ethernet38,Ethernet39,Ethernet40,Ethernet41,Ethernet42,Ethernet43,Ethernet44,Ethernet45,Ethernet46,Ethernet47,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68": {


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

ADO: 26034082

Currently Pfcwd query is not working as the mapping of Pfwd to oid is broken due to incorrect table name. Fix table name and corresponding UT.

#### How I did it

Fix table name and corresponding UT.

#### How to verify it

UT

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

