### PR TITLE
Call flag.Parse() to parse global flags like -logtostderr

### DIFF
--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -85,24 +85,25 @@ func runTelemetry(args []string) error {
 	return nil
 }
 
-func getGlogPrefixes() []string {
+func getGlogsFlagMap() []string {
 	// glog flags: https://pkg.go.dev/github.com/golang/glog
-	return []string {
-		"-alsologtostderr",
-		"-log_backtrace_at",
-		"-log_dir",
-		"-log_link",
-		"-logbuflevel",
-		"-logtostderr",
-		"-stderrthreshold",
-		"-v",
-		"-vmodule",
+	return map[string]bool {
+		"-alsologtostderr":  true,
+		"-log_backtrace_at": true,
+		"-log_dir":          true,
+		"-log_link":         true,
+		"-logbuflevel":      true,
+		"-logtostderr":      true,
+		"-stderrthreshold":  true,
+		"-v":                true,
+		"-vmodule":          true,
 	}
 }
 
 func parseOSArgs() ([]string, []string) {
 	glogFlags := []string{os.Args[0]}
 	telemetryFlags := []string{os.Args[0]}
+	glogFlagsMap = getGlogFlagsMap()
 
 	for _, arg := range os.Args[1:] {
 		if strings.HasPrefix(arg, "-v") { // only flag in both glog and telemetry
@@ -111,12 +112,10 @@ func parseOSArgs() ([]string, []string) {
 			continue
 		}
 		isGlogFlag := false
-		for _, prefix := range getGlogPrefixes() {
-			if strings.HasPrefix(arg, prefix) {
-				glogFlags = append(glogFlags, arg)
-				isGlogFlag = true
-				break
-			}
+		if glogFlagsMap[arg] {
+			glogFlags = append(glogFlags, arg)
+			isGlogFlag = true
+			break
 		}
 		if !isGlogFlag {
 			telemetryFlags = append(telemetryFlags, arg)

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -85,7 +85,7 @@ func runTelemetry(args []string) error {
 	return nil
 }
 
-func getGlogFlagsMap() []string {
+func getGlogFlagsMap() map[string] bool {
 	// glog flags: https://pkg.go.dev/github.com/golang/glog
 	return map[string]bool {
 		"-alsologtostderr":  true,
@@ -103,7 +103,7 @@ func getGlogFlagsMap() []string {
 func parseOSArgs() ([]string, []string) {
 	glogFlags := []string{os.Args[0]}
 	telemetryFlags := []string{os.Args[0]}
-	glogFlagsMap = getGlogFlagsMap()
+	glogFlagsMap := getGlogFlagsMap()
 
 	for _, arg := range os.Args[1:] {
 		if strings.HasPrefix(arg, "-v") { // only flag in both glog and telemetry

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -85,7 +85,7 @@ func runTelemetry(args []string) error {
 	return nil
 }
 
-func getGlogsFlagMap() []string {
+func getGlogFlagsMap() []string {
 	// glog flags: https://pkg.go.dev/github.com/golang/glog
 	return map[string]bool {
 		"-alsologtostderr":  true,

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -11,6 +11,7 @@ import (
 	"time"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"sync"
 	log "github.com/golang/glog"
@@ -50,8 +51,20 @@ func main() {
 }
 
 func runTelemetry(args []string) error {
+	/* Glog flags like -logtostderr have to be part of the global flagset.
+	   Because we use a custom flagset to avoid the use of global var and improve
+	   testability, we have to parse cmd line args two different times such that
+	   in the first parse, cmd line args will contain global flags and flag.Parse() will be called.
+	   The second parse, cmd line args will contain flags only relevant to telemetry, and our custom flagset will
+	   call Parse().
+	*/
+	glogFlags, telemetryFlags := parseOSArgs()
+	os.Args = glogFlags
+	flag.Parse() // glog flags will be populated after global flag parse
+
+	os.Args = telemetryFlags
 	fs := flag.NewFlagSet(args[0], flag.ExitOnError)
-	telemetryCfg, cfg, err := setupFlags(fs)
+	telemetryCfg, cfg, err := setupFlags(fs) // telemetry flags will be populated after second parse
 	if err != nil {
 		return err
 	}
@@ -70,6 +83,46 @@ func runTelemetry(args []string) error {
 
 	wg.Wait()
 	return nil
+}
+
+func getGlogPrefixes() []string {
+	// glog flags: https://pkg.go.dev/github.com/golang/glog
+	return []string {
+		"-alsologtostderr",
+		"-log_backtrace_at",
+		"-log_dir",
+		"-log_link",
+		"-logbuflevel",
+		"-logtostderr",
+		"-stderrthreshold",
+		"-v",
+		"-vmodule",
+	}
+}
+
+func parseOSArgs() ([]string, []string) {
+	glogFlags := []string{os.Args[0]}
+	telemetryFlags := []string{os.Args[0]}
+
+	for _, arg := range os.Args[1:] {
+		if strings.HasPrefix(arg, "-v") { // only flag in both glog and telemetry
+			glogFlags = append(glogFlags, arg)
+			telemetryFlags = append(telemetryFlags, arg)
+			continue
+		}
+		isGlogFlag := false
+		for _, prefix := range getGlogPrefixes() {
+			if strings.HasPrefix(arg, prefix) {
+				glogFlags = append(glogFlags, arg)
+				isGlogFlag = true
+				break
+			}
+		}
+		if !isGlogFlag {
+			telemetryFlags = append(telemetryFlags, arg)
+		}
+	}
+	return glogFlags, telemetryFlags
 }
 
 func setupFlags(fs *flag.FlagSet) (*TelemetryConfig, *gnmi.Config, error) {

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -115,7 +115,7 @@ func parseOSArgs() ([]string, []string) {
 		if glogFlagsMap[arg] {
 			glogFlags = append(glogFlags, arg)
 			isGlogFlag = true
-			break
+			continue
 		}
 		if !isGlogFlag {
 			telemetryFlags = append(telemetryFlags, arg)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Currently we are using a custom flagset, however glog requires that it's flags like logtostderr and v, be part of the global flag set. I parse cmd line args such that we call flag.Parse on only the glog global flags and then call the custom flagset parse on non glog flags.

#### How I did it

Parse os.args such that we separate it into glog flags and telemetry flags. Call flag.Parse() to set up the global flags that glog requires, then flagset.Parse() to set up the flags that telemetry config will use.

#### How to verify it

UT

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

