### PR TITLE
Fix ZMQ memory leak in unit test.

### DIFF
--- a/sonic_data_client/client_test.go
+++ b/sonic_data_client/client_test.go
@@ -448,9 +448,15 @@ func TestZmqReconnect(t *testing.T) {
 		t.Errorf("Receive data from ZMQ failed")
 	}
 
+	client.Close()
 	swsscommon.DeleteZmqConsumerStateTable(consumer)
+	swsscommon.DeleteZmqClient(client.zmqClient)
 	swsscommon.DeleteZmqServer(zmqServer)
 	swsscommon.DeleteDBConnector(db)
+
+	for _, client := range zmqClientMap {
+		swsscommon.DeleteZmqClient(client)
+	}
 }
 
 func TestRetryHelper(t *testing.T) {
@@ -613,4 +619,8 @@ func TestGetZmqClient(t *testing.T) {
 	swsscommon.DeleteTable(dpusTable)
 	swsscommon.DeleteTable(dhcpPortTable)
 	swsscommon.DeleteDBConnector(configDb)
+
+	for _, client := range zmqClientMap {
+		swsscommon.DeleteZmqClient(client)
+	}
 }

--- a/sonic_data_client/mixed_db_client.go
+++ b/sonic_data_client/mixed_db_client.go
@@ -1548,10 +1548,6 @@ func (c *MixedDbClient) Close() error {
 		swsscommon.DeleteSonicDBKey(c.dbkey)
 	}
 
-	for _, client := range zmqClientMap {
-		swsscommon.DeleteZmqClient(client)
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
Fix ZMQ memory leak in unit test.

#### Why I did it
Found memory leak in mixed_db_client test case.

#### How I did it
Delete global variable in unit test.

#### How to verify it
Manually test.

#### Work item tracking

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
Fix ZMQ memory leak in unit test.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

