### PR TITLE
Fix mixed_db_client memory leak.

### DIFF
--- a/sonic_data_client/client_test.go
+++ b/sonic_data_client/client_test.go
@@ -394,6 +394,7 @@ func TestNonDbClientGetError(t *testing.T) {
 */
 func ReceiveFromZmq(consumer swsscommon.ZmqConsumerStateTable) (bool) {
 	receivedData := swsscommon.NewKeyOpFieldsValuesQueue()
+	defer swsscommon.DeleteKeyOpFieldsValuesQueue(receivedData)
 	retry := 0;
 	for {
 		// sender's ZMQ may disconnect, wait and retry for reconnect 
@@ -402,11 +403,9 @@ func ReceiveFromZmq(consumer swsscommon.ZmqConsumerStateTable) (bool) {
 		if receivedData.Size() == 0 {
 			retry++
 			if retry >= 10 {
-				swsscommon.DeleteKeyOpFieldsValuesQueue(receivedData)
 				return false
 			}
 		} else {
-			swsscommon.DeleteKeyOpFieldsValuesQueue(receivedData)
 			return true
 		}
 	}

--- a/sonic_data_client/client_test.go
+++ b/sonic_data_client/client_test.go
@@ -402,9 +402,11 @@ func ReceiveFromZmq(consumer swsscommon.ZmqConsumerStateTable) (bool) {
 		if receivedData.Size() == 0 {
 			retry++
 			if retry >= 10 {
+				swsscommon.DeleteKeyOpFieldsValuesQueue(receivedData)
 				return false
 			}
 		} else {
+			swsscommon.DeleteKeyOpFieldsValuesQueue(receivedData)
 			return true
 		}
 	}
@@ -443,6 +445,10 @@ func TestZmqReconnect(t *testing.T) {
 	if !ReceiveFromZmq(consumer) {
 		t.Errorf("Receive data from ZMQ failed")
 	}
+
+	swsscommon.DeleteZmqConsumerStateTable(consumer)
+	swsscommon.DeleteZmqServer(zmqServer)
+	swsscommon.DeleteDBConnector(db)
 }
 
 func TestRetryHelper(t *testing.T) {
@@ -473,6 +479,7 @@ func TestRetryHelper(t *testing.T) {
 		t.Errorf("RetryHelper retry too much")
 	}
 
+	swsscommon.DeleteZmqClient(zmqClient)
 	swsscommon.DeleteZmqServer(zmqServer)
 }
 
@@ -551,6 +558,11 @@ func TestGetDpuAddress(t *testing.T) {
 	if err == nil {
 		t.Errorf("get invalid ZMQ address failed")
 	}
+	
+	swsscommon.DeleteTable(midPlaneTable)
+	swsscommon.DeleteTable(dpusTable)
+	swsscommon.DeleteTable(dhcpPortTable)
+	swsscommon.DeleteDBConnector(configDb)
 }
 
 func TestGetZmqClient(t *testing.T) {
@@ -594,4 +606,9 @@ func TestGetZmqClient(t *testing.T) {
 	if err == nil {
 		t.Errorf("Remove ZMQ client should failed")
 	}
+	
+	swsscommon.DeleteTable(midPlaneTable)
+	swsscommon.DeleteTable(dpusTable)
+	swsscommon.DeleteTable(dhcpPortTable)
+	swsscommon.DeleteDBConnector(configDb)
 }

--- a/sonic_data_client/mixed_db_client.go
+++ b/sonic_data_client/mixed_db_client.go
@@ -93,7 +93,7 @@ var DbInstNum = 0
 
 func Hget(configDbConnector *swsscommon.ConfigDBConnector, table string, key string, field string) (string, error) {
     var fieldValuePairs = configDbConnector.Get_entry(table, key)
-	defer swsscommon.DeleteFieldValueMap(fieldValuePairs)
+    defer swsscommon.DeleteFieldValueMap(fieldValuePairs)
 
     if fieldValuePairs.Has_key(field) {
         return fieldValuePairs.Get(field), nil


### PR DESCRIPTION
Fix mixed_db_client memory leak.

#### Why I did it
Found memory leak in mixed_db_client.

#### How I did it
Add delete code for all sonic-swss-common lib resource.

#### How to verify it
Manually test.

#### Work item tracking

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
Fix mixed_db_client memory leak.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

