### PR TITLE
Use the latest libswsscommon artifacts from the repo

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -82,8 +82,6 @@ stages:
         patterns: |
             target/debs/bookworm/libyang*.deb
             target/debs/bookworm/libnl*.deb
-            target/debs/bookworm/libswsscommon*.deb
-            target/debs/bookworm/python3-swsscommon*.deb
             target/python-wheels/bookworm/sonic_yang_models*.whl
       displayName: "Download bookworm debs"
 
@@ -124,14 +122,26 @@ stages:
         curl -sSL https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
         sudo apt-add-repository https://packages.microsoft.com/debian/12/prod
         sudo apt-get update
-        sudo apt-get install -y dotnet-sdk-7.0
+        sudo apt-get install -y dotnet-sdk-8.0
       displayName: "Install .NET CORE"
 
+    - task: DownloadPipelineArtifact@2
+      inputs:
+        source: specific
+        project: build
+        pipeline: Azure.sonic-swss-common
+        artifact: sonic-swss-common-bookworm
+        runVersion: 'latestFromBranch'
+        runBranch: 'refs/heads/$(BUILD_BRANCH)'
+      displayName: "Download sonic-swss-common"
+
     - script: |
+        set -ex
         # LIBSWSSCOMMON
-        sudo dpkg -i ../target/debs/bookworm/libswsscommon_1.0.0_amd64.deb
-        sudo dpkg -i ../target/debs/bookworm/libswsscommon-dev_1.0.0_amd64.deb
-        sudo dpkg -i ../target/debs/bookworm/python3-swsscommon_1.0.0_amd64.deb
+        sudo dpkg -i libswsscommon_1.0.0_amd64.deb
+        sudo dpkg -i libswsscommon-dev_1.0.0_amd64.deb
+        sudo dpkg -i python3-swsscommon_1.0.0_amd64.deb
+      workingDirectory: $(Pipeline.Workspace)/
       displayName: 'Install libswsscommon package'
 
     - script: |


### PR DESCRIPTION


<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

For libswsscommon, instead of getting the artifacts from the sonic-buildimage repo, get it from the sonic-swss-common repo instead. The version in sonic-buildimage might be behind because the submodule update hasn't happened. That way, it's testing with the latest code, and also matches the go compilation where it uses the latest of sonic-swss-common.

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

