### PR TITLE
Account for GLOBAL key in PFC_WD

### DIFF
--- a/sonic_data_client/virtual_db.go
+++ b/sonic_data_client/virtual_db.go
@@ -149,8 +149,10 @@ func getPfcwdMap() (map[string]map[string]string, error) {
 		}
 
 		for _, key := range resp {
-			name := key[7:]
-			pfcwdName_map[name] = make(map[string]string)
+			if len(key > 7) && strings.Contains(key, "Ethernet") {
+				name := key[7:]
+				pfcwdName_map[name] = make(map[string]string)
+			}
 		}
 
 		// Get Queue indexes that are enabled with PFC-WD
@@ -198,9 +200,6 @@ func getPfcwdMap() (map[string]map[string]string, error) {
 		var queue_key string
 		queue_separator, _ := GetTableKeySeparator("COUNTERS_DB", namespace)
 		for port, _ := range pfcwdName_map {
-			if !strings.Contains(port, "Ethernet") { // account for GLOBAL key in PFC_WD
-				continue
-			}
 			for _, indice := range indices {
 				queue_key = port + queue_separator + indice
 				oid, ok := countersQueueNameMap[queue_key]

--- a/sonic_data_client/virtual_db.go
+++ b/sonic_data_client/virtual_db.go
@@ -198,6 +198,9 @@ func getPfcwdMap() (map[string]map[string]string, error) {
 		var queue_key string
 		queue_separator, _ := GetTableKeySeparator("COUNTERS_DB", namespace)
 		for port, _ := range pfcwdName_map {
+			if !strings.HasPrefix(port, "Ethernet") { // account for GLOBAL key in PFC_WD
+				continue
+			}
 			for _, indice := range indices {
 				queue_key = port + queue_separator + indice
 				oid, ok := countersQueueNameMap[queue_key]

--- a/sonic_data_client/virtual_db.go
+++ b/sonic_data_client/virtual_db.go
@@ -149,7 +149,7 @@ func getPfcwdMap() (map[string]map[string]string, error) {
 		}
 
 		for _, key := range resp {
-			if len(key > 7) && strings.Contains(key, "Ethernet") {
+			if strings.Contains(key, "Ethernet") { // Account for non interface ports in PFC_WD such as GLOBAL
 				name := key[7:]
 				pfcwdName_map[name] = make(map[string]string)
 			}

--- a/sonic_data_client/virtual_db.go
+++ b/sonic_data_client/virtual_db.go
@@ -198,7 +198,7 @@ func getPfcwdMap() (map[string]map[string]string, error) {
 		var queue_key string
 		queue_separator, _ := GetTableKeySeparator("COUNTERS_DB", namespace)
 		for port, _ := range pfcwdName_map {
-			if !strings.HasPrefix(port, "Ethernet") { // account for GLOBAL key in PFC_WD
+			if !strings.Contains(port, "Ethernet") { // account for GLOBAL key in PFC_WD
 				continue
 			}
 			for _, indice := range indices {

--- a/testdata/CONFIG_PFCWD_PORTS.txt
+++ b/testdata/CONFIG_PFCWD_PORTS.txt
@@ -3,6 +3,9 @@
         "3": "3",
         "4": "4"
     },
+    "PFC_WD|GLOBAL": {
+        "action": "drop"
+    },
     "PFC_WD|Ethernet0": {
         "action": "drop"
     },

--- a/testdata/CONFIG_PFCWD_PORTS.txt
+++ b/testdata/CONFIG_PFCWD_PORTS.txt
@@ -168,7 +168,7 @@
     "PFC_WD|Ethernet9": {
         "action": "drop"
     },
-    "PORT_QOS_MAP|Ethernet0,Ethernet1,Ethernet2,Ethernet3,Ethernet4,Ethernet5,Ethernet6,Ethernet7,Ethernet8,Ethernet9,Ethernet10,Ethernet11,Ethernet12,Ethernet13,Ethernet14,Ethernet15,Ethernet16,Ethernet17,Ethernet18,Ethernet19,Ethernet20,Ethernet21,Ethernet22,Ethernet23,Ethernet24,Ethernet25,Ethernet26,Ethernet27,Ethernet28,Ethernet29,Ethernet30,Ethernet31,Ethernet32,Ethernet33,Ethernet34,Ethernet35,Ethernet36,Ethernet37,Ethernet38,Ethernet39,Ethernet40,Ethernet41,Ethernet42,Ethernet43,Ethernet44,Ethernet45,Ethernet46,Ethernet47,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68": {
+    "PORT_QOS_MAP|Ethernet0,Ethernet1,Ethernet2,Ethernet3,Ethernet4,Ethernet5,Ethernet6,Ethernet7,Ethernet8,Ethernet9,Ethernet10,Ethernet11,Ethernet12,Ethernet13,Ethernet14,Ethernet15,Ethernet16,Ethernet17,Ethernet18,Ethernet19,Ethernet20,Ethernet21,Ethernet22,Ethernet23,Ethernet24,Ethernet25,Ethernet26,Ethernet27,Ethernet28,Ethernet29,Ethernet30,Ethernet31,Ethernet32,Ethernet33,Ethernet34,Ethernet35,Ethernet36,Ethernet37,Ethernet38,Ethernet39,Ethernet40,Ethernet41,Ethernet42,Ethernet43,Ethernet44,Ethernet45,Ethernet46,Ethernet47,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,global": {
         "pfc_enable": "3,4"
     }
 }

--- a/testdata/CONFIG_PFCWD_PORTS.txt
+++ b/testdata/CONFIG_PFCWD_PORTS.txt
@@ -3,9 +3,6 @@
         "3": "3",
         "4": "4"
     },
-    "PFC_WD|GLOBAL": {
-        "action": "drop"
-    },
     "PFC_WD|Ethernet0": {
         "action": "drop"
     },
@@ -166,6 +163,9 @@
         "action": "drop"
     },
     "PFC_WD|Ethernet9": {
+        "action": "drop"
+    },
+    "PFC_WD|GLOBAL": {
         "action": "drop"
     },
     "PORT_QOS_MAP|Ethernet0,Ethernet1,Ethernet2,Ethernet3,Ethernet4,Ethernet5,Ethernet6,Ethernet7,Ethernet8,Ethernet9,Ethernet10,Ethernet11,Ethernet12,Ethernet13,Ethernet14,Ethernet15,Ethernet16,Ethernet17,Ethernet18,Ethernet19,Ethernet20,Ethernet21,Ethernet22,Ethernet23,Ethernet24,Ethernet25,Ethernet26,Ethernet27,Ethernet28,Ethernet29,Ethernet30,Ethernet31,Ethernet32,Ethernet33,Ethernet34,Ethernet35,Ethernet36,Ethernet37,Ethernet38,Ethernet39,Ethernet40,Ethernet41,Ethernet42,Ethernet43,Ethernet44,Ethernet45,Ethernet46,Ethernet47,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,global": {


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

In some cases in PFC_WD table there are keys such as "PFC_WD|GLOBAL" and GLOBAL cannot be mapped to COUNTERS_QUEUE_NAME_MAP so we run into an error since we cannot retrieve counters for key with not interface declared.  

#### How I did it

Omit keys from PFC_WD that do not declare an interface

#### How to verify it

UT/manaul testing

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

