### PR TITLE
Use ASICx suffix in DB target path only if the device is multi-asic

### DIFF
--- a/sonic_data_client/db_client.go
+++ b/sonic_data_client/db_client.go
@@ -465,15 +465,14 @@ func IsTargetDb(target string) (string, bool, string, bool) {
 	dbName := targetname[0]
 	dbNameSpaceExist := false
 	dbNamespace, _ := sdcfg.GetDbDefaultNamespace()
-	isMultiNamespace := false
+	isMultiNamespace, _ := sdcfg.CheckDbMultiNamespace()
 
 	if len(targetname) > 2 {
 		log.V(1).Infof("target format is not correct")
 		return dbName, false, dbNamespace, dbNameSpaceExist
 	}
 	// ASIC Suffix is only used in case if device is multi-asic/namespace
-	isMultiNamespace, _ := sdcfg.CheckDbMultiNamespace()
-	if isMultiNamespace && len(targetname) > 1{
+	if isMultiNamespace && len(targetname) > 1 {
 		dbNamespace = targetname[1]
 		dbNameSpaceExist = true
 	}

--- a/sonic_data_client/db_client.go
+++ b/sonic_data_client/db_client.go
@@ -465,13 +465,15 @@ func IsTargetDb(target string) (string, bool, string, bool) {
 	dbName := targetname[0]
 	dbNameSpaceExist := false
 	dbNamespace, _ := sdcfg.GetDbDefaultNamespace()
+	isMultiNamespace:= false
 
 	if len(targetname) > 2 {
 		log.V(1).Infof("target format is not correct")
 		return dbName, false, dbNamespace, dbNameSpaceExist
 	}
-        // ASIC Suffix is only used in case if device is multi-asic/namespace
-	if len(targetname) > 1 && sdcfg.CheckDbMultiNamespace() {
+	// ASIC Suffix is only used in case if device is multi-asic/namespace
+	isMultiNamespace, _ := sdcfg.CheckDbMultiNamespace()
+	if isMultiNamespace && len(targetname) > 1{
 		dbNamespace = targetname[1]
 		dbNameSpaceExist = true
 	}

--- a/sonic_data_client/db_client.go
+++ b/sonic_data_client/db_client.go
@@ -470,8 +470,8 @@ func IsTargetDb(target string) (string, bool, string, bool) {
 		log.V(1).Infof("target format is not correct")
 		return dbName, false, dbNamespace, dbNameSpaceExist
 	}
-
-	if len(targetname) > 1 {
+        // ASIC Suffix is only used in case if device is multi-asic/namespace
+	if len(targetname) > 1 && sdcfg.CheckDbMultiNamespace() {
 		dbNamespace = targetname[1]
 		dbNameSpaceExist = true
 	}

--- a/sonic_data_client/db_client.go
+++ b/sonic_data_client/db_client.go
@@ -465,7 +465,7 @@ func IsTargetDb(target string) (string, bool, string, bool) {
 	dbName := targetname[0]
 	dbNameSpaceExist := false
 	dbNamespace, _ := sdcfg.GetDbDefaultNamespace()
-	isMultiNamespace:= false
+	isMultiNamespace := false
 
 	if len(targetname) > 2 {
 		log.V(1).Infof("target format is not correct")


### PR DESCRIPTION
What I did:
For supporting multi-asic as described here: https://github.com/sonic-net/sonic-telemetry/pull/77 we added support to handle `ASICx1` suffix in the target DB path. We  should only use that suffix  if the device is multi-asic else we can ignore it. This PR handle this case.

Why I did:
Telemetry Client can pass `ASICx` even for single asic device. To protect from that condition this change has been added.

How I verify:
Manually Verified . Before the fix client was getting error. After change it is getting data as expected.
