### PR TITLE
Support control character in config

### DIFF
--- a/sonic_data_client/mixed_db_client.go
+++ b/sonic_data_client/mixed_db_client.go
@@ -1133,14 +1133,16 @@ import json
 
 yang_parser = sonic_yang.SonicYang("/usr/local/yang-models")
 yang_parser.loadYangModel()
-text = '''%s'''
+filename = "%s"
+with open(filename, 'r') as fp:
+	text = fp.read()
 
-try:
-    yang_parser.loadData(configdbJson=json.loads(text))
-    yang_parser.validate_data_tree()
-except sonic_yang.SonicYangException as e:
-    print("Yang validation error: {}".format(str(e)))
-    raise
+	try:
+		yang_parser.loadData(configdbJson=json.loads(text))
+		yang_parser.validate_data_tree()
+	except sonic_yang.SonicYangException as e:
+		print("Yang validation error: {}".format(str(e)))
+		raise
 `
 
 func (c *MixedDbClient) SetIncrementalConfig(delete []*gnmipb.Path, replace []*gnmipb.Update, update []*gnmipb.Update) error {


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
https://github.com/sonic-net/sonic-buildimage/pull/16957
Above PR introduced "\n" in config_db, and current GNMI implementation does not support such config.

#### How I did it
Update yang validation part to read config from file.

#### How to verify it
Run GNMI end to end test.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

