### PR TITLE
[202205] Use ASICx suffix in DB target path only if the device is multi-asic

### DIFF
--- a/sonic_data_client/db_client.go
+++ b/sonic_data_client/db_client.go
@@ -398,8 +398,8 @@ func IsTargetDb(target string) (string, bool, string, bool) {
 		log.V(1).Infof("target format is not correct")
 		return dbName, false, dbNamespace, dbNameSpaceExist
 	}
-
-	if len(targetname) > 1 {
+        // ASIC Suffix is only used in case if device is multi-asic/namespace
+	if len(targetname) > 1 && sdcfg.CheckDbMultiNamespace() {
 		dbNamespace = targetname[1]
 		dbNameSpaceExist = true
 	}


### PR DESCRIPTION
Cherry-pick of PR: https://github.com/sonic-net/sonic-gnmi/pull/184