### PR TITLE
Support multiple database for DPU

### DIFF
--- a/dialout/dialout_client/dialout_client.go
+++ b/dialout/dialout_client/dialout_client.go
@@ -460,7 +460,7 @@ func setupDestGroupClients(ctx context.Context, destGroupName string) {
 // start/stop/update telemetry publist client as requested
 // TODO: more validation on db data
 func processTelemetryClientConfig(ctx context.Context, redisDb *redis.Client, key string, op string) error {
-	separator, _ := sdc.GetTableKeySeparator("CONFIG_DB", sdcfg.GetDbDefaultNamespace())
+	separator, _ := sdc.GetTableKeySeparator("CONFIG_DB", sdcfg.GetDbDefaultInstance())
 	tableKey := "TELEMETRY_CLIENT" + separator + key
 	fv, err := redisDb.HGetAll(tableKey).Result()
 	if err != nil {
@@ -640,13 +640,13 @@ func processTelemetryClientConfig(ctx context.Context, redisDb *redis.Client, ke
 // read configDB data for telemetry client and start publishing service for client subscription
 func DialOutRun(ctx context.Context, ccfg *ClientConfig) error {
 	clientCfg = ccfg
-	dbn := sdcfg.GetDbId("CONFIG_DB", sdcfg.GetDbDefaultNamespace())
+	dbn := sdcfg.GetDbId("CONFIG_DB", sdcfg.GetDbDefaultInstance())
 
 	var redisDb *redis.Client
 	if sdc.UseRedisLocalTcpPort == false {
 		redisDb = redis.NewClient(&redis.Options{
 			Network:     "unix",
-			Addr:        sdcfg.GetDbSock("CONFIG_DB", sdcfg.GetDbDefaultNamespace()),
+			Addr:        sdcfg.GetDbSock("CONFIG_DB", sdcfg.GetDbDefaultInstance()),
 			Password:    "", // no password set
 			DB:          dbn,
 			DialTimeout: 0,
@@ -654,14 +654,14 @@ func DialOutRun(ctx context.Context, ccfg *ClientConfig) error {
 	} else {
 		redisDb = redis.NewClient(&redis.Options{
 			Network:     "tcp",
-			Addr:        sdcfg.GetDbTcpAddr("CONFIG_DB", sdcfg.GetDbDefaultNamespace()),
+			Addr:        sdcfg.GetDbTcpAddr("CONFIG_DB", sdcfg.GetDbDefaultInstance()),
 			Password:    "", // no password set
 			DB:          dbn,
 			DialTimeout: 0,
 		})
 	}
 
-	separator, _ := sdc.GetTableKeySeparator("CONFIG_DB", sdcfg.GetDbDefaultNamespace())
+	separator, _ := sdc.GetTableKeySeparator("CONFIG_DB", sdcfg.GetDbDefaultInstance())
 	pattern := "__keyspace@" + strconv.Itoa(int(dbn)) + "__:TELEMETRY_CLIENT" + separator
 	prefixLen := len(pattern)
 	pattern += "*"

--- a/dialout/dialout_client/dialout_client_test.go
+++ b/dialout/dialout_client/dialout_client_test.go
@@ -97,9 +97,9 @@ func runServer(t *testing.T, s *sds.Server) {
 func getRedisClient(t *testing.T) *redis.Client {
 	rclient := redis.NewClient(&redis.Options{
 		Network:     "tcp",
-		Addr:        sdcfg.GetDbTcpAddr("COUNTERS_DB", sdcfg.GetDbDefaultNamespace()),
+		Addr:        sdcfg.GetDbTcpAddr("COUNTERS_DB", sdcfg.GetDbDefaultInstance()),
 		Password:    "", // no password set
-		DB:          sdcfg.GetDbId("COUNTERS_DB", sdcfg.GetDbDefaultNamespace()),
+		DB:          sdcfg.GetDbId("COUNTERS_DB", sdcfg.GetDbDefaultInstance()),
 		DialTimeout: 0,
 	})
 	_, err := rclient.Ping().Result()
@@ -126,9 +126,9 @@ func exe_cmd(t *testing.T, cmd string) {
 func getConfigDbClient(t *testing.T) *redis.Client {
 	rclient := redis.NewClient(&redis.Options{
 		Network:     "tcp",
-		Addr:        sdcfg.GetDbTcpAddr("CONFIG_DB", sdcfg.GetDbDefaultNamespace()),
+		Addr:        sdcfg.GetDbTcpAddr("CONFIG_DB", sdcfg.GetDbDefaultInstance()),
 		Password:    "", // no password set
-		DB:          sdcfg.GetDbId("CONFIG_DB", sdcfg.GetDbDefaultNamespace()),
+		DB:          sdcfg.GetDbId("CONFIG_DB", sdcfg.GetDbDefaultInstance()),
 		DialTimeout: 0,
 	})
 	_, err := rclient.Ping().Result()

--- a/gnmi_server/connection_manager.go
+++ b/gnmi_server/connection_manager.go
@@ -26,7 +26,7 @@ func (cm *ConnectionManager) GetThreshold() int {
 }
 
 func (cm *ConnectionManager) PrepareRedis() {
-	ns := sdcfg.GetDbDefaultNamespace()
+	ns := sdcfg.GetDbDefaultInstance()
 	rclient = redis.NewClient(&redis.Options{
 		Network:     "tcp",
 		Addr:        sdcfg.GetDbTcpAddr("STATE_DB", ns),

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -3861,6 +3861,7 @@ print('%s')
 	s.s.Stop()
 }
 
+// Test DPU configuration with multiple databases
 func TestGNMINativeDPU(t *testing.T) {
 	sdcfg.Init()
 	err := test_utils.SetupMultiDPU()
@@ -3893,7 +3894,6 @@ func TestGNMINativeDPU(t *testing.T) {
 	} else {
 		fmt.Println(string(result))
 	}
-
 }
 
 func TestServerPort(t *testing.T) {

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -3835,7 +3835,9 @@ print('%s')
 	path = filepath.Dir(path)
 
 	var cmd *exec.Cmd
-	cmd = exec.Command("bash", "-c", "cd "+path+" && "+"pytest -m 'not dpu'")
+	// This test is used for single database configuration
+	// Run tests not marked with multidb
+	cmd = exec.Command("bash", "-c", "cd "+path+" && "+"pytest -m 'not multidb'")
 	if result, err := cmd.Output(); err != nil {
 		fmt.Println(string(result))
 		t.Errorf("Fail to execute pytest: %v", err)
@@ -3861,18 +3863,18 @@ print('%s')
 	s.s.Stop()
 }
 
-// Test DPU configuration with multiple databases
-func TestGNMINativeDPU(t *testing.T) {
+// Test configuration with multiple databases
+func TestGNMINativeMultiDB(t *testing.T) {
 	sdcfg.Init()
-	err := test_utils.SetupMultiDPU()
+	err := test_utils.SetupMultiDatabase()
 	if err != nil {
-		t.Fatalf("error Setting up MultiDPU files with err %T", err)
+		t.Fatalf("error Setting up MultiDatabase files with err %T", err)
 	}
 
 	/* https://www.gopherguides.com/articles/test-cleanup-in-go-1-14*/
 	t.Cleanup(func() {
-		if err := test_utils.CleanUpMultiDPU(); err != nil {
-			t.Fatalf("error Cleaning up MultiDPU files with err %T", err)
+		if err := test_utils.CleanUpMultiDatabase(); err != nil {
+			t.Fatalf("error Cleaning up MultiDatabase files with err %T", err)
 
 		}
 	})
@@ -3887,7 +3889,9 @@ func TestGNMINativeDPU(t *testing.T) {
 	path = filepath.Dir(path)
 
 	var cmd *exec.Cmd
-	cmd = exec.Command("bash", "-c", "cd "+path+" && "+"pytest -m 'dpu'")
+	// This test is used for multiple database configuration
+	// Run tests marked with multidb
+	cmd = exec.Command("bash", "-c", "cd "+path+" && "+"pytest -m 'multidb'")
 	if result, err := cmd.Output(); err != nil {
 		fmt.Println(string(result))
 		t.Errorf("Fail to execute pytest: %v", err)

--- a/gnmi_server/transl_sub_test.go
+++ b/gnmi_server/transl_sub_test.go
@@ -891,8 +891,8 @@ type DbDataMap map[string]map[string]map[string]interface{}
 func updateDb(t *testing.T, data DbDataMap) {
 	t.Helper()
 	for dbName, tableData := range data {
-		n := dbconfig.GetDbId(dbName, dbconfig.GetDbDefaultNamespace())
-		redis := getRedisClientN(t, n, dbconfig.GetDbDefaultNamespace())
+		n := dbconfig.GetDbId(dbName, dbconfig.GetDbDefaultInstance())
+		redis := getRedisClientN(t, n, dbconfig.GetDbDefaultInstance())
 		defer redis.Close()
 		for key, fields := range tableData {
 			if fields == nil {

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 markers:
-    dpu
+    multidb
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers:
+    dpu
+

--- a/sonic_data_client/client_test.go
+++ b/sonic_data_client/client_test.go
@@ -309,28 +309,20 @@ func TestJsonRemoveNegative(t *testing.T) {
 	}
 }
 
-func TestParseTarget(t *testing.T) {
+func TestParseDatabase(t *testing.T) {
 	var test_paths []*gnmipb.Path
 	var err error
 
-	_, err = ParseTarget("test", test_paths)
-	if err != nil {
-		t.Errorf("ParseTarget failed for empty path: %v", err)
-	}
-
-	test_target := "TEST_DB"
-	path, err := xpath.ToGNMIPath("sonic-db:" + test_target + "/VLAN")
+	test_target := "APPL_DB"
+	test_inst := "dpu0"
+	path, err := xpath.ToGNMIPath("sonic-db:" + test_target + "/" + test_inst + "/VLAN")
 	test_paths = append(test_paths, path)
-	target, err := ParseTarget("", test_paths)
+	target, inst, err := ParseDatabase(nil, test_paths)
 	if err != nil {
-		t.Errorf("ParseTarget failed to get target: %v", err)
+		t.Errorf("ParseDatabase failed to get target: %v", err)
 	}
-	if target != test_target {
-		t.Errorf("ParseTarget return wrong target: %v", target)
-	}
-	target, err = ParseTarget("INVALID_DB", test_paths)
-	if err == nil {
-		t.Errorf("ParseTarget should fail for conflict")
+	if target != test_target || inst != test_inst {
+		t.Errorf("ParseDatabase return wrong target: %v", target)
 	}
 }
 
@@ -386,7 +378,7 @@ func ReceiveFromZmq(consumer swsscommon.ZmqConsumerStateTable) (bool) {
 
 func TestZmqReconnect(t *testing.T) {
 	// create ZMQ server
-	db := swsscommon.NewDBConnector(APPL_DB_NAME, SWSS_TIMEOUT, false)
+	db := swsscommon.NewDBConnector(PREV_APPL_DB_NAME, SWSS_TIMEOUT, false)
 	zmqServer := swsscommon.NewZmqServer("tcp://*:1234")
 	var TEST_TABLE string = "DASH_ROUTE"
     consumer := swsscommon.NewZmqConsumerStateTable(db, TEST_TABLE, zmqServer)
@@ -394,7 +386,7 @@ func TestZmqReconnect(t *testing.T) {
 	// create ZMQ client side
 	zmqAddress := "tcp://127.0.0.1:1234"
 	client := MixedDbClient {
-		applDB : swsscommon.NewDBConnector(APPL_DB_NAME, SWSS_TIMEOUT, false),
+		applDB : swsscommon.NewDBConnector(PREV_APPL_DB_NAME, SWSS_TIMEOUT, false),
 		tableMap : map[string]swsscommon.ProducerStateTable{},
 		zmqClient : swsscommon.NewZmqClient(zmqAddress),
 	}

--- a/sonic_data_client/events_client.go
+++ b/sonic_data_client/events_client.go
@@ -226,7 +226,7 @@ func update_stats(evtc *EventClient) {
 
     /* Populate counters from DB for cumulative counters. */
     if !evtc.isStopped() {
-        ns := sdcfg.GetDbDefaultNamespace()
+        ns := sdcfg.GetDbDefaultInstance()
 
         rclient = redis.NewClient(&redis.Options{
             Network:    "tcp",

--- a/sonic_data_client/mixed_db_client.go
+++ b/sonic_data_client/mixed_db_client.go
@@ -29,7 +29,7 @@ import (
 )
 
 const REDIS_SOCK string = "/var/run/redis/redis.sock"
-// New database for DPU configuration, but swsscommon does not support it yet
+// New database configuration, but swsscommon does not support it yet
 const APPL_DB_NAME string = "DPU_APPL_DB"
 // Use APPL_DB as workaround
 const PREV_APPL_DB_NAME string = "APPL_DB"

--- a/sonic_data_client/mixed_db_client.go
+++ b/sonic_data_client/mixed_db_client.go
@@ -29,7 +29,9 @@ import (
 )
 
 const REDIS_SOCK string = "/var/run/redis/redis.sock"
+// New database for DPU configuration, but swsscommon does not support it yet
 const APPL_DB_NAME string = "DPU_APPL_DB"
+// Use APPL_DB as workaround
 const PREV_APPL_DB_NAME string = "APPL_DB"
 const DASH_TABLE_PREFIX string = "DASH_"
 const SWSS_TIMEOUT uint = 0
@@ -273,7 +275,9 @@ func NewMixedDbClient(paths []*gnmipb.Path, prefix *gnmipb.Path, origin string, 
 	}
 	dbId := sdcfg.GetDbId(client.target, client.instance)
 	dbSock := sdcfg.GetDbSock(client.target, client.instance)
-	// TODO: Current swsscommon implement does not support dpu database, need new ctor
+	// swsscommon does not support database configuration defined by database_name
+	// And then we can't use new database name from /var/run/redisdpu0/sonic-db/database_config.json
+	// TODO: Update swsscommon to support new database structure and new constructor for database_name
 	client.applDB = swsscommon.NewDBConnector(dbId, dbSock, SWSS_TIMEOUT)
 	client.paths = paths
 	client.workPath = common_utils.GNMI_WORK_PATH

--- a/sonic_db_config/db_config.go
+++ b/sonic_db_config/db_config.go
@@ -200,6 +200,7 @@ func DbParseConfigFile(name_to_cfgfile_map map[string]string) {
 			panic(err)
 		}
 		for _, entry := range sonic_db_global_config["INCLUDES"].([]interface{}) {
+			// Support namespace and batabase_name in global config file
 			name := SONIC_DEFAULT_INSTANCE
 			ns, ok1 := entry.(map[string]interface{})["namespace"]
 			dbName, ok2 := entry.(map[string]interface{})["database_name"]

--- a/sonic_db_config/db_config.go
+++ b/sonic_db_config/db_config.go
@@ -23,7 +23,7 @@ var sonic_db_config = make(map[string]map[string]interface{}) // nosemgrep: iter
 var sonic_db_init bool
 var sonic_db_multi_instance bool
 
-// Use multiple instances to support multiple asic and multiple dpu
+// Use multiple instances to support multiple asic and multiple database
 // Instance can be localhost, asic0, asic1, ..., dpu0, dpu1, ...
 func GetDbDefaultInstance() string {
 	return SONIC_DEFAULT_INSTANCE

--- a/sonic_db_config/db_config_test.go
+++ b/sonic_db_config/db_config_test.go
@@ -80,17 +80,17 @@ func TestGetDbMultiNs(t *testing.T) {
 	})
 }
 
-func TestGetDbMultiDPU(t *testing.T) {
+func TestGetDbMultiDatabase(t *testing.T) {
 	Init()
-	err := test_utils.SetupMultiDPU()
+	err := test_utils.SetupMultiDatabase()
 	if err != nil {
-		t.Fatalf("error Setting up MultiDPU files with err %T", err)
+		t.Fatalf("error Setting up MultiDatabase files with err %T", err)
 	}
 
 	/* https://www.gopherguides.com/articles/test-cleanup-in-go-1-14*/
 	t.Cleanup(func() {
-		if err := test_utils.CleanUpMultiDPU(); err != nil {
-			t.Fatalf("error Cleaning up MultiDPU files with err %T", err)
+		if err := test_utils.CleanUpMultiDatabase(); err != nil {
+			t.Fatalf("error Cleaning up MultiDatabase files with err %T", err)
 
 		}
 	})
@@ -113,13 +113,13 @@ func TestGetDbMultiDPU(t *testing.T) {
 			t.Fatalf(`Sock("") = %q, want %s, error`, sock_path, exp_path)
 		}
 	})
-	t.Run("AllDPU", func(t *testing.T) {
+	t.Run("All database", func(t *testing.T) {
 		ns_list := GetDbAllInstances()
 		if len(ns_list) != 2 {
-			t.Fatalf(`AllDPU("") = %q, want "2", error %v`, len(ns_list), ns_list)
+			t.Fatalf(`All database("") = %q, want "2", error %v`, len(ns_list), ns_list)
 		}
 		if !((ns_list[0] == GetDbDefaultInstance() && ns_list[1] == "dpu0") || (ns_list[0] == "dpu0" && ns_list[1] == GetDbDefaultInstance())) {
-			t.Fatalf(`AllDPU("") = %q %q, want default and dpu0, error`, ns_list[0], ns_list[1])
+			t.Fatalf(`All database("") = %q %q, want default and dpu0, error`, ns_list[0], ns_list[1])
 		}
 	})
 	t.Run("TcpAddr", func(t *testing.T) {

--- a/sonic_db_config/db_config_test.go
+++ b/sonic_db_config/db_config_test.go
@@ -9,33 +9,34 @@ import (
 
 func TestGetDb(t *testing.T) {
 	t.Run("Id", func(t *testing.T) {
-		db_id := GetDbId("CONFIG_DB", GetDbDefaultNamespace())
+		db_id := GetDbId("CONFIG_DB", GetDbDefaultInstance())
 		if db_id != 4 {
 			t.Fatalf(`Id("") = %d, want 4, error`, db_id)
 		}
 	})
 	t.Run("Sock", func(t *testing.T) {
-		sock_path := GetDbSock("CONFIG_DB", GetDbDefaultNamespace())
+		sock_path := GetDbSock("CONFIG_DB", GetDbDefaultInstance())
 		if sock_path != "/var/run/redis/redis.sock" {
 			t.Fatalf(`Sock("") = %q, want "/var/run/redis/redis.sock", error`, sock_path)
 		}
 	})
 	t.Run("AllNamespaces", func(t *testing.T) {
-		ns_list := GetDbAllNamespaces()
+		ns_list := GetDbAllInstances()
 		if len(ns_list) != 1 {
 			t.Fatalf(`AllNamespaces("") = %q, want "1", error`, len(ns_list))
 		}
-		if ns_list[0] != GetDbDefaultNamespace() {
+		if ns_list[0] != GetDbDefaultInstance() {
 			t.Fatalf(`AllNamespaces("") = %q, want default, error`, ns_list[0])
 		}
 	})
 	t.Run("TcpAddr", func(t *testing.T) {
-		tcp_addr := GetDbTcpAddr("CONFIG_DB", GetDbDefaultNamespace())
+		tcp_addr := GetDbTcpAddr("CONFIG_DB", GetDbDefaultInstance())
 		if tcp_addr != "127.0.0.1:6379" {
 			t.Fatalf(`TcpAddr("") = %q, want 127.0.0.1:6379, error`, tcp_addr)
 		}
 	})
 }
+
 func TestGetDbMultiNs(t *testing.T) {
 	Init()
 	err := test_utils.SetupMultiNamespace()
@@ -63,16 +64,66 @@ func TestGetDbMultiNs(t *testing.T) {
 		}
 	})
 	t.Run("AllNamespaces", func(t *testing.T) {
-		ns_list := GetDbAllNamespaces()
+		ns_list := GetDbAllInstances()
 		if len(ns_list) != 2 {
 			t.Fatalf(`AllNamespaces("") = %q, want "2", error`, len(ns_list))
 		}
-		if !((ns_list[0] == GetDbDefaultNamespace() && ns_list[1] == "asic0") || (ns_list[0] == "asic0" && ns_list[1] == GetDbDefaultNamespace())) {
+		if !((ns_list[0] == GetDbDefaultInstance() && ns_list[1] == "asic0") || (ns_list[0] == "asic0" && ns_list[1] == GetDbDefaultInstance())) {
 			t.Fatalf(`AllNamespaces("") = %q %q, want default and asic0, error`, ns_list[0], ns_list[1])
 		}
 	})
 	t.Run("TcpAddr", func(t *testing.T) {
 		tcp_addr := GetDbTcpAddr("CONFIG_DB", "asic0")
+		if tcp_addr != "127.0.0.1:6379" {
+			t.Fatalf(`TcpAddr("") = %q, want 127.0.0.1:6379, error`, tcp_addr)
+		}
+	})
+}
+
+func TestGetDbMultiDPU(t *testing.T) {
+	Init()
+	err := test_utils.SetupMultiDPU()
+	if err != nil {
+		t.Fatalf("error Setting up MultiDPU files with err %T", err)
+	}
+
+	/* https://www.gopherguides.com/articles/test-cleanup-in-go-1-14*/
+	t.Cleanup(func() {
+		if err := test_utils.CleanUpMultiDPU(); err != nil {
+			t.Fatalf("error Cleaning up MultiDPU files with err %T", err)
+
+		}
+	})
+	t.Run("CONFIG_DB Id", func(t *testing.T) {
+		db_id := GetDbId("CONFIG_DB", "dpu0")
+		if db_id != 4 {
+			t.Fatalf(`Id("") = %d, want 4, error`, db_id)
+		}
+	})
+	t.Run("DPU_APPL_DB Id", func(t *testing.T) {
+		db_id := GetDbId("DPU_APPL_DB", "dpu0")
+		if db_id != 15 {
+			t.Fatalf(`Id("") = %d, want 15, error`, db_id)
+		}
+	})
+	t.Run("Sock", func(t *testing.T) {
+		sock_path := GetDbSock("CONFIG_DB", "dpu0")
+		exp_path := "/var/run/redis/redis.sock"
+		if sock_path != exp_path {
+			t.Fatalf(`Sock("") = %q, want %s, error`, sock_path, exp_path)
+		}
+	})
+	t.Run("AllDPU", func(t *testing.T) {
+		ns_list := GetDbAllInstances()
+		if len(ns_list) != 2 {
+			t.Fatalf(`AllDPU("") = %q, want "2", error %v`, len(ns_list), ns_list)
+		}
+		if !((ns_list[0] == GetDbDefaultInstance() && ns_list[1] == "dpu0") || (ns_list[0] == "dpu0" && ns_list[1] == GetDbDefaultInstance())) {
+			t.Fatalf(`AllDPU("") = %q %q, want default and dpu0, error`, ns_list[0], ns_list[1])
+		}
+	})
+	t.Run("TcpAddr", func(t *testing.T) {
+		tcp_addr := GetDbTcpAddr("CONFIG_DB", "dpu0")
 		if tcp_addr != "127.0.0.1:6379" {
 			t.Fatalf(`TcpAddr("") = %q, want 127.0.0.1:6379, error`, tcp_addr)
 		}
@@ -96,6 +147,6 @@ func TestOverrideDbConfigFile(t *testing.T) {
 			t.Fatalf("Unexpected panic: %v", r)
 		}
 	}()
-	_ = GetDbId("CONFIG_DB", GetDbDefaultNamespace())
+	_ = GetDbId("CONFIG_DB", GetDbDefaultInstance())
 	t.Fatal("GetDbId() should have paniced")
 }

--- a/test/test_gnmi_appldb.py
+++ b/test/test_gnmi_appldb.py
@@ -8,16 +8,16 @@ import pytest
 test_data_update_normal = [
     [
         {
-            'update_path': '/sonic-db:APPL_DB/DASH_QOS',
-            'get_path': '/sonic-db:APPL_DB/_DASH_QOS',
+            'update_path': '/sonic-db:APPL_DB/dpu0/DASH_QOS',
+            'get_path': '/sonic-db:APPL_DB/dpu0/_DASH_QOS',
             'value': {
                 'qos_01': {'bw': '54321', 'cps': '1000', 'flows': '300'},
                 'qos_02': {'bw': '6000', 'cps': '200', 'flows': '101'}
             }
         },
         {
-            'update_path': '/sonic-db:APPL_DB/DASH_VNET',
-            'get_path': '/sonic-db:APPL_DB/_DASH_VNET',
+            'update_path': '/sonic-db:APPL_DB/dpu0/DASH_VNET',
+            'get_path': '/sonic-db:APPL_DB/dpu0/_DASH_VNET',
             'value': {
                 'Vnet3721': {
                     'address_spaces': ["10.250.0.0", "192.168.3.0", "139.66.72.9"]
@@ -27,18 +27,18 @@ test_data_update_normal = [
     ],
     [
         {
-            'update_path': '/sonic-db:APPL_DB/DASH_QOS/qos_01',
-            'get_path': '/sonic-db:APPL_DB/_DASH_QOS/qos_01',
+            'update_path': '/sonic-db:APPL_DB/dpu0/DASH_QOS/qos_01',
+            'get_path': '/sonic-db:APPL_DB/dpu0/_DASH_QOS/qos_01',
             'value': {'bw': '10001', 'cps': '1001', 'flows': '101'}
         },
         {
-            'update_path': '/sonic-db:APPL_DB/DASH_QOS/qos_02',
-            'get_path': '/sonic-db:APPL_DB/_DASH_QOS/qos_02',
+            'update_path': '/sonic-db:APPL_DB/dpu0/DASH_QOS/qos_02',
+            'get_path': '/sonic-db:APPL_DB/dpu0/_DASH_QOS/qos_02',
             'value': {'bw': '10002', 'cps': '1002', 'flows': '102'}
         },
         {
-            'update_path': '/sonic-db:APPL_DB/DASH_VNET/Vnet3721',
-            'get_path': '/sonic-db:APPL_DB/_DASH_VNET/Vnet3721',
+            'update_path': '/sonic-db:APPL_DB/dpu0/DASH_VNET/Vnet3721',
+            'get_path': '/sonic-db:APPL_DB/dpu0/_DASH_VNET/Vnet3721',
             'value': {
                 'address_spaces': ["10.250.0.0", "192.168.3.0", "139.66.72.9"]
             }
@@ -47,7 +47,7 @@ test_data_update_normal = [
 ]
 
 def clear_appl_db(table_name):
-    prefix = '/sonic-db:APPL_DB'
+    prefix = '/sonic-db:APPL_DB/dpu0'
     get_path = prefix + '/_' + table_name
     ret, msg_list = gnmi_get([get_path])
     if ret != 0:
@@ -64,6 +64,7 @@ def clear_appl_db(table_name):
 
 class TestGNMIApplDb:
 
+    @pytest.mark.dpu
     @pytest.mark.parametrize('test_data', test_data_update_normal)
     def test_gnmi_update_normal_01(self, test_data):
         clear_appl_db('DASH_QOS')
@@ -95,6 +96,7 @@ class TestGNMIApplDb:
                     break
             assert hit == True, 'No match for %s'%str(data['value'])
 
+    @pytest.mark.dpu
     @pytest.mark.parametrize('test_data', test_data_update_normal)
     def test_gnmi_update_normal_02(self, test_data):
         clear_appl_db('DASH_QOS')
@@ -113,6 +115,7 @@ class TestGNMIApplDb:
         ret, msg = gnmi_set([], update_list, [])
         assert ret != 0, "Invalid json ietf value"
 
+    @pytest.mark.dpu
     @pytest.mark.parametrize('test_data', test_data_update_normal)
     def test_gnmi_delete_normal_01(self, test_data):
         delete_list = []
@@ -121,9 +124,9 @@ class TestGNMIApplDb:
         for i, data in enumerate(test_data):
             path = data['update_path']
             path_length = path.count('/')
-            # path length is 2, path has table name, and has no key
+            # path length is 3, path has table name, and has no key
             # there's no consumer for unit test, and gnmi cannot delete temporary state table
-            if path_length <= 2:
+            if path_length <= 3:
                 continue
             get_path = data['get_path']
             value = json.dumps(data['value'])
@@ -148,6 +151,7 @@ class TestGNMIApplDb:
             for msg in msg_list:
                 assert msg == '{}', 'Delete failed'
 
+    @pytest.mark.dpu
     @pytest.mark.parametrize('test_data', test_data_update_normal)
     def test_gnmi_replace_normal_01(self, test_data):
         clear_appl_db('DASH_QOS')
@@ -179,6 +183,7 @@ class TestGNMIApplDb:
                     break
             assert hit == True, 'No match for %s'%str(data['value'])
 
+    @pytest.mark.dpu
     @pytest.mark.parametrize('test_data', test_data_update_normal)
     def test_gnmi_replace_normal_02(self, test_data):
         replace_list = []
@@ -187,9 +192,9 @@ class TestGNMIApplDb:
         for i, data in enumerate(test_data):
             path = data['update_path']
             path_length = path.count('/')
-            # path length is 2, path has table name, and has no key
+            # path length is 3, path has table name, and has no key
             # there's no consumer for unit test, and gnmi cannot delete temporary state table
-            if path_length <= 2:
+            if path_length <= 3:
                 continue
             get_path = data['get_path']
             value = json.dumps(data['value'])
@@ -214,8 +219,9 @@ class TestGNMIApplDb:
             for msg in msg_list:
                 assert msg == '{}', 'Delete failed'
 
+    @pytest.mark.dpu
     def test_gnmi_invalid_path_01(self):
-        path = '/sonic-db:APPL_DB/DASH_QOS/qos_01/bw'
+        path = '/sonic-db:APPL_DB/dpu0/DASH_QOS/qos_01/bw'
         value = '300'
         update_list = []
         text = json.dumps(value)
@@ -229,9 +235,10 @@ class TestGNMIApplDb:
         assert ret != 0, 'Invalid path'
         assert 'Unsupported path' in msg
 
+    @pytest.mark.dpu
     def test_gnmi_invalid_origin_01(self):
-        path1 = '/sonic-db:APPL_DB/DASH_QOS'
-        path2 = '/sonic-yang:APPL_DB/DASH_QOS'
+        path1 = '/sonic-db:APPL_DB/dpu0/DASH_QOS'
+        path2 = '/sonic-yang:APPL_DB/dpu0/DASH_QOS'
         value = {
             'qos_01': {'bw': '54321', 'cps': '1000', 'flows': '300'},
             'qos_02': {'bw': '6000', 'cps': '200', 'flows': '101'}
@@ -259,8 +266,9 @@ class TestGNMIApplDb:
                 break
         assert hit == True, 'No expected error: %s'%exp
 
+    @pytest.mark.dpu
     def test_gnmi_invalid_target_01(self):
-        path = '/sonic-db:INVALID_DB/DASH_QOS'
+        path = '/sonic-db:DPU_INVALID_DB/dpu0/DASH_QOS'
         value = {
             'qos_01': {'bw': '54321', 'cps': '1000', 'flows': '300'},
             'qos_02': {'bw': '6000', 'cps': '200', 'flows': '101'}
@@ -288,8 +296,9 @@ class TestGNMIApplDb:
                 break
         assert hit == True, 'No expected error: %s'%exp
 
+    @pytest.mark.dpu
     def test_gnmi_invalid_target_02(self):
-        path = '/sonic-db:ASIC_DB/DASH_QOS'
+        path = '/sonic-db:ASIC_DB/dpu0/DASH_QOS'
         value = {
             'qos_01': {'bw': '54321', 'cps': '1000', 'flows': '300'},
             'qos_02': {'bw': '6000', 'cps': '200', 'flows': '101'}
@@ -306,9 +315,10 @@ class TestGNMIApplDb:
         assert ret != 0, 'Target is invalid'
         assert 'Set RPC does not support ASIC_DB' in msg
 
+    @pytest.mark.dpu
     def test_gnmi_invalid_target_03(self):
-        path1 = '/sonic-db:APPL_DB/DASH_QOS'
-        path2 = '/sonic-db:CONFIG_DB/DASH_QOS'
+        path1 = '/sonic-db:APPL_DB/dpu0/DASH_QOS'
+        path2 = '/sonic-db:CONFIG_DB/dpu0/DASH_QOS'
         value = {
             'qos_01': {'bw': '54321', 'cps': '1000', 'flows': '300'},
             'qos_02': {'bw': '6000', 'cps': '200', 'flows': '101'}
@@ -323,21 +333,22 @@ class TestGNMIApplDb:
 
         ret, msg = gnmi_set([], update_list, [])
         assert ret != 0, 'Target is invalid'
-        assert 'Target conflict' in msg
+        assert 'Target/Instance conflict ' in msg
 
         get_list = [path1, path2]
         ret, msg_list = gnmi_get(get_list)
         assert ret != 0, 'Target is invalid'
         hit = False
-        exp = 'Target conflict'
+        exp = 'Target/Instance conflict '
         for msg in msg_list:
             if exp in msg:
                 hit = True
                 break
         assert hit == True, 'No expected error: %s'%exp
 
+    @pytest.mark.dpu
     def test_gnmi_invalid_encoding(self):
-        path = '/sonic-db:APPL_DB/DASH_QOS'
+        path = '/sonic-db:APPL_DB/dpu0/DASH_QOS'
         get_list = [path]
         ret, msg_list = gnmi_get_with_encoding(get_list, "ASCII")
         assert ret != 0, 'Encoding is not supported'
@@ -349,22 +360,23 @@ class TestGNMIApplDb:
                 break
         assert hit == True, 'No expected error: %s'%exp
 
+    @pytest.mark.dpu
     def test_gnmi_update_proto_01(self):
         proto_bytes = b"\n\x010\x12$b6d54023-5d24-47de-ae94-8afe693dd1fc\x1a\x17\n\x12\x12\x10\r\xc0-\xdd\x82\xa3\x88;\x0fP\x84<\xaakc\x16\x10\x80\x01\x1a\x17\n\x12\x12\x10-\x0e\xf2\x7f\n~c_\xd8\xb7\x10\x84\x81\xd6'|\x10\x80\x01\x1a\x17\n\x12\x12\x10\x1bV\x89\xc8JW\x06\xfb\xad\b*fN\x9e(\x17\x10\x80\x01\x1a\x17\n\x12\x12\x107\xf9\xbc\xc0\x8d!s\xccVT\x88\x00\xf8\x9c\xce\x90\x10\x80\x01\x1a\x17\n\x12\x12\x10\tEb\x11Mf]\x12\x17x\x99\x80\xea\xd1u\xb4\x10\x80\x01\x1a\x17\n\x12\x12\x10\x1f\xd3\x1c\x89\x99\x16\xe7\x18\x91^0\x81\xb1\x04\x8c\x1e\x10\x80\x01\x1a\x17\n\x12\x12\x10\x06\x9e55\xdb\xb5&\x93\x99\xfaC\x81\x16P\xdc\x1d\x10\x80\x01\x1a\x17\n\x12\x12\x10&]U\x96e4\xf4\xd2'&\x04i\xdf\x8dA\x9f\x10\x80\x01\x1a\x17\n\x12\x12\x108\xd5\xa3*\xe7\x80\xdc\x1e\x80f\x94\xb7\xb6\x86~\xcd\x10\x80\x01\x1a\x17\n\x12\x12\x101\xf0@F\nu+}\x1e\"\\\\\xdb\x01\xe3\x82\x10\x80\x01\"\x05vnet1\"\x05vnet2\"\x05vnet1\"\x05vnet2\"\x05vnet2\"\x05vnet1\"\x05vnet2\"\x05vnet2\"\x05vnet1\"\x05vnet1"
         test_data = [
             {
-                'update_path': '/sonic-db:APPL_DB/DASH_ROUTE_TABLE[key=F4939FEFC47E:20.2.2.0/24]',
-                'get_path': '/sonic-db:APPL_DB/_DASH_ROUTE_TABLE[key=F4939FEFC47E:20.2.2.0/24]',
+                'update_path': '/sonic-db:APPL_DB/dpu0/DASH_ROUTE_TABLE[key=F4939FEFC47E:20.2.2.0/24]',
+                'get_path': '/sonic-db:APPL_DB/dpu0/_DASH_ROUTE_TABLE[key=F4939FEFC47E:20.2.2.0/24]',
                 'value': proto_bytes
             },
             {
-                'update_path': '/sonic-db:APPL_DB/DASH_ROUTE_TABLE[key=F4939FEFC47E:30.3.3.0/24]',
-                'get_path': '/sonic-db:APPL_DB/_DASH_ROUTE_TABLE[key=F4939FEFC47E:30.3.3.0/24]',
+                'update_path': '/sonic-db:APPL_DB/dpu0/DASH_ROUTE_TABLE[key=F4939FEFC47E:30.3.3.0/24]',
+                'get_path': '/sonic-db:APPL_DB/dpu0/_DASH_ROUTE_TABLE[key=F4939FEFC47E:30.3.3.0/24]',
                 'value': proto_bytes
             },
             {
-                'update_path': '/sonic-db:APPL_DB/DASH_VNET_MAPPING_TABLE[key=Vnet2:20.2.2.2]',
-                'get_path': '/sonic-db:APPL_DB/_DASH_VNET_MAPPING_TABLE[key=Vnet2:20.2.2.2]',
+                'update_path': '/sonic-db:APPL_DB/dpu0/DASH_VNET_MAPPING_TABLE[key=Vnet2:20.2.2.2]',
+                'get_path': '/sonic-db:APPL_DB/dpu0/_DASH_VNET_MAPPING_TABLE[key=Vnet2:20.2.2.2]',
                 'value': proto_bytes
             }
         ]
@@ -388,9 +400,10 @@ class TestGNMIApplDb:
             result_bytes = open(file_name, 'rb').read()
             assert proto_bytes == result_bytes, 'get proto not equal to update proto'
 
+    @pytest.mark.dpu
     def test_gnmi_update_proto_02(self):
-        update_path = '/sonic-db:APPL_DB/DASH_QOS'
-        get_path = '/sonic-db:APPL_DB/_DASH_QOS[key=qos1]'
+        update_path = '/sonic-db:APPL_DB/dpu0/DASH_QOS'
+        get_path = '/sonic-db:APPL_DB/dpu0/_DASH_QOS[key=qos1]'
         value = {
             'qos_01': {'bw': '54321', 'cps': '1000', 'flows': '300'},
             'qos_02': {'bw': '6000', 'cps': '200', 'flows': '101'}
@@ -411,22 +424,23 @@ class TestGNMIApplDb:
         ret, msg_list = gnmi_get_proto(get_list, file_list)
         assert ret != 0, 'Can not get result with proto encoding'
 
+    @pytest.mark.dpu
     def test_gnmi_update_proto_03(self):
         proto_bytes = b""
         test_data = [
             {
-                'update_path': '/sonic-db:APPL_DB/DASH_ROUTE_TABLE[key=F4939FEFC47E:20.2.2.0/24]',
-                'get_path': '/sonic-db:APPL_DB/_DASH_ROUTE_TABLE[key=F4939FEFC47E:20.2.2.0/24]',
+                'update_path': '/sonic-db:APPL_DB/dpu0/DASH_ROUTE_TABLE[key=F4939FEFC47E:20.2.2.0/24]',
+                'get_path': '/sonic-db:APPL_DB/dpu0/_DASH_ROUTE_TABLE[key=F4939FEFC47E:20.2.2.0/24]',
                 'value': proto_bytes
             },
             {
-                'update_path': '/sonic-db:APPL_DB/DASH_ROUTE_TABLE[key=F4939FEFC47E:30.3.3.0/24]',
-                'get_path': '/sonic-db:APPL_DB/_DASH_ROUTE_TABLE[key=F4939FEFC47E:30.3.3.0/24]',
+                'update_path': '/sonic-db:APPL_DB/dpu0/DASH_ROUTE_TABLE[key=F4939FEFC47E:30.3.3.0/24]',
+                'get_path': '/sonic-db:APPL_DB/dpu0/_DASH_ROUTE_TABLE[key=F4939FEFC47E:30.3.3.0/24]',
                 'value': proto_bytes
             },
             {
-                'update_path': '/sonic-db:APPL_DB/DASH_VNET_MAPPING_TABLE[key=Vnet2:20.2.2.2]',
-                'get_path': '/sonic-db:APPL_DB/_DASH_VNET_MAPPING_TABLE[key=Vnet2:20.2.2.2]',
+                'update_path': '/sonic-db:APPL_DB/dpu0/DASH_VNET_MAPPING_TABLE[key=Vnet2:20.2.2.2]',
+                'get_path': '/sonic-db:APPL_DB/dpu0/_DASH_VNET_MAPPING_TABLE[key=Vnet2:20.2.2.2]',
                 'value': proto_bytes
             }
         ]
@@ -450,16 +464,17 @@ class TestGNMIApplDb:
             result_bytes = open(file_name, 'rb').read()
             assert proto_bytes == result_bytes, 'get proto not equal to update proto'
 
+    @pytest.mark.dpu
     def test_gnmi_delete_proto_01(self):
         test_data = [
             {
-                'update_path': '/sonic-db:APPL_DB/DASH_ROUTE_TABLE/F4939FEFC47E:20.2.2.0\\\\/24',
+                'update_path': '/sonic-db:APPL_DB/dpu0/DASH_ROUTE_TABLE/F4939FEFC47E:20.2.2.0\\\\/24',
             },
             {
-                'update_path': '/sonic-db:APPL_DB/DASH_ROUTE_TABLE/F4939FEFC47E:30.3.3.0\\\\/24',
+                'update_path': '/sonic-db:APPL_DB/dpu0/DASH_ROUTE_TABLE/F4939FEFC47E:30.3.3.0\\\\/24',
             },
             {
-                'update_path': '/sonic-db:APPL_DB/DASH_VNET_MAPPING_TABLE/Vnet2:20.2.2.2',
+                'update_path': '/sonic-db:APPL_DB/dpu0/DASH_VNET_MAPPING_TABLE/Vnet2:20.2.2.2',
             }
         ]
         delete_list = []

--- a/test/test_gnmi_appldb.py
+++ b/test/test_gnmi_appldb.py
@@ -64,7 +64,7 @@ def clear_appl_db(table_name):
 
 class TestGNMIApplDb:
 
-    @pytest.mark.dpu
+    @pytest.mark.multidb
     @pytest.mark.parametrize('test_data', test_data_update_normal)
     def test_gnmi_update_normal_01(self, test_data):
         clear_appl_db('DASH_QOS')
@@ -96,7 +96,7 @@ class TestGNMIApplDb:
                     break
             assert hit == True, 'No match for %s'%str(data['value'])
 
-    @pytest.mark.dpu
+    @pytest.mark.multidb
     @pytest.mark.parametrize('test_data', test_data_update_normal)
     def test_gnmi_update_normal_02(self, test_data):
         clear_appl_db('DASH_QOS')
@@ -115,7 +115,7 @@ class TestGNMIApplDb:
         ret, msg = gnmi_set([], update_list, [])
         assert ret != 0, "Invalid json ietf value"
 
-    @pytest.mark.dpu
+    @pytest.mark.multidb
     @pytest.mark.parametrize('test_data', test_data_update_normal)
     def test_gnmi_delete_normal_01(self, test_data):
         delete_list = []
@@ -151,7 +151,7 @@ class TestGNMIApplDb:
             for msg in msg_list:
                 assert msg == '{}', 'Delete failed'
 
-    @pytest.mark.dpu
+    @pytest.mark.multidb
     @pytest.mark.parametrize('test_data', test_data_update_normal)
     def test_gnmi_replace_normal_01(self, test_data):
         clear_appl_db('DASH_QOS')
@@ -183,7 +183,7 @@ class TestGNMIApplDb:
                     break
             assert hit == True, 'No match for %s'%str(data['value'])
 
-    @pytest.mark.dpu
+    @pytest.mark.multidb
     @pytest.mark.parametrize('test_data', test_data_update_normal)
     def test_gnmi_replace_normal_02(self, test_data):
         replace_list = []
@@ -219,7 +219,7 @@ class TestGNMIApplDb:
             for msg in msg_list:
                 assert msg == '{}', 'Delete failed'
 
-    @pytest.mark.dpu
+    @pytest.mark.multidb
     def test_gnmi_invalid_path_01(self):
         path = '/sonic-db:APPL_DB/dpu0/DASH_QOS/qos_01/bw'
         value = '300'
@@ -235,7 +235,7 @@ class TestGNMIApplDb:
         assert ret != 0, 'Invalid path'
         assert 'Unsupported path' in msg
 
-    @pytest.mark.dpu
+    @pytest.mark.multidb
     def test_gnmi_invalid_origin_01(self):
         path1 = '/sonic-db:APPL_DB/dpu0/DASH_QOS'
         path2 = '/sonic-yang:APPL_DB/dpu0/DASH_QOS'
@@ -266,7 +266,7 @@ class TestGNMIApplDb:
                 break
         assert hit == True, 'No expected error: %s'%exp
 
-    @pytest.mark.dpu
+    @pytest.mark.multidb
     def test_gnmi_invalid_target_01(self):
         path = '/sonic-db:DPU_INVALID_DB/dpu0/DASH_QOS'
         value = {
@@ -296,7 +296,7 @@ class TestGNMIApplDb:
                 break
         assert hit == True, 'No expected error: %s'%exp
 
-    @pytest.mark.dpu
+    @pytest.mark.multidb
     def test_gnmi_invalid_target_02(self):
         path = '/sonic-db:ASIC_DB/dpu0/DASH_QOS'
         value = {
@@ -315,7 +315,7 @@ class TestGNMIApplDb:
         assert ret != 0, 'Target is invalid'
         assert 'Set RPC does not support ASIC_DB' in msg
 
-    @pytest.mark.dpu
+    @pytest.mark.multidb
     def test_gnmi_invalid_target_03(self):
         path1 = '/sonic-db:APPL_DB/dpu0/DASH_QOS'
         path2 = '/sonic-db:CONFIG_DB/dpu0/DASH_QOS'
@@ -346,7 +346,7 @@ class TestGNMIApplDb:
                 break
         assert hit == True, 'No expected error: %s'%exp
 
-    @pytest.mark.dpu
+    @pytest.mark.multidb
     def test_gnmi_invalid_encoding(self):
         path = '/sonic-db:APPL_DB/dpu0/DASH_QOS'
         get_list = [path]
@@ -360,7 +360,7 @@ class TestGNMIApplDb:
                 break
         assert hit == True, 'No expected error: %s'%exp
 
-    @pytest.mark.dpu
+    @pytest.mark.multidb
     def test_gnmi_update_proto_01(self):
         proto_bytes = b"\n\x010\x12$b6d54023-5d24-47de-ae94-8afe693dd1fc\x1a\x17\n\x12\x12\x10\r\xc0-\xdd\x82\xa3\x88;\x0fP\x84<\xaakc\x16\x10\x80\x01\x1a\x17\n\x12\x12\x10-\x0e\xf2\x7f\n~c_\xd8\xb7\x10\x84\x81\xd6'|\x10\x80\x01\x1a\x17\n\x12\x12\x10\x1bV\x89\xc8JW\x06\xfb\xad\b*fN\x9e(\x17\x10\x80\x01\x1a\x17\n\x12\x12\x107\xf9\xbc\xc0\x8d!s\xccVT\x88\x00\xf8\x9c\xce\x90\x10\x80\x01\x1a\x17\n\x12\x12\x10\tEb\x11Mf]\x12\x17x\x99\x80\xea\xd1u\xb4\x10\x80\x01\x1a\x17\n\x12\x12\x10\x1f\xd3\x1c\x89\x99\x16\xe7\x18\x91^0\x81\xb1\x04\x8c\x1e\x10\x80\x01\x1a\x17\n\x12\x12\x10\x06\x9e55\xdb\xb5&\x93\x99\xfaC\x81\x16P\xdc\x1d\x10\x80\x01\x1a\x17\n\x12\x12\x10&]U\x96e4\xf4\xd2'&\x04i\xdf\x8dA\x9f\x10\x80\x01\x1a\x17\n\x12\x12\x108\xd5\xa3*\xe7\x80\xdc\x1e\x80f\x94\xb7\xb6\x86~\xcd\x10\x80\x01\x1a\x17\n\x12\x12\x101\xf0@F\nu+}\x1e\"\\\\\xdb\x01\xe3\x82\x10\x80\x01\"\x05vnet1\"\x05vnet2\"\x05vnet1\"\x05vnet2\"\x05vnet2\"\x05vnet1\"\x05vnet2\"\x05vnet2\"\x05vnet1\"\x05vnet1"
         test_data = [
@@ -400,7 +400,7 @@ class TestGNMIApplDb:
             result_bytes = open(file_name, 'rb').read()
             assert proto_bytes == result_bytes, 'get proto not equal to update proto'
 
-    @pytest.mark.dpu
+    @pytest.mark.multidb
     def test_gnmi_update_proto_02(self):
         update_path = '/sonic-db:APPL_DB/dpu0/DASH_QOS'
         get_path = '/sonic-db:APPL_DB/dpu0/_DASH_QOS[key=qos1]'
@@ -424,7 +424,7 @@ class TestGNMIApplDb:
         ret, msg_list = gnmi_get_proto(get_list, file_list)
         assert ret != 0, 'Can not get result with proto encoding'
 
-    @pytest.mark.dpu
+    @pytest.mark.multidb
     def test_gnmi_update_proto_03(self):
         proto_bytes = b""
         test_data = [
@@ -464,7 +464,7 @@ class TestGNMIApplDb:
             result_bytes = open(file_name, 'rb').read()
             assert proto_bytes == result_bytes, 'get proto not equal to update proto'
 
-    @pytest.mark.dpu
+    @pytest.mark.multidb
     def test_gnmi_delete_proto_01(self):
         test_data = [
             {

--- a/test/test_gnmi_configdb.py
+++ b/test/test_gnmi_configdb.py
@@ -10,7 +10,7 @@ import pytest
 test_data_update_normal = [
     [
         {
-            'path': '/sonic-db:CONFIG_DB/PORT',
+            'path': '/sonic-db:CONFIG_DB/localhost/PORT',
             'value': {
                 'Ethernet4': {'admin_status': 'down'},
                 'Ethernet8': {'admin_status': 'down'}
@@ -19,21 +19,21 @@ test_data_update_normal = [
     ],
     [
         {
-            'path': '/sonic-db:CONFIG_DB/PORT/Ethernet4/admin_status',
+            'path': '/sonic-db:CONFIG_DB/localhost/PORT/Ethernet4/admin_status',
             'value': 'up'
         },
         {
-            'path': '/sonic-db:CONFIG_DB/PORT/Ethernet8/admin_status',
+            'path': '/sonic-db:CONFIG_DB/localhost/PORT/Ethernet8/admin_status',
             'value': 'up'
         }
     ],
     [
         {
-            'path': '/sonic-db:CONFIG_DB/PORT/Ethernet4',
+            'path': '/sonic-db:CONFIG_DB/localhost/PORT/Ethernet4',
             'value': {'admin_status': 'down'}
         },
         {
-            'path': '/sonic-db:CONFIG_DB/PORT/Ethernet8',
+            'path': '/sonic-db:CONFIG_DB/localhost/PORT/Ethernet8',
             'value': {'admin_status': 'down'}
         }
     ]
@@ -54,14 +54,14 @@ test_json_checkpoint = {
 test_data_checkpoint = [
     [
         {
-            'path': '/sonic-db:CONFIG_DB/DASH_QOS',
+            'path': '/sonic-db:CONFIG_DB/localhost/DASH_QOS',
             'value': {
                 'qos_01': {'bw': '54321', 'cps': '1000', 'flows': '300'},
                 'qos_02': {'bw': '6000', 'cps': '200', 'flows': '101'}
             }
         },
         {
-            'path': '/sonic-db:CONFIG_DB/DASH_VNET',
+            'path': '/sonic-db:CONFIG_DB/localhost/DASH_VNET',
             'value': {
                 'vnet_3721': {
                     'address_spaces': ["10.250.0.0", "192.168.3.0", "139.66.72.9"]
@@ -71,15 +71,15 @@ test_data_checkpoint = [
     ],
     [
         {
-            'path': '/sonic-db:CONFIG_DB/DASH_QOS/qos_01',
+            'path': '/sonic-db:CONFIG_DB/localhost/DASH_QOS/qos_01',
             'value': {'bw': '54321', 'cps': '1000', 'flows': '300'},
         },
         {
-            'path': '/sonic-db:CONFIG_DB/DASH_QOS/qos_02',
+            'path': '/sonic-db:CONFIG_DB/localhost/DASH_QOS/qos_02',
             'value': {'bw': '6000', 'cps': '200', 'flows': '101'}
         },
         {
-            'path': '/sonic-db:CONFIG_DB/DASH_VNET/vnet_3721',
+            'path': '/sonic-db:CONFIG_DB/localhost/DASH_VNET/vnet_3721',
             'value': {
                 'address_spaces': ["10.250.0.0", "192.168.3.0", "139.66.72.9"]
             }
@@ -87,25 +87,25 @@ test_data_checkpoint = [
     ],
     [
         {
-            'path': '/sonic-db:CONFIG_DB/DASH_QOS/qos_01/flows',
+            'path': '/sonic-db:CONFIG_DB/localhost/DASH_QOS/qos_01/flows',
             'value': '300'
         },
         {
-            'path': '/sonic-db:CONFIG_DB/DASH_QOS/qos_02/bw',
+            'path': '/sonic-db:CONFIG_DB/localhost/DASH_QOS/qos_02/bw',
             'value': '6000'
         },
         {
-            'path': '/sonic-db:CONFIG_DB/DASH_VNET/vnet_3721/address_spaces',
+            'path': '/sonic-db:CONFIG_DB/localhost/DASH_VNET/vnet_3721/address_spaces',
             'value': ["10.250.0.0", "192.168.3.0", "139.66.72.9"]
         }
     ],
     [
         {
-            'path': '/sonic-db:CONFIG_DB/DASH_VNET/vnet_3721/address_spaces/0',
+            'path': '/sonic-db:CONFIG_DB/localhost/DASH_VNET/vnet_3721/address_spaces/0',
             'value': "10.250.0.0"
         },
         {
-            'path': '/sonic-db:CONFIG_DB/DASH_VNET/vnet_3721/address_spaces/1',
+            'path': '/sonic-db:CONFIG_DB/localhost/DASH_VNET/vnet_3721/address_spaces/1',
             'value': "192.168.3.0"
         }
     ]
@@ -161,7 +161,7 @@ class TestGNMIConfigDb:
             test_value = item['value']
             for patch_data in patch_json:
                 assert patch_data['op'] == 'add', "Invalid operation"
-                if test_path == '/sonic-db:CONFIG_DB' + patch_data['path'] and test_value == patch_data['value']:
+                if test_path == '/sonic-db:CONFIG_DB/localhost' + patch_data['path'] and test_value == patch_data['value']:
                     break
             else:
                 pytest.fail('No item in patch: %s'%str(item))
@@ -199,7 +199,7 @@ class TestGNMIConfigDb:
             test_path = item['path']
             for patch_data in patch_json:
                 assert patch_data['op'] == 'remove', "Invalid operation"
-                if test_path == '/sonic-db:CONFIG_DB' + patch_data['path']:
+                if test_path == '/sonic-db:CONFIG_DB/localhost' + patch_data['path']:
                     break
             else:
                 pytest.fail('No item in patch: %s'%str(item))
@@ -253,7 +253,7 @@ class TestGNMIConfigDb:
             test_value = item['value']
             for patch_data in patch_json:
                 assert patch_data['op'] == 'add', "Invalid operation"
-                if test_path == '/sonic-db:CONFIG_DB' + patch_data['path'] and test_value == patch_data['value']:
+                if test_path == '/sonic-db:CONFIG_DB/localhost' + patch_data['path'] and test_value == patch_data['value']:
                     break
             else:
                 pytest.fail('No item in patch: %s'%str(item))
@@ -273,8 +273,8 @@ class TestGNMIConfigDb:
         value = json.dumps(test_data)
         file_object.write(value)
         file_object.close()
-        delete_list = ['/sonic-db:CONFIG_DB/']
-        update_list = ['/sonic-db:CONFIG_DB/' + ':@./' + file_name]
+        delete_list = ['/sonic-db:CONFIG_DB/localhost/']
+        update_list = ['/sonic-db:CONFIG_DB/localhost/' + ':@./' + file_name]
 
         ret, msg = gnmi_set(delete_list, update_list, [])
         assert ret == 0, msg
@@ -284,8 +284,8 @@ class TestGNMIConfigDb:
         assert test_data == config_json, "Wrong config file"
 
     def test_gnmi_full_negative(self):
-        delete_list = ['/sonic-db:CONFIG_DB/']
-        update_list = ['/sonic-db:CONFIG_DB/' + ':abc']
+        delete_list = ['/sonic-db:CONFIG_DB/localhost/']
+        update_list = ['/sonic-db:CONFIG_DB/localhost/' + ':abc']
 
         ret, msg = gnmi_set(delete_list, update_list, [])
         assert ret != 0, 'Invalid ietf_json_val'
@@ -331,7 +331,7 @@ class TestGNMIConfigDb:
         text = json.dumps(test_json_checkpoint)
         create_checkpoint(checkpoint_file, text)
 
-        get_list = ['/sonic-db:CONFIG_DB/DASH_VNET/vnet_3721/address_spaces/0/abc']
+        get_list = ['/sonic-db:CONFIG_DB/localhost/DASH_VNET/vnet_3721/address_spaces/0/abc']
  
         ret, _ = gnmi_get(get_list)
         assert ret != 0, 'Invalid path'
@@ -340,7 +340,7 @@ class TestGNMIConfigDb:
         text = json.dumps(test_json_checkpoint)
         create_checkpoint(checkpoint_file, text)
 
-        get_list = ['/sonic-db:CONFIG_DB/DASH_VNET/vnet_3721/address_spaces/abc']
+        get_list = ['/sonic-db:CONFIG_DB/localhost/DASH_VNET/vnet_3721/address_spaces/abc']
  
         ret, _ = gnmi_get(get_list)
         assert ret != 0, 'Invalid path'
@@ -349,13 +349,13 @@ class TestGNMIConfigDb:
         text = json.dumps(test_json_checkpoint)
         create_checkpoint(checkpoint_file, text)
 
-        get_list = ['/sonic-db:CONFIG_DB/DASH_VNET/vnet_3721/address_spaces/1000']
+        get_list = ['/sonic-db:CONFIG_DB/localhost/DASH_VNET/vnet_3721/address_spaces/1000']
  
         ret, _ = gnmi_get(get_list)
         assert ret != 0, 'Invalid path'
 
     def test_gnmi_get_full_01(self):
-        get_list = ['/sonic-db:CONFIG_DB/']
+        get_list = ['/sonic-db:CONFIG_DB/localhost/']
 
         ret, msg_list = gnmi_get(get_list)
         assert ret == 0, 'Fail to get full config'

--- a/test/test_gnmi_countersdb.py
+++ b/test/test_gnmi_countersdb.py
@@ -9,13 +9,13 @@ import pytest
 class TestGNMICountersDb:
 
     def test_gnmi_get_full_01(self):
-        get_list = ['/sonic-db:COUNTERS_DB/']
+        get_list = ['/sonic-db:COUNTERS_DB/localhost/']
 
         ret, msg_list = gnmi_get(get_list)
         assert ret != 0, 'Does not support to read all table in COUNTERS_DB'
 
     def test_gnmi_get_table_01(self):
-        get_list = ['/sonic-db:COUNTERS_DB/COUNTERS']
+        get_list = ['/sonic-db:COUNTERS_DB/localhost/COUNTERS']
 
         ret, msg_list = gnmi_get(get_list)
         assert ret == 0, 'Fail to read COUNTERS table, ' + msg_list[0]

--- a/test_utils/test_utils.go
+++ b/test_utils/test_utils.go
@@ -56,7 +56,7 @@ func GetMultiNsNamespace() string {
 	return "asic0"
 }
 
-func SetupMultiDPU() error {
+func SetupMultiDatabase() error {
 	err := os.MkdirAll("/var/run/redisdpu0/sonic-db/", 0755)
 	if err != nil {
 		return err
@@ -92,7 +92,7 @@ func SetupMultiDPU() error {
 	return nil
 }
 
-func CleanUpMultiDPU() error {
+func CleanUpMultiDatabase() error {
 	err := os.Remove("/var/run/redis/sonic-db/database_global.json")
 	if err != nil {
 		return err

--- a/test_utils/test_utils.go
+++ b/test_utils/test_utils.go
@@ -55,3 +55,52 @@ func CleanUpMultiNamespace() error {
 func GetMultiNsNamespace() string {
 	return "asic0"
 }
+
+func SetupMultiDPU() error {
+	err := os.MkdirAll("/var/run/redisdpu0/sonic-db/", 0755)
+	if err != nil {
+		return err
+	}
+	srcFileName := [2]string{"../testdata/database_global_dpu.json", "../testdata/database_config_dpu0.json"}
+	dstFileName := [2]string{"/var/run/redis/sonic-db/database_global.json", "/var/run/redisdpu0/sonic-db/database_config.json"}
+	for i := 0; i < len(srcFileName); i++ {
+		sourceFileStat, err := os.Stat(srcFileName[i])
+		if err != nil {
+			return err
+		}
+
+		if !sourceFileStat.Mode().IsRegular() {
+			return err
+		}
+
+		source, err := os.Open(srcFileName[i])
+		if err != nil {
+			return err
+		}
+		defer source.Close()
+
+		destination, err := os.Create(dstFileName[i])
+		if err != nil {
+			return err
+		}
+		defer destination.Close()
+		_, err = io.Copy(destination, source)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func CleanUpMultiDPU() error {
+	err := os.Remove("/var/run/redis/sonic-db/database_global.json")
+	if err != nil {
+		return err
+	}
+	err = os.RemoveAll("/var/run/redisdpu0")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+

--- a/testdata/database_config_dpu0.json
+++ b/testdata/database_config_dpu0.json
@@ -1,0 +1,73 @@
+{
+    "INSTANCES": {
+        "redis":{
+            "hostname" : "127.0.0.1",
+            "port" : 6379,
+            "unix_socket_path" : "/var/run/redis/redis.sock"
+        }
+    },
+    "DATABASES" : {
+        "APPL_DB" : {
+            "id" : 0,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "ASIC_DB" : {
+            "id" : 1,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "COUNTERS_DB" : {
+            "id" : 2,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "CONFIG_DB" : {
+            "id" : 4,
+            "separator": "|",
+            "instance" : "redis"
+        },
+        "PFC_WD_DB" : {
+            "id" : 5,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "FLEX_COUNTER_DB" : {
+            "id" : 5,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "STATE_DB" : {
+            "id" : 6,
+            "separator": "|",
+            "instance" : "redis"
+        },
+        "SNMP_OVERLAY_DB" : {
+            "id" : 7,
+            "separator": "|",
+            "instance" : "redis"
+        },
+        "DPU_APPL_DB" : {
+            "id" : 15,
+            "separator": ":",
+            "instance" : "redis",
+            "format": "proto"
+        },
+        "DPU_APPL_STATE_DB" : {
+            "id" : 16,
+            "separator": "|",
+            "instance" : "redis"
+        },
+        "DPU_STATE_DB" : {
+            "id" : 17,
+            "separator": "|",
+            "instance" : "redis"
+        },
+        "DPU_COUNTERS_DB" : {
+            "id" : 18,
+            "separator": ":",
+            "instance" : "redis"
+        }
+    },
+    "VERSION" : "1.0"
+}

--- a/testdata/database_global_dpu.json
+++ b/testdata/database_global_dpu.json
@@ -1,0 +1,12 @@
+{
+    "INCLUDES" : [
+        {
+            "include" : "../../redis/sonic-db/database_config.json"
+        },
+        {
+            "database_name" : "dpu0",
+            "include" : "../../redisdpu0/sonic-db/database_config.json"
+        }
+    ],
+    "VERSION" : "1.0"
+}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
https://github.com/sonic-net/sonic-buildimage/pull/17161
We have updated database configuration to support multiple databases for smartswitch.
And then we need to update sonic-gnmi to support new database configuration and new GNMI path for smartswitch

#### How I did it
* Support new database configuration

```
{
    "INCLUDES" : [
        {
            "include" : "../../redis/sonic-db/database_config.json"
        },
        {
            "database_name" : "dpu0",
            "include" : "../../redisdpu0/sonic-db/database_config.json"
        }
    ],
    "VERSION" : "1.0"
}
```

Use a single layer instance for each device to support multiple asic and multiple dpu.
For example, for multiple asic, the instances can be named localhost, asic0, asic1, and so on. For multiple dpu, the instances can be named localhost, dpu0, dpu1, and so on. For multiple asic npu and multiple dpu, the instances can be named localhost, asic0, asic1, ..., dpu0, dpu1, and so on.

```
        "DPU_APPL_DB" : {
            "id" : 15,
            "separator": ":",
            "instance" : "redis",
            "format": "proto"
        },
```
We are trying to modify DPU_APPL_DB with GNMI, but the database is not accessible by swsscommon. This is because DPU_APPL_DB is a new database defined in /var/run/redisdpu0/sonic-db/database_config.json. As a workaround, we use GNMI to modify APPL_DB instead, but we need to update swsscommon to support the new database configuration.

* Update GNMI path to support multiple database

I add a new element in GNMI path to support database instance.
```
/APPL_DB/dpu0/DASH_VNET_TABLE/vnet1/
```
The second element is used for target database instance, and it can be localhost, asic0, asic1, ..., dpu0, dpu1, and so on.
If SONiC device is not multi-asic or multi-dpu, this second element should be localhost.

This design is not backward compatible.

#### How to verify it
Run unit test for sonic-gnmi.
Run end to end test for dash and gnmi.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

