### PR TITLE
Fix "sonic" string in OTHERS/osversion/build

### DIFF
--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -1421,7 +1421,7 @@ func runGnmiTestGet(t *testing.T, namespace string) {
 		// Happy path
 		createBuildVersionTestCase(
 			"get osversion/build",                                  // query path
-			`{"build_version": "sonic.12345678.90", "error":""}`,   // expected response
+			`{"build_version": "SONiC.12345678.90", "error":""}`,   // expected response
 			"build_version: '12345678.90'\ndebian_version: '9.13'", // YAML file content
 			nil), // mock file reading error
 
@@ -1442,7 +1442,7 @@ func runGnmiTestGet(t *testing.T, namespace string) {
 		// Happy path with different value
 		createBuildVersionTestCase(
 			"get osversion/build different value",
-			`{"build_version": "sonic.23456789.01", "error":""}`,
+			`{"build_version": "SONiC.23456789.01", "error":""}`,
 			"build_version: '23456789.01'\ndebian_version: '9.15'",
 			nil),
 	}

--- a/sonic_data_client/non_db_client.go
+++ b/sonic_data_client/non_db_client.go
@@ -322,7 +322,7 @@ func getBuildVersion() ([]byte, error) {
 
 		// Prepend 'sonic.' to the build version string.
 		if versionFileStash.versionInfo.BuildVersion != "sonic.NA" {
-			versionFileStash.versionInfo.BuildVersion = "sonic." + versionFileStash.versionInfo.BuildVersion
+			versionFileStash.versionInfo.BuildVersion = "SONiC." + versionFileStash.versionInfo.BuildVersion
 		}
 	})
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#25377424

Expected to pass SONiC.20XX, currently passing sonic.20XX

#### How I did it

string change

#### How to verify it

UT

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

