### PR TITLE
Let pfcwdmap creation fail gracefully

### DIFF
--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -592,43 +592,6 @@ func prepareConfigDb(t *testing.T, namespace string) {
 	loadConfigDB(t, rclient, mpi_pfcwd_map)
 }
 
-func prepareConfigDbPfcwdError(t *testing.T, namespace string) {
-	rclient := getConfigDbClient(t, namespace)
-	defer rclient.Close()
-	rclient.FlushDB()
-
-	fileName := "../testdata/COUNTERS_PORT_ALIAS_MAP.txt"
-	countersPortAliasMapByte, err := ioutil.ReadFile(fileName)
-	if err != nil {
-		t.Fatalf("read file %v err: %v", fileName, err)
-	}
-	mpi_alias_map := loadConfig(t, "", countersPortAliasMapByte)
-	loadConfigDB(t, rclient, mpi_alias_map)
-
-	fileName = "../testdata/CONFIG_PFCWD_PORTS.txt"
-	configPfcwdByte, err := ioutil.ReadFile(fileName)
-	if err != nil {
-		t.Fatalf("read file %v err: %v", fileName, err)
-	}
-	var pfcwdPortData map[string]interface{}
-	err = json.Unmarshal(configPfcwdByte, &pfcwdPortData)
-	if err != nil {
-		t.Fatalf("unmarshal err: %v", err)
-	}
-	for key := range pfcwdPortData {
-		if strings.HasPrefix(key, "PORT_QOS_MAP|Ethernet") {
-			delete(pfcwdPortData, key)
-		}
-	}
-	newConfigPfcwdByte, err := json.Marshal(pfcwdPortData)
-	if err != nil {
-		t.Fatalf("marshal err: %v", err)
-	}
-	mpi_pfcwd_map := loadConfig(t, "", newConfigPfcwdByte)
-	loadConfigDB(t, rclient, mpi_pfcwd_map)
-}
-
-
 func prepareStateDb(t *testing.T, namespace string) {
 	rclient := getRedisClientN(t, 6, namespace)
 	defer rclient.Close()
@@ -732,96 +695,6 @@ func prepareDb(t *testing.T, namespace string) {
 	//Load STATE_DB to test non V2R dataset
 	prepareStateDb(t, namespace)
 }
-
-func prepareDbPfcwdError(t *testing.T, namespace string) {
-	rclient := getRedisClient(t, namespace)
-	defer rclient.Close()
-	rclient.FlushDB()
-	//Enable keysapce notification
-	os.Setenv("PATH", "/usr/bin:/sbin:/bin:/usr/local/bin")
-	cmd := exec.Command("redis-cli", "config", "set", "notify-keyspace-events", "KEA")
-	_, err := cmd.Output()
-	if err != nil {
-		t.Fatal("failed to enable redis keyspace notification ", err)
-	}
-
-	fileName := "../testdata/COUNTERS_PORT_NAME_MAP.txt"
-	countersPortNameMapByte, err := ioutil.ReadFile(fileName)
-	if err != nil {
-		t.Fatalf("read file %v err: %v", fileName, err)
-	}
-	mpi_name_map := loadConfig(t, "COUNTERS_PORT_NAME_MAP", countersPortNameMapByte)
-	loadDB(t, rclient, mpi_name_map)
-
-	fileName = "../testdata/COUNTERS_QUEUE_NAME_MAP.txt"
-	countersQueueNameMapByte, err := ioutil.ReadFile(fileName)
-	if err != nil {
-		t.Fatalf("read file %v err: %v", fileName, err)
-	}
-	mpi_qname_map := loadConfig(t, "COUNTERS_QUEUE_NAME_MAP", countersQueueNameMapByte)
-	loadDB(t, rclient, mpi_qname_map)
-
-	fileName = "../testdata/COUNTERS:Ethernet68.txt"
-	countersEthernet68Byte, err := ioutil.ReadFile(fileName)
-	if err != nil {
-		t.Fatalf("read file %v err: %v", fileName, err)
-	}
-	// "Ethernet68": "oid:0x1000000000039",
-	mpi_counter := loadConfig(t, "COUNTERS:oid:0x1000000000039", countersEthernet68Byte)
-	loadDB(t, rclient, mpi_counter)
-
-	fileName = "../testdata/COUNTERS:Ethernet1.txt"
-	countersEthernet1Byte, err := ioutil.ReadFile(fileName)
-	if err != nil {
-		t.Fatalf("read file %v err: %v", fileName, err)
-	}
-	// "Ethernet1": "oid:0x1000000000003",
-	mpi_counter = loadConfig(t, "COUNTERS:oid:0x1000000000003", countersEthernet1Byte)
-	loadDB(t, rclient, mpi_counter)
-
-	// "Ethernet64:0": "oid:0x1500000000092a"  : queue counter, to work as data noise
-	fileName = "../testdata/COUNTERS:oid:0x1500000000092a.txt"
-	counters92aByte, err := ioutil.ReadFile(fileName)
-	if err != nil {
-		t.Fatalf("read file %v err: %v", fileName, err)
-	}
-	mpi_counter = loadConfig(t, "COUNTERS:oid:0x1500000000092a", counters92aByte)
-	loadDB(t, rclient, mpi_counter)
-
-	// "Ethernet68:1": "oid:0x1500000000091c"  : queue counter, for COUNTERS/Ethernet68/Queue vpath test
-	fileName = "../testdata/COUNTERS:oid:0x1500000000091c.txt"
-	countersEeth68_1Byte, err := ioutil.ReadFile(fileName)
-	if err != nil {
-		t.Fatalf("read file %v err: %v", fileName, err)
-	}
-	mpi_counter = loadConfig(t, "COUNTERS:oid:0x1500000000091c", countersEeth68_1Byte)
-	loadDB(t, rclient, mpi_counter)
-
-	// "Ethernet68:3": "oid:0x1500000000091e"  : lossless queue counter, for COUNTERS/Ethernet68/Pfcwd vpath test
-	fileName = "../testdata/COUNTERS:oid:0x1500000000091e.txt"
-	countersEeth68_3Byte, err := ioutil.ReadFile(fileName)
-	if err != nil {
-		t.Fatalf("read file %v err: %v", fileName, err)
-	}
-	mpi_counter = loadConfig(t, "COUNTERS:oid:0x1500000000091e", countersEeth68_3Byte)
-	loadDB(t, rclient, mpi_counter)
-
-	// "Ethernet68:4": "oid:0x1500000000091f"  : lossless queue counter, for COUNTERS/Ethernet68/Pfcwd vpath test
-	fileName = "../testdata/COUNTERS:oid:0x1500000000091f.txt"
-	countersEeth68_4Byte, err := ioutil.ReadFile(fileName)
-	if err != nil {
-		t.Fatalf("read file %v err: %v", fileName, err)
-	}
-	mpi_counter = loadConfig(t, "COUNTERS:oid:0x1500000000091f", countersEeth68_4Byte)
-	loadDB(t, rclient, mpi_counter)
-
-	// Load CONFIG_DB for alias translation
-	prepareConfigDbPfcwdError(t, namespace)
-
-	//Load STATE_DB to test non V2R dataset
-	prepareStateDb(t, namespace)
-}
-
 
 func prepareDbTranslib(t *testing.T) {
 	ns, _ := sdcfg.GetDbDefaultNamespace()
@@ -1296,11 +1169,13 @@ func TestGnmiGetAuthFail(t *testing.T) {
 }
 
 func TestPFCWDErrors(t *testing.T) {
-	namespace, _ := sdcfg.GetDbDefaultNamespace()
 	s := createServer(t, 8081)
 	go runServer(t, s)
 
-	prepareDbPfcwdError(t, namespace)
+	mock := gomonkey.ApplyFunc(sdc.GetPfcwdMap, func() (map[string]map[string]string, error)  {
+		return nil, fmt.Errorf("Mock error")
+	})
+	defer mock.Reset()
 
 	tests := []struct {
 		desc    string

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -1296,7 +1296,7 @@ func TestGnmiGetAuthFail(t *testing.T) {
 }
 
 func TestPFCWDErrors(t *testing.T) {
-	namespace := sdcfg.GetDbDefaultNamespace()
+	namespace, _ := sdcfg.GetDbDefaultNamespace()
 	s := createServer(t, 8081)
 	go runServer(t, s)
 

--- a/sonic_data_client/db_client.go
+++ b/sonic_data_client/db_client.go
@@ -607,7 +607,7 @@ func populateDbtablePath(prefix, path *gnmipb.Path, pathG2S *map[*gnmipb.Path][]
 		}
 		err = initCountersPfcwdNameMap()
 		if err != nil {
-			log.Errof("Could not create CountersPfcwdNameMap: %v", err)
+			log.Errorf("Could not create CountersPfcwdNameMap: %v", err)
 		}
 	}
 

--- a/sonic_data_client/db_client.go
+++ b/sonic_data_client/db_client.go
@@ -607,7 +607,7 @@ func populateDbtablePath(prefix, path *gnmipb.Path, pathG2S *map[*gnmipb.Path][]
 		}
 		err = initCountersPfcwdNameMap()
 		if err != nil {
-			return err
+			log.Errof("Could not create CountersPfcwdNameMap: %v", err)
 		}
 	}
 

--- a/sonic_data_client/virtual_db.go
+++ b/sonic_data_client/virtual_db.go
@@ -110,7 +110,7 @@ func initAliasMap() error {
 func initCountersPfcwdNameMap() error {
 	var err error
 	if len(countersPfcwdNameMap) == 0 {
-		countersPfcwdNameMap, err = getPfcwdMap()
+		countersPfcwdNameMap, err = GetPfcwdMap()
 		if err != nil {
 			return err
 		}
@@ -119,7 +119,7 @@ func initCountersPfcwdNameMap() error {
 }
 
 // Get the mapping between sonic interface name and oids of their PFC-WD enabled queues in COUNTERS_DB
-func getPfcwdMap() (map[string]map[string]string, error) {
+func GetPfcwdMap() (map[string]map[string]string, error) {
 	var pfcwdName_map = make(map[string]map[string]string)
 
 	dbName := "CONFIG_DB"

--- a/sonic_data_client/virtual_db.go
+++ b/sonic_data_client/virtual_db.go
@@ -169,7 +169,7 @@ func getPfcwdMap() (map[string]map[string]string, error) {
 
 		var qos_key string
 		for _, key := range resp {
-			if strings.Contains(key, "Ethernet") { // Account for PORT_QOS_MAP|global
+			if !strings.Contains(key, "global") || !strings.Contains(key, "GLOBAL") { // Account for PORT_QOS_MAP|global
 				qos_key = key
 				break
 			}

--- a/sonic_data_client/virtual_db.go
+++ b/sonic_data_client/virtual_db.go
@@ -169,7 +169,7 @@ func GetPfcwdMap() (map[string]map[string]string, error) {
 
 		var qos_key string
 		for _, key := range resp {
-			if !strings.Contains(key, "global") || !strings.Contains(key, "GLOBAL") { // Account for PORT_QOS_MAP|global
+			if !strings.Contains(key, "global") && !strings.Contains(key, "GLOBAL") { // Account for PORT_QOS_MAP|global
 				qos_key = key
 				break
 			}

--- a/sonic_data_client/virtual_db.go
+++ b/sonic_data_client/virtual_db.go
@@ -166,7 +166,19 @@ func getPfcwdMap() (map[string]map[string]string, error) {
 			log.V(1).Infof("PFC WD not enabled on device")
 			return nil, nil
 		}
-		qos_key := resp[0]
+
+		var qos_key string
+		for _, key := range resp {
+			if strings.Contains(key, "Ethernet") { // Account for PORT_QOS_MAP|global
+				qos_key = key
+				break
+			}
+		}
+
+		if qos_key == "" {
+			log.V(1).Infof("No valid port_qos_map key found")
+			return nil, nil
+		}
 
 		fieldName := "pfc_enable"
 		priorities, err := redisDb.HGet(qos_key, fieldName).Result()

--- a/sonic_data_client/virtual_db.go
+++ b/sonic_data_client/virtual_db.go
@@ -175,11 +175,6 @@ func getPfcwdMap() (map[string]map[string]string, error) {
 			}
 		}
 
-		if qos_key == "" {
-			log.V(1).Infof("No valid port_qos_map key found")
-			return nil, nil
-		}
-
 		fieldName := "pfc_enable"
 		priorities, err := redisDb.HGet(qos_key, fieldName).Result()
 		if err != nil {

--- a/testdata/CONFIG_PFCWD_PORTS.txt
+++ b/testdata/CONFIG_PFCWD_PORTS.txt
@@ -168,7 +168,10 @@
     "PFC_WD|GLOBAL": {
         "action": "drop"
     },
-    "PORT_QOS_MAP|Ethernet0,Ethernet1,Ethernet2,Ethernet3,Ethernet4,Ethernet5,Ethernet6,Ethernet7,Ethernet8,Ethernet9,Ethernet10,Ethernet11,Ethernet12,Ethernet13,Ethernet14,Ethernet15,Ethernet16,Ethernet17,Ethernet18,Ethernet19,Ethernet20,Ethernet21,Ethernet22,Ethernet23,Ethernet24,Ethernet25,Ethernet26,Ethernet27,Ethernet28,Ethernet29,Ethernet30,Ethernet31,Ethernet32,Ethernet33,Ethernet34,Ethernet35,Ethernet36,Ethernet37,Ethernet38,Ethernet39,Ethernet40,Ethernet41,Ethernet42,Ethernet43,Ethernet44,Ethernet45,Ethernet46,Ethernet47,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,global": {
+    "PORT_QOS_MAP|Ethernet0,Ethernet1,Ethernet2,Ethernet3,Ethernet4,Ethernet5,Ethernet6,Ethernet7,Ethernet8,Ethernet9,Ethernet10,Ethernet11,Ethernet12,Ethernet13,Ethernet14,Ethernet15,Ethernet16,Ethernet17,Ethernet18,Ethernet19,Ethernet20,Ethernet21,Ethernet22,Ethernet23,Ethernet24,Ethernet25,Ethernet26,Ethernet27,Ethernet28,Ethernet29,Ethernet30,Ethernet31,Ethernet32,Ethernet33,Ethernet34,Ethernet35,Ethernet36,Ethernet37,Ethernet38,Ethernet39,Ethernet40,Ethernet41,Ethernet42,Ethernet43,Ethernet44,Ethernet45,Ethernet46,Ethernet47,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68": {
         "pfc_enable": "3,4"
+    },
+    "PORT_QOS_MAP|global": {
+        "dummy": "value"
     }
 }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
ADO: 27075747
#### Why I did it

There is a chance that PORT_QOS_MAP|global is used to fetc pfc_enable key, which will cause redis hget to fail and return err. All queries to counters_db will fail after that.

- Fix that |global will not break redis hget
- Failure to create pfcwd map will not impact COUNTERS_DB queries. 

#### How I did it

Iterate and not use global as key for port_qos_map to check for pfc_enable

Any error creating pfcwd map will not stop future COUNTERS_DB queries

#### How to verify it

UT/Manual test. Tested in 202305

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

