### PR TITLE
Improve GNMI incremental config and add unit test for BGP

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -88,6 +88,7 @@ stages:
     - script: |
         # PYTEST
         sudo pip3 install -U pytest
+        sudo pip3 install -U jsonpatch
 
         # REDIS
         sudo apt-get update

--- a/sonic_data_client/client_test.go
+++ b/sonic_data_client/client_test.go
@@ -226,10 +226,22 @@ func TestJsonReplace(t *testing.T) {
 		`["10.250.0.0", "192.168.3.0", "139.66.72.9"]`,
 		`"6.6.6.6"`,
 	}
+	replace_value_list := []string {
+		`{"qos_01": {"bw": "12345", "cps": "2000", "flows": "500"}}`,
+		`{"bw": "20001", "cps": "2002", "flows": "300"}`,
+		`"6666"`,
+		`["10.250.0.1", "192.168.3.1", "139.66.72.10"]`,
+		`"8.8.8.8"`,
+	}
 	for i := 0; i < len(path_list); i++ {
 		path := path_list[i]
 		value := value_list[i]
-		err = client.Replace(path, value)
+		replace_value := replace_value_list[i]
+		err = client.Add(path, value)
+		if err != nil {
+			t.Errorf("Add %v fail: %v", path, err)
+		}
+		err = client.Replace(path, replace_value)
 		if err != nil {
 			t.Errorf("Replace %v fail: %v", path, err)
 		}
@@ -237,13 +249,13 @@ func TestJsonReplace(t *testing.T) {
 		if err != nil {
 			t.Errorf("Get %v fail: %v", path, err)
 		}
-		ok, err := JsonEqual([]byte(value), res)
+		ok, err := JsonEqual([]byte(replace_value), res)
 		if err != nil {
 			t.Errorf("Compare json fail: %v", err)
 			return
 		}
 		if ok != true {
-			t.Errorf("%v and %v do not match", value, string(res))
+			t.Errorf("%v and %v do not match", replace_value, string(res))
 		}
 	}
 	path := []string{}

--- a/sonic_data_client/client_test.go
+++ b/sonic_data_client/client_test.go
@@ -184,6 +184,76 @@ func TestJsonAddNegative(t *testing.T) {
 	}
 }
 
+func TestJsonReplace(t *testing.T) {
+	text := "{}"
+	err := ioutil.WriteFile(testFile, []byte(text), 0644)
+	if err != nil {
+		t.Errorf("Fail to create test file")
+	}
+	client, err := NewJsonClient(testFile)
+	if err != nil {
+		t.Errorf("Create client fail: %v", err)
+	}
+	path_list := [][]string {
+		[]string {
+			"DASH_QOS",
+		},
+		[]string {
+			"DASH_QOS",
+			"qos_02",
+		},
+		[]string {
+			"DASH_QOS",
+			"qos_03",
+			"bw",
+		},
+		[]string {
+			"DASH_VNET",
+			"vnet001",
+			"address_spaces",
+		},
+		[]string {
+			"DASH_VNET",
+			"vnet002",
+			"address_spaces",
+			"0",
+		},
+	}
+	value_list := []string {
+		`{"qos_01": {"bw": "54321", "cps": "1000", "flows": "300"}}`,
+		`{"bw": "10001", "cps": "1001", "flows": "101"}`,
+		`"20001"`,
+		`["10.250.0.0", "192.168.3.0", "139.66.72.9"]`,
+		`"6.6.6.6"`,
+	}
+	for i := 0; i < len(path_list); i++ {
+		path := path_list[i]
+		value := value_list[i]
+		err = client.Replace(path, value)
+		if err != nil {
+			t.Errorf("Replace %v fail: %v", path, err)
+		}
+		res, err := client.Get(path)
+		if err != nil {
+			t.Errorf("Get %v fail: %v", path, err)
+		}
+		ok, err := JsonEqual([]byte(value), res)
+		if err != nil {
+			t.Errorf("Compare json fail: %v", err)
+			return
+		}
+		if ok != true {
+			t.Errorf("%v and %v do not match", value, string(res))
+		}
+	}
+	path := []string{}
+	res, err := client.Get(path)
+	if err != nil {
+		t.Errorf("Get %v fail: %v", path, err)
+	}
+	t.Logf("Result %s", string(res))
+}
+
 func TestJsonRemove(t *testing.T) {
 	text := "{}"
 	err := ioutil.WriteFile(testFile, []byte(text), 0644)

--- a/sonic_data_client/json_client.go
+++ b/sonic_data_client/json_client.go
@@ -385,13 +385,9 @@ func (c *JsonClient) Replace(path []string, value string) error {
 			log.V(2).Infof("Invalid target field %v", ventry)
 			return fmt.Errorf("Invalid target field %v", ventry)
 		}
-		if id < 0 || id > len(vlist) {
+		if id < 0 || id >= len(vlist) {
 			log.V(2).Infof("Invalid index %v", id)
 			return fmt.Errorf("Invalid index %v", id)
-		}
-		if id == len(vlist) {
-			vlist = append(vlist, "")
-			ventry[path[2]] = vlist
 		}
 		v, err := parseJson([]byte(value))
 		if err != nil {

--- a/sonic_data_client/json_client.go
+++ b/sonic_data_client/json_client.go
@@ -282,13 +282,14 @@ func (c *JsonClient) Add(path []string, value string) error {
 		}
 		if id == len(vlist) {
 			vlist = append(vlist, "")
-			ventry[path[2]] = vlist
+		} else {
+			vlist = append(vlist[:id+1], vlist[id:]...)
 		}
+		ventry[path[2]] = vlist
 		v, err := parseJson([]byte(value))
 		if err != nil {
 			return fmt.Errorf("Fail to parse %v", value)
 		}
-		vlist = append(vlist[:id+1], vlist[id:]...)
 		vlist[id] = v
 	default:
 		log.V(2).Infof("Invalid db table Path %v", path)

--- a/sonic_data_client/json_client.go
+++ b/sonic_data_client/json_client.go
@@ -288,6 +288,114 @@ func (c *JsonClient) Add(path []string, value string) error {
 		if err != nil {
 			return fmt.Errorf("Fail to parse %v", value)
 		}
+		vlist = append(vlist[:id+1], vlist[id:]...)
+		vlist[id] = v
+	default:
+		log.V(2).Infof("Invalid db table Path %v", path)
+		return fmt.Errorf("Invalid db table Path %v", path)
+	}
+		
+	return nil
+}
+
+func (c *JsonClient) Replace(path []string, value string) error {
+	// The expect real db path could be in one of the formats:
+	// <1> DB Table
+	// <2> DB Table Key
+	// <3> DB Table Key Field
+	// <4> DB Table Key Field Index
+	switch len(path) {
+	case 1: // only table name provided
+		vtable, err := parseJson([]byte(value))
+		if err != nil {
+			return fmt.Errorf("Fail to parse %v", value)
+		}
+		v, ok := vtable.(map[string]interface{})
+		if !ok {
+			log.V(2).Infof("Invalid table %v", vtable)
+			return fmt.Errorf("Invalid table %v", vtable)
+		}
+		c.jsonData[path[0]] = v
+	case 2: // Second element must be table key
+		vtable, err := DecodeJsonTable(c.jsonData, path[0])
+		if err != nil {
+			vtable = make(map[string]interface{})
+			c.jsonData[path[0]] = vtable
+		}
+		ventry, err := parseJson([]byte(value))
+		if err != nil {
+			return fmt.Errorf("Fail to parse %v", value)
+		}
+		v, ok := ventry.(map[string]interface{})
+		if !ok {
+			log.V(2).Infof("Invalid entry %v", ventry)
+			return fmt.Errorf("Invalid entry %v", ventry)
+		}
+		vtable[path[1]] = v
+	case 3: // Third element must be field name
+		vtable, err := DecodeJsonTable(c.jsonData, path[0])
+		if err != nil {
+			vtable = make(map[string]interface{})
+			c.jsonData[path[0]] = vtable
+		}
+		ventry, err := DecodeJsonEntry(vtable, path[1])
+		if err != nil {
+			ventry = make(map[string]interface{})
+			vtable[path[1]] = ventry
+		}
+		vfield, err := parseJson([]byte(value))
+		if err != nil {
+			return fmt.Errorf("Fail to parse %v", value)
+		}
+		vstr, ok := vfield.(string)
+		if ok {
+			ventry[path[2]] = vstr
+			return nil
+		}
+		vlist, ok := vfield.([]interface{})
+		if ok {
+			ventry[path[2]] = vlist
+			return nil
+		}
+		log.V(2).Infof("Invalid field %v", vfield)
+		return fmt.Errorf("Invalid field %v", vfield)
+	case 4: // Fourth element must be list index
+		id, err := strconv.Atoi(path[3])
+		if err != nil {
+			log.V(2).Infof("Invalid index %v", path[3])
+			return fmt.Errorf("Invalid index %v", path[3])
+		}
+		vtable, err := DecodeJsonTable(c.jsonData, path[0])
+		if err != nil {
+			vtable = make(map[string]interface{})
+			c.jsonData[path[0]] = vtable
+		}
+		ventry, err := DecodeJsonEntry(vtable, path[1])
+		if err != nil {
+			ventry = make(map[string]interface{})
+			vtable[path[1]] = ventry
+		}
+		vstr, vlist, err := DecodeJsonField(ventry, path[2])
+		if err != nil {
+			vlist = make([]interface{}, 0)
+			ventry[path[2]] = vlist
+		}
+		if vstr != nil {
+			log.V(2).Infof("Invalid target field %v", ventry)
+			return fmt.Errorf("Invalid target field %v", ventry)
+		}
+		if id < 0 || id > len(vlist) {
+			log.V(2).Infof("Invalid index %v", id)
+			return fmt.Errorf("Invalid index %v", id)
+		}
+		if id == len(vlist) {
+			vlist = append(vlist, "")
+			ventry[path[2]] = vlist
+		}
+		v, err := parseJson([]byte(value))
+		if err != nil {
+			return fmt.Errorf("Fail to parse %v", value)
+		}
 		vlist[id] = v
 	default:
 		log.V(2).Infof("Invalid db table Path %v", path)

--- a/sonic_data_client/mixed_db_client.go
+++ b/sonic_data_client/mixed_db_client.go
@@ -1292,6 +1292,7 @@ func (c *MixedDbClient) SetIncrementalConfig(delete []*gnmipb.Path, replace []*g
 		return err
 	}
 
+	// If target is not changed, not need to update
 	if bytes.Equal(original, target) {
 		return nil
 	}
@@ -1302,6 +1303,7 @@ func (c *MixedDbClient) SetIncrementalConfig(delete []*gnmipb.Path, replace []*g
 		return err
 	}
 
+	// Invoke GCU replace to update
 	if c.origin == "sonic-db" {
 		err = sc.ReplaceDb(string(target))
 	}

--- a/sonic_data_client/mixed_db_client.go
+++ b/sonic_data_client/mixed_db_client.go
@@ -43,6 +43,9 @@ const RETRY_DELAY_FACTOR uint = 2
 const CHECK_POINT_PATH string = "/etc/sonic"
 const ELEM_INDEX_DATABASE = 0
 const ELEM_INDEX_INSTANCE = 1
+const UPDATE_OPERATION = "add"
+const DELETE_OPERATION = "remove"
+const REPLACE_OPERATION = "replace"
 
 const (
     opAdd = iota
@@ -1110,7 +1113,7 @@ func (c *MixedDbClient) handleTableData(tblPaths []tablePath) error {
 }
 
 /* Populate the JsonPatch corresponding each GNMI operation. */
-func (c *MixedDbClient) ConvertToJsonPatch(prefix *gnmipb.Path, path *gnmipb.Path, t *gnmipb.TypedValue, output *string) error {
+func (c *MixedDbClient) ConvertToJsonPatch(prefix *gnmipb.Path, path *gnmipb.Path, t *gnmipb.TypedValue, operation string, output *string) error {
 	if t != nil {
 		if len(t.GetJsonIetfVal()) == 0 {
 			return fmt.Errorf("Value encoding is not IETF JSON")
@@ -1122,11 +1125,7 @@ func (c *MixedDbClient) ConvertToJsonPatch(prefix *gnmipb.Path, path *gnmipb.Pat
 	}
 
 	elems := fullPath.GetElem()
-	if t == nil {
-		*output = `{"op": "remove", "path": "/`
-	} else {
-		*output = `{"op": "add", "path": "/`
-	}
+	*output = `{"op": "` + operation + `", "path": "/`
 
 	if elems != nil {
 		/* Iterate through elements. */
@@ -1237,7 +1236,7 @@ func (c *MixedDbClient) SetIncrementalConfig(delete []*gnmipb.Path, replace []*g
 			}
 		}
 		curr = ``
-		err = c.ConvertToJsonPatch(c.prefix, path, nil, &curr)
+		err = c.ConvertToJsonPatch(c.prefix, path, nil, DELETE_OPERATION, &curr)
 		if err != nil {
 			return err
 		}
@@ -1268,7 +1267,7 @@ func (c *MixedDbClient) SetIncrementalConfig(delete []*gnmipb.Path, replace []*g
 					continue
 				}
 			} else {
-				err := c.jClient.Add(stringSlice, string(t.GetJsonIetfVal()))
+				err := c.jClient.Replace(stringSlice, string(t.GetJsonIetfVal()))
 				if err != nil {
 					// Add failed
 					return err
@@ -1276,7 +1275,7 @@ func (c *MixedDbClient) SetIncrementalConfig(delete []*gnmipb.Path, replace []*g
 			}
 		}
 		curr = ``
-		err = c.ConvertToJsonPatch(c.prefix, path.GetPath(), path.GetVal(), &curr)
+		err = c.ConvertToJsonPatch(c.prefix, path.GetPath(), path.GetVal(), REPLACE_OPERATION, &curr)
 		if err != nil {
 			return err
 		}
@@ -1311,7 +1310,7 @@ func (c *MixedDbClient) SetIncrementalConfig(delete []*gnmipb.Path, replace []*g
 			}
 		}
 		curr = ``
-		err = c.ConvertToJsonPatch(c.prefix, path.GetPath(), path.GetVal(), &curr)
+		err = c.ConvertToJsonPatch(c.prefix, path.GetPath(), path.GetVal(), UPDATE_OPERATION, &curr)
 		if err != nil {
 			return err
 		}

--- a/sonic_service_client/dbus_client.go
+++ b/sonic_service_client/dbus_client.go
@@ -14,6 +14,8 @@ type Service interface {
 	ConfigSave(fileName string) error
 	ApplyPatchYang(fileName string) error
 	ApplyPatchDb(fileName string) error
+	ReplaceYang(fileName string) error
+	ReplaceDb(fileName string) error
 	CreateCheckPoint(cpName string)  error
 	DeleteCheckPoint(cpName string) error
 }
@@ -124,6 +126,26 @@ func (c *DbusClient) ApplyPatchDb(patch string) error {
 	busName := c.busNamePrefix + modName
 	busPath := c.busPathPrefix + modName
 	intName := c.intNamePrefix + modName + ".apply_patch_db"
+	err := DbusApi(busName, busPath, intName, 60, patch)
+	return err
+}
+
+func (c *DbusClient) ReplaceYang(patch string) error {
+	common_utils.IncCounter(common_utils.DBUS_APPLY_PATCH_YANG)
+	modName := "gcu"
+	busName := c.busNamePrefix + modName
+	busPath := c.busPathPrefix + modName
+	intName := c.intNamePrefix + modName + ".replace_yang"
+	err := DbusApi(busName, busPath, intName, 60, patch)
+	return err
+}
+
+func (c *DbusClient) ReplaceDb(patch string) error {
+	common_utils.IncCounter(common_utils.DBUS_APPLY_PATCH_DB)
+	modName := "gcu"
+	busName := c.busNamePrefix + modName
+	busPath := c.busPathPrefix + modName
+	intName := c.intNamePrefix + modName + ".replace_db"
 	err := DbusApi(busName, busPath, intName, 60, patch)
 	return err
 }

--- a/sonic_service_client/dbus_client_test.go
+++ b/sonic_service_client/dbus_client_test.go
@@ -286,6 +286,128 @@ func TestApplyPatchDbNegative(t *testing.T) {
 	}
 }
 
+func TestReplaceYang(t *testing.T) {
+	mock1 := gomonkey.ApplyFunc(dbus.SystemBus, func() (conn *dbus.Conn, err error) {
+		return &dbus.Conn{}, nil
+	})
+	defer mock1.Reset()
+	mock2 := gomonkey.ApplyMethod(reflect.TypeOf(&dbus.Object{}), "Go", func(obj *dbus.Object, method string, flags dbus.Flags, ch chan *dbus.Call, args ...interface{}) *dbus.Call {
+		if method != "org.SONiC.HostService.gcu.replace_yang" {
+			t.Errorf("Wrong method: %v", method)
+		}
+		ret := &dbus.Call{}
+		ret.Err = nil
+		ret.Body = make([]interface{}, 2)
+		ret.Body[0] = int32(0)
+		ch <- ret
+		return &dbus.Call{}
+	})
+	defer mock2.Reset()
+
+	client, err := NewDbusClient()
+	if err != nil {
+		t.Errorf("NewDbusClient failed: %v", err)
+	}
+	err = client.ReplaceYang("abc")
+	if err != nil {
+		t.Errorf("ReplaceYang should pass: %v", err)
+	}
+}
+
+func TestReplaceYangNegative(t *testing.T) {
+	err_msg := "This is the mock error message"
+	mock1 := gomonkey.ApplyFunc(dbus.SystemBus, func() (conn *dbus.Conn, err error) {
+		return &dbus.Conn{}, nil
+	})
+	defer mock1.Reset()
+	mock2 := gomonkey.ApplyMethod(reflect.TypeOf(&dbus.Object{}), "Go", func(obj *dbus.Object, method string, flags dbus.Flags, ch chan *dbus.Call, args ...interface{}) *dbus.Call {
+		if method != "org.SONiC.HostService.gcu.replace_yang" {
+			t.Errorf("Wrong method: %v", method)
+		}
+		ret := &dbus.Call{}
+		ret.Err = nil
+		ret.Body = make([]interface{}, 2)
+		ret.Body[0] = int32(1)
+		ret.Body[1] = err_msg
+		ch <- ret
+		return &dbus.Call{}
+	})
+	defer mock2.Reset()
+
+	client, err := NewDbusClient()
+	if err != nil {
+		t.Errorf("NewDbusClient failed: %v", err)
+	}
+	err = client.ReplaceYang("abc")
+	if err == nil {
+		t.Errorf("ReplaceYang should fail")
+	}
+	if err.Error() != err_msg {
+		t.Errorf("Wrong error: %v", err)
+	}
+}
+
+func TestReplaceDb(t *testing.T) {
+	mock1 := gomonkey.ApplyFunc(dbus.SystemBus, func() (conn *dbus.Conn, err error) {
+		return &dbus.Conn{}, nil
+	})
+	defer mock1.Reset()
+	mock2 := gomonkey.ApplyMethod(reflect.TypeOf(&dbus.Object{}), "Go", func(obj *dbus.Object, method string, flags dbus.Flags, ch chan *dbus.Call, args ...interface{}) *dbus.Call {
+		if method != "org.SONiC.HostService.gcu.replace_db" {
+			t.Errorf("Wrong method: %v", method)
+		}
+		ret := &dbus.Call{}
+		ret.Err = nil
+		ret.Body = make([]interface{}, 2)
+		ret.Body[0] = int32(0)
+		ch <- ret
+		return &dbus.Call{}
+	})
+	defer mock2.Reset()
+
+	client, err := NewDbusClient()
+	if err != nil {
+		t.Errorf("NewDbusClient failed: %v", err)
+	}
+	err = client.ReplaceDb("abc")
+	if err != nil {
+		t.Errorf("ReplaceDb should pass: %v", err)
+	}
+}
+
+func TestReplaceDbNegative(t *testing.T) {
+	err_msg := "This is the mock error message"
+	mock1 := gomonkey.ApplyFunc(dbus.SystemBus, func() (conn *dbus.Conn, err error) {
+		return &dbus.Conn{}, nil
+	})
+	defer mock1.Reset()
+	mock2 := gomonkey.ApplyMethod(reflect.TypeOf(&dbus.Object{}), "Go", func(obj *dbus.Object, method string, flags dbus.Flags, ch chan *dbus.Call, args ...interface{}) *dbus.Call {
+		if method != "org.SONiC.HostService.gcu.replace_db" {
+			t.Errorf("Wrong method: %v", method)
+		}
+		ret := &dbus.Call{}
+		ret.Err = nil
+		ret.Body = make([]interface{}, 2)
+		ret.Body[0] = int32(1)
+		ret.Body[1] = err_msg
+		ch <- ret
+		return &dbus.Call{}
+	})
+	defer mock2.Reset()
+
+	client, err := NewDbusClient()
+	if err != nil {
+		t.Errorf("NewDbusClient failed: %v", err)
+	}
+	err = client.ReplaceDb("abc")
+	if err == nil {
+		t.Errorf("ReplaceDb should fail")
+	}
+	if err.Error() != err_msg {
+		t.Errorf("Wrong error: %v", err)
+	}
+}
+
 func TestCreateCheckPoint(t *testing.T) {
 	mock1 := gomonkey.ApplyFunc(dbus.SystemBus, func() (conn *dbus.Conn, err error) {
 		return &dbus.Conn{}, nil

--- a/test/test_gnmi_configdb.py
+++ b/test/test_gnmi_configdb.py
@@ -111,7 +111,7 @@ test_data_checkpoint = [
     ]
 ]
 
-patch_file = '/tmp/gcu.patch'
+patch_file = '/tmp/gcu.target'
 config_file = '/tmp/config_db.json.tmp'
 checkpoint_file = '/etc/sonic/config.cp.json'
 
@@ -156,15 +156,7 @@ class TestGNMIConfigDb:
         assert os.path.exists(patch_file), "No patch file"
         with open(patch_file,'r') as pf:
             patch_json = json.load(pf)
-        for item in test_data:
-            test_path = item['path']
-            test_value = item['value']
-            for patch_data in patch_json:
-                assert patch_data['op'] == 'add', "Invalid operation"
-                if test_path == '/sonic-db:CONFIG_DB/localhost' + patch_data['path'] and test_value == patch_data['value']:
-                    break
-            else:
-                pytest.fail('No item in patch: %s'%str(item))
+        assert "PORT" in patch_json
         ret, new_apply_patch_cnt = gnmi_dump("DBUS apply patch db")
         assert ret == 0, 'Fail to read counter'
         assert new_apply_patch_cnt == old_apply_patch_cnt + 1, 'DBUS API is not invoked'
@@ -194,15 +186,7 @@ class TestGNMIConfigDb:
         assert ret == 0, msg
         assert os.path.exists(patch_file), "No patch file"
         with open(patch_file,'r') as pf:
-            patch_json = json.load(pf)
-        for item in test_data:
-            test_path = item['path']
-            for patch_data in patch_json:
-                assert patch_data['op'] == 'remove', "Invalid operation"
-                if test_path == '/sonic-db:CONFIG_DB/localhost' + patch_data['path']:
-                    break
-            else:
-                pytest.fail('No item in patch: %s'%str(item))
+            json.load(pf)
         ret, new_cnt = gnmi_dump("DBUS apply patch db")
         assert ret == 0, 'Fail to read counter'
         assert new_cnt == old_cnt+1, 'DBUS API should not be invoked'
@@ -222,7 +206,7 @@ class TestGNMIConfigDb:
         assert ret == 0, 'Fail to read counter'
         ret, msg = gnmi_set(delete_list, [], [])
         assert ret == 0, msg
-        assert not os.path.exists(patch_file), "Should not generate patch file"
+        assert not os.path.exists(patch_file), "No patch file"
         ret, new_cnt = gnmi_dump("DBUS apply patch db")
         assert ret == 0, 'Fail to read counter'
         assert new_cnt == old_cnt, 'DBUS API should not be invoked'
@@ -232,7 +216,7 @@ class TestGNMIConfigDb:
         test_config = {
             "PORT": {
                 'Ethernet4': {'admin_status': 'down'},
-                'Ethernet8': {'admin_status': 'down'}
+                'Ethernet8': {'admin_status': 'up'}
             }
         }
         create_checkpoint(checkpoint_file, json.dumps(test_config))
@@ -254,15 +238,7 @@ class TestGNMIConfigDb:
         assert os.path.exists(patch_file), "No patch file"
         with open(patch_file,'r') as pf:
             patch_json = json.load(pf)
-        for item in test_data:
-            test_path = item['path']
-            test_value = item['value']
-            for patch_data in patch_json:
-                assert patch_data['op'] == 'replace', "Invalid operation"
-                if test_path == '/sonic-db:CONFIG_DB/localhost' + patch_data['path'] and test_value == patch_data['value']:
-                    break
-            else:
-                pytest.fail('No item in patch: %s'%str(item))
+        assert "PORT" in patch_json
         ret, new_cnt = gnmi_dump("DBUS apply patch db")
         assert ret == 0, 'Fail to read counter'
         assert new_cnt == old_cnt+1, 'DBUS API is not invoked'

--- a/test/test_gnmi_configdb.py
+++ b/test/test_gnmi_configdb.py
@@ -252,7 +252,7 @@ class TestGNMIConfigDb:
             test_path = item['path']
             test_value = item['value']
             for patch_data in patch_json:
-                assert patch_data['op'] == 'add', "Invalid operation"
+                assert patch_data['op'] == 'replace', "Invalid operation"
                 if test_path == '/sonic-db:CONFIG_DB/localhost' + patch_data['path'] and test_value == patch_data['value']:
                     break
             else:

--- a/test/test_gnmi_configdb.py
+++ b/test/test_gnmi_configdb.py
@@ -229,7 +229,13 @@ class TestGNMIConfigDb:
 
     @pytest.mark.parametrize("test_data", test_data_update_normal)
     def test_gnmi_incremental_replace(self, test_data):
-        create_checkpoint(checkpoint_file, '{}')
+        test_config = {
+            "PORT": {
+                'Ethernet4': {'admin_status': 'down'},
+                'Ethernet8': {'admin_status': 'down'}
+            }
+        }
+        create_checkpoint(checkpoint_file, json.dumps(test_config))
 
         replace_list = []
         for i, data in enumerate(test_data):

--- a/test/test_gnmi_configdb_patch.py
+++ b/test/test_gnmi_configdb_patch.py
@@ -800,13 +800,6 @@ class TestGNMIConfigDbPatch:
             diff = jsonpatch.make_patch(test_data['origin_json'], test_data["target_json"])
             assert len(diff.patch) == 0, "%s failed, no patch file" % (test_data["test_name"])
 
-    @pytest.mark.parametrize("test_data", test_data_aaa_patch)
-    def test_gnmi_aaa_patch(self, test_data):
-        '''
-        Generate GNMI request for AAA and verify jsonpatch
-        '''
-        self.common_test_handler(test_data)
-
     @pytest.mark.parametrize("test_data", test_data_bgp_prefix_patch)
     def test_gnmi_bgp_prefix_patch(self, test_data):
         '''

--- a/test/test_gnmi_configdb_patch.py
+++ b/test/test_gnmi_configdb_patch.py
@@ -1,0 +1,827 @@
+import os
+import json
+import jsonpatch
+from utils import gnmi_set, gnmi_get, gnmi_dump
+
+import pytest
+
+patch_file = "/tmp/gcu.patch"
+config_file = "/tmp/config_db.json.tmp"
+checkpoint_file = "/etc/sonic/config.cp.json"
+
+def create_dir(path):
+    isExists = os.path.exists(path)
+    if not isExists:
+        os.makedirs(path)
+
+def create_checkpoint(file_name, text):
+    create_dir(os.path.dirname(file_name))
+    file_object = open(file_name, "w")
+    file_object.write(text)
+    file_object.close()
+    return
+
+test_data_bgp_prefix_patch = [
+    {
+        "test_name": "bgp_prefix_tc1_add_config",
+        "operations": [
+            {
+                "op": "update",
+                "path": "/sonic-db:CONFIG_DB/localhost/BGP_ALLOWED_PREFIXES",
+                "value": {
+                    "DEPLOYMENT_ID|0|1010:1010": {
+                        "prefixes_v4": [
+                            "10.20.0.0/16"
+                        ],
+                        "prefixes_v6": [
+                            "fc01:20::/64"
+                        ]
+                    }
+                }
+            }
+        ],
+        "origin_json": {},
+        "target_json": {
+            "BGP_ALLOWED_PREFIXES": {
+                "DEPLOYMENT_ID|0|1010:1010": {
+                    "prefixes_v4": [
+                        "10.20.0.0/16"
+                    ],
+                    "prefixes_v6": [
+                        "fc01:20::/64"
+                    ]
+                }
+            }
+        }
+    },
+    {
+        "test_name": "bgp_prefix_tc1_replace",
+        "operations": [
+            {
+                "op": "replace",
+                "path": "/sonic-db:CONFIG_DB/localhost/BGP_ALLOWED_PREFIXES/DEPLOYMENT_ID\\|0\\|1010:1010/prefixes_v6/0",
+                "value": "fc01:30::/64"
+            },
+            {
+                "op": "replace",
+                "path": "/sonic-db:CONFIG_DB/localhost/BGP_ALLOWED_PREFIXES/DEPLOYMENT_ID\\|0\\|1010:1010/prefixes_v4/0",
+                "value": "10.30.0.0/16"
+            }
+        ],
+        "origin_json": {
+            "BGP_ALLOWED_PREFIXES": {
+                "DEPLOYMENT_ID|0|1010:1010": {
+                    "prefixes_v4": [
+                        "10.20.0.0/16"
+                    ],
+                    "prefixes_v6": [
+                        "fc01:20::/64"
+                    ]
+                }
+            }
+        },
+        "target_json": {
+            "BGP_ALLOWED_PREFIXES": {
+                "DEPLOYMENT_ID|0|1010:1010": {
+                    "prefixes_v4": [
+                        "10.30.0.0/16"
+                    ],
+                    "prefixes_v6": [
+                        "fc01:30::/64"
+                    ]
+                }
+            }
+        }
+    },
+    {
+        "test_name": "bgp_prefix_tc1_add",
+        "operations": [
+            {
+                "op": "update",
+                "path": "/sonic-db:CONFIG_DB/localhost/BGP_ALLOWED_PREFIXES/DEPLOYMENT_ID\\|0\\|1010:1010/prefixes_v6/0",
+                "value": "fc01:30::/64"
+            },
+            {
+                "op": "update",
+                "path": "/sonic-db:CONFIG_DB/localhost/BGP_ALLOWED_PREFIXES/DEPLOYMENT_ID\\|0\\|1010:1010/prefixes_v4/0",
+                "value": "10.30.0.0/16"
+            }
+        ],
+        "origin_json": {
+            "BGP_ALLOWED_PREFIXES": {
+                "DEPLOYMENT_ID|0|1010:1010": {
+                    "prefixes_v4": [
+                        "10.20.0.0/16"
+                    ],
+                    "prefixes_v6": [
+                        "fc01:20::/64"
+                    ]
+                }
+            }
+        },
+        "target_json": {
+            "BGP_ALLOWED_PREFIXES": {
+                "DEPLOYMENT_ID|0|1010:1010": {
+                    "prefixes_v4": [
+                        "10.30.0.0/16", "10.20.0.0/16"
+                    ],
+                    "prefixes_v6": [
+                        "fc01:30::/64", "fc01:20::/64"
+                    ]
+                }
+            }
+        }
+    },
+    {
+        "test_name": "bgp_prefix_tc1_remove",
+        "operations": [
+            {
+                "op": "del",
+                "path": "/sonic-db:CONFIG_DB/localhost/BGP_ALLOWED_PREFIXES"
+            }
+        ],
+        "origin_json": {
+            "BGP_ALLOWED_PREFIXES": {
+                "DEPLOYMENT_ID|0|1010:1010": {
+                    "prefixes_v4": [
+                        "10.30.0.0/16", "10.20.0.0/16"
+                    ],
+                    "prefixes_v6": [
+                        "fc01:30::/64", "fc01:20::/64"
+                    ]
+                }
+            }
+        },
+        "target_json": {}
+    }
+]
+
+test_data_bgp_sentinel_patch = [
+    {
+        "test_name": "bgp_sentinel_tc1_add_config",
+        "operations": [
+            {
+                "op": "update",
+                "path": "/sonic-db:CONFIG_DB/localhost/BGP_SENTINELS",
+                "value": {
+                    "BGPSentinel": {
+                        "ip_range": [
+                            "10.10.20.0/24"
+                        ],
+                        "name": "BGPSentinel",
+                        "src_address": "10.5.5.5"
+                    },
+                    "BGPSentinelV6": {
+                        "ip_range": [
+                            "2603:10a1:30a:8000::/59"
+                        ],
+                        "name": "BGPSentinelV6",
+                        "src_address": "fc00:fc00:0:10::5"
+                    }
+                }
+            }
+        ],
+        "origin_json": {},
+        "target_json": {
+            "BGP_SENTINELS": {
+                "BGPSentinel": {
+                    "ip_range": [
+                        "10.10.20.0/24"
+                    ],
+                    "name": "BGPSentinel",
+                    "src_address": "10.5.5.5"
+                },
+                "BGPSentinelV6": {
+                    "ip_range": [
+                        "2603:10a1:30a:8000::/59"
+                    ],
+                    "name": "BGPSentinelV6",
+                    "src_address": "fc00:fc00:0:10::5"
+                }
+            }
+        }
+    },
+    {
+        "test_name": "bgp_sentinel_tc1_add_dummy_ip_range",
+        "operations": [
+            {
+                "op": "update",
+                "path": "/sonic-db:CONFIG_DB/localhost/BGP_SENTINELS/BGPSentinel/ip_range/1",
+                "value": "10.255.0.0/25"
+            },
+            {
+                "op": "update",
+                "path": "/sonic-db:CONFIG_DB/localhost/BGP_SENTINELS/BGPSentinelV6/ip_range/1",
+                "value": "cc98:2008:2012:2022::/64"
+            }
+        ],
+        "origin_json": {
+            "BGP_SENTINELS": {
+                "BGPSentinel": {
+                    "ip_range": [
+                        "10.10.20.0/24"
+                    ],
+                    "name": "BGPSentinel",
+                    "src_address": "10.5.5.5"
+                },
+                "BGPSentinelV6": {
+                    "ip_range": [
+                        "2603:10a1:30a:8000::/59"
+                    ],
+                    "name": "BGPSentinelV6",
+                    "src_address": "fc00:fc00:0:10::5"
+                }
+            }
+        },
+        "target_json": {
+            "BGP_SENTINELS": {
+                "BGPSentinel": {
+                    "ip_range": [
+                        "10.10.20.0/24", "10.255.0.0/25"
+                    ],
+                    "name": "BGPSentinel",
+                    "src_address": "10.5.5.5"
+                },
+                "BGPSentinelV6": {
+                    "ip_range": [
+                        "2603:10a1:30a:8000::/59", "cc98:2008:2012:2022::/64"
+                    ],
+                    "name": "BGPSentinelV6",
+                    "src_address": "fc00:fc00:0:10::5"
+                }
+            }
+        }
+    },
+    {
+        "test_name": "bgp_sentinel_tc1_rm_dummy_ip_range",
+        "operations": [
+            {
+                "op": "del",
+                "path": "/sonic-db:CONFIG_DB/localhost/BGP_SENTINELS/BGPSentinel/ip_range/1",
+                "value": "10.255.0.0/25"
+            },
+            {
+                "op": "del",
+                "path": "/sonic-db:CONFIG_DB/localhost/BGP_SENTINELS/BGPSentinelV6/ip_range/1",
+                "value": "cc98:2008:2012:2022::/64"
+            }
+        ],
+        "origin_json": {
+            "BGP_SENTINELS": {
+                "BGPSentinel": {
+                    "ip_range": [
+                        "10.10.20.0/24", "10.255.0.0/25"
+                    ],
+                    "name": "BGPSentinel",
+                    "src_address": "10.5.5.5"
+                },
+                "BGPSentinelV6": {
+                    "ip_range": [
+                        "2603:10a1:30a:8000::/59", "cc98:2008:2012:2022::/64"
+                    ],
+                    "name": "BGPSentinelV6",
+                    "src_address": "fc00:fc00:0:10::5"
+                }
+            }
+        },
+        "target_json": {
+            "BGP_SENTINELS": {
+                "BGPSentinel": {
+                    "ip_range": [
+                        "10.10.20.0/24"
+                    ],
+                    "name": "BGPSentinel",
+                    "src_address": "10.5.5.5"
+                },
+                "BGPSentinelV6": {
+                    "ip_range": [
+                        "2603:10a1:30a:8000::/59"
+                    ],
+                    "name": "BGPSentinelV6",
+                    "src_address": "fc00:fc00:0:10::5"
+                }
+            }
+        }
+    },
+    {
+        "test_name": "bgp_sentinel_tc1_replace_src_address",
+        "operations": [
+            {
+                "op": "replace",
+                "path": "/sonic-db:CONFIG_DB/localhost/BGP_SENTINELS/BGPSentinel/src_address",
+                "value": "10.1.0.33"
+            },
+            {
+                "op": "replace",
+                "path": "/sonic-db:CONFIG_DB/localhost/BGP_SENTINELS/BGPSentinelV6/src_address",
+                "value": "fc00:1::33"
+            }
+        ],
+        "origin_json": {
+            "BGP_SENTINELS": {
+                "BGPSentinel": {
+                    "ip_range": [
+                        "10.10.20.0/24"
+                    ],
+                    "name": "BGPSentinel",
+                    "src_address": "10.5.5.5"
+                },
+                "BGPSentinelV6": {
+                    "ip_range": [
+                        "2603:10a1:30a:8000::/59"
+                    ],
+                    "name": "BGPSentinelV6",
+                    "src_address": "fc00:fc00:0:10::5"
+                }
+            }
+        },
+        "target_json": {
+            "BGP_SENTINELS": {
+                "BGPSentinel": {
+                    "ip_range": [
+                        "10.10.20.0/24"
+                    ],
+                    "name": "BGPSentinel",
+                    "src_address": "10.1.0.33"
+                },
+                "BGPSentinelV6": {
+                    "ip_range": [
+                        "2603:10a1:30a:8000::/59"
+                    ],
+                    "name": "BGPSentinelV6",
+                    "src_address": "fc00:1::33"
+                }
+            }
+        }
+    }
+]
+
+test_data_bgp_speaker_patch = [
+    {
+        "test_name": "bgp_speaker_tc1_add_config",
+        "operations": [
+            {
+                "op": "update",
+                "path": "/sonic-db:CONFIG_DB/localhost/BGP_PEER_RANGE",
+                "value": {
+                    "BGPSLBPassive": {
+                        "ip_range": [
+                            "10.255.0.0/25"
+                        ],
+                        "name": "BGPSLBPassive",
+                        "src_address": "10.1.0.33"
+                    },
+                    "BGPSLBPassiveV6": {
+                        "ip_range": [
+                            "cc98:2008:2012:2022::/64"
+                        ],
+                        "name": "BGPSLBPassiveV6",
+                        "src_address": "fc00:1::33"
+                    }
+                }
+            }
+        ],
+        "origin_json": {},
+        "target_json": {
+            "BGP_PEER_RANGE": {
+                "BGPSLBPassive": {
+                    "ip_range": [
+                        "10.255.0.0/25"
+                    ],
+                    "name": "BGPSLBPassive",
+                    "src_address": "10.1.0.33"
+                },
+                "BGPSLBPassiveV6": {
+                    "ip_range": [
+                        "cc98:2008:2012:2022::/64"
+                    ],
+                    "name": "BGPSLBPassiveV6",
+                    "src_address": "fc00:1::33"
+                }
+            }
+        }
+    },
+    {
+        "test_name": "bgp_speaker_tc1_add_dummy_ip_range",
+        "operations": [
+            {
+                "op": "update",
+                "path": "/sonic-db:CONFIG_DB/localhost/BGP_PEER_RANGE/BGPSLBPassive/ip_range/1",
+                "value": "20.255.0.0/25"
+            },
+            {
+                "op": "update",
+                "path": "/sonic-db:CONFIG_DB/localhost/BGP_PEER_RANGE/BGPSLBPassiveV6/ip_range/1",
+                "value": "cc98:2008:2012:2222::/64"
+            }
+        ],
+        "origin_json": {
+            "BGP_PEER_RANGE": {
+                "BGPSLBPassive": {
+                    "ip_range": [
+                        "10.255.0.0/25"
+                    ],
+                    "name": "BGPSLBPassive",
+                    "src_address": "10.1.0.33"
+                },
+                "BGPSLBPassiveV6": {
+                    "ip_range": [
+                        "cc98:2008:2012:2022::/64"
+                    ],
+                    "name": "BGPSLBPassiveV6",
+                    "src_address": "fc00:1::33"
+                }
+            }
+        },
+        "target_json": {
+            "BGP_PEER_RANGE": {
+                "BGPSLBPassive": {
+                    "ip_range": [
+                        "10.255.0.0/25", "20.255.0.0/25"
+                    ],
+                    "name": "BGPSLBPassive",
+                    "src_address": "10.1.0.33"
+                },
+                "BGPSLBPassiveV6": {
+                    "ip_range": [
+                        "cc98:2008:2012:2022::/64", "cc98:2008:2012:2222::/64"
+                    ],
+                    "name": "BGPSLBPassiveV6",
+                    "src_address": "fc00:1::33"
+                }
+            }
+        }
+    },
+    {
+        "test_name": "bgp_speaker_tc1_rm_dummy_ip_range",
+        "operations": [
+            {
+                "op": "del",
+                "path": "/sonic-db:CONFIG_DB/localhost/BGP_PEER_RANGE/BGPSLBPassive/ip_range/1"
+            },
+            {
+                "op": "del",
+                "path": "/sonic-db:CONFIG_DB/localhost/BGP_PEER_RANGE/BGPSLBPassiveV6/ip_range/1"
+            }
+        ],
+        "origin_json": {
+            "BGP_PEER_RANGE": {
+                "BGPSLBPassive": {
+                    "ip_range": [
+                        "10.255.0.0/25", "20.255.0.0/25"
+                    ],
+                    "name": "BGPSLBPassive",
+                    "src_address": "10.1.0.33"
+                },
+                "BGPSLBPassiveV6": {
+                    "ip_range": [
+                        "cc98:2008:2012:2022::/64", "cc98:2008:2012:2222::/64"
+                    ],
+                    "name": "BGPSLBPassiveV6",
+                    "src_address": "fc00:1::33"
+                }
+            }
+        },
+        "target_json": {
+            "BGP_PEER_RANGE": {
+                "BGPSLBPassive": {
+                    "ip_range": [
+                        "10.255.0.0/25"
+                    ],
+                    "name": "BGPSLBPassive",
+                    "src_address": "10.1.0.33"
+                },
+                "BGPSLBPassiveV6": {
+                    "ip_range": [
+                        "cc98:2008:2012:2022::/64"
+                    ],
+                    "name": "BGPSLBPassiveV6",
+                    "src_address": "fc00:1::33"
+                }
+            }
+        }
+    },
+    {
+        "test_name": "bgp_speaker_tc1_replace_src_address",
+        "operations": [
+            {
+                "op": "replace",
+                "path": "/sonic-db:CONFIG_DB/localhost/BGP_PEER_RANGE/BGPSLBPassive/src_address",
+                "value": "10.2.0.33"
+            },
+            {
+                "op": "replace",
+                "path": "/sonic-db:CONFIG_DB/localhost/BGP_PEER_RANGE/BGPSLBPassiveV6/src_address",
+                "value": "fc00:2::33"
+            }
+        ],
+        "origin_json": {
+            "BGP_PEER_RANGE": {
+                "BGPSLBPassive": {
+                    "ip_range": [
+                        "10.255.0.0/25"
+                    ],
+                    "name": "BGPSLBPassive",
+                    "src_address": "10.1.0.33"
+                },
+                "BGPSLBPassiveV6": {
+                    "ip_range": [
+                        "cc98:2008:2012:2022::/64"
+                    ],
+                    "name": "BGPSLBPassiveV6",
+                    "src_address": "fc00:1::33"
+                }
+            }
+        },
+        "target_json": {
+            "BGP_PEER_RANGE": {
+                "BGPSLBPassive": {
+                    "ip_range": [
+                        "10.255.0.0/25"
+                    ],
+                    "name": "BGPSLBPassive",
+                    "src_address": "10.2.0.33"
+                },
+                "BGPSLBPassiveV6": {
+                    "ip_range": [
+                        "cc98:2008:2012:2022::/64"
+                    ],
+                    "name": "BGPSLBPassiveV6",
+                    "src_address": "fc00:2::33"
+                }
+            }
+        }
+    }
+]
+
+test_data_bgp_mon_patch = [
+    {
+        "test_name": "bgpmon_tc1_add_init",
+        "operations": [
+            {
+                "op": "update",
+                "path": "/sonic-db:CONFIG_DB/localhost/BGP_MONITORS",
+                "value": {
+                    "10.10.10.10": {
+                        "admin_status": "up",
+                        "asn": "66666",
+                        "holdtime": "180",
+                        "keepalive": "60",
+                        "local_addr": "10.10.10.20",
+                        "name": "BGPMonitor",
+                        "nhopself": "0",
+                        "rrclient": "0"
+                    }
+                }
+            }
+        ],
+        "origin_json": {},
+        "target_json": {
+            "BGP_MONITORS": {
+                "10.10.10.10": {
+                    "admin_status": "up",
+                    "asn": "66666",
+                    "holdtime": "180",
+                    "keepalive": "60",
+                    "local_addr": "10.10.10.20",
+                    "name": "BGPMonitor",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                }
+            }
+        }
+    },
+    {
+        "test_name": "bgpmon_tc1_add_duplicate",
+        "operations": [
+            {
+                "op": "update",
+                "path": "/sonic-db:CONFIG_DB/localhost/BGP_MONITORS/10.10.10.10",
+                "value": {
+                    "admin_status": "up",
+                    "asn": "66666",
+                    "holdtime": "180",
+                    "keepalive": "60",
+                    "local_addr": "10.10.10.20",
+                    "name": "BGPMonitor",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                }
+            }
+        ],
+        "origin_json": {
+            "BGP_MONITORS": {
+                "10.10.10.10": {
+                    "admin_status": "up",
+                    "asn": "66666",
+                    "holdtime": "180",
+                    "keepalive": "60",
+                    "local_addr": "10.10.10.20",
+                    "name": "BGPMonitor",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                }
+            }
+        },
+        "target_json": {
+            "BGP_MONITORS": {
+                "10.10.10.10": {
+                    "admin_status": "up",
+                    "asn": "66666",
+                    "holdtime": "180",
+                    "keepalive": "60",
+                    "local_addr": "10.10.10.20",
+                    "name": "BGPMonitor",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                }
+            }
+        }
+    },
+    {
+        "test_name": "bgpmon_tc1_admin_change",
+        "operations": [
+            {
+                "op": "replace",
+                "path": "/sonic-db:CONFIG_DB/localhost/BGP_MONITORS/10.10.10.10/admin_status",
+                "value": "down"
+            }
+        ],
+        "origin_json": {
+            "BGP_MONITORS": {
+                "10.10.10.10": {
+                    "admin_status": "up",
+                    "asn": "66666",
+                    "holdtime": "180",
+                    "keepalive": "60",
+                    "local_addr": "10.10.10.20",
+                    "name": "BGPMonitor",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                }
+            }
+        },
+        "target_json": {
+            "BGP_MONITORS": {
+                "10.10.10.10": {
+                    "admin_status": "down",
+                    "asn": "66666",
+                    "holdtime": "180",
+                    "keepalive": "60",
+                    "local_addr": "10.10.10.20",
+                    "name": "BGPMonitor",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                }
+            }
+        }
+    },
+    {
+        "test_name": "bgpmon_tc1_ip_change",
+        "operations": [
+            {
+                "op": "del",
+                "path": "/sonic-db:CONFIG_DB/localhost/BGP_MONITORS/10.10.10.10",
+            },
+            {
+                "op": "update",
+                "path": "/sonic-db:CONFIG_DB/localhost/BGP_MONITORS/10.10.10.30",
+                "value": {
+                    "admin_status": "up",
+                    "asn": "66666",
+                    "holdtime": "180",
+                    "keepalive": "60",
+                    "local_addr": "10.10.10.20",
+                    "name": "BGPMonitor",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                }
+            }
+        ],
+        "origin_json": {
+            "BGP_MONITORS": {
+                "10.10.10.10": {
+                    "admin_status": "up",
+                    "asn": "66666",
+                    "holdtime": "180",
+                    "keepalive": "60",
+                    "local_addr": "10.10.10.20",
+                    "name": "BGPMonitor",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                }
+            }
+        },
+        "target_json": {
+            "BGP_MONITORS": {
+                "10.10.10.30": {
+                    "admin_status": "up",
+                    "asn": "66666",
+                    "holdtime": "180",
+                    "keepalive": "60",
+                    "local_addr": "10.10.10.20",
+                    "name": "BGPMonitor",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                }
+            }
+        }
+    },
+    {
+        "test_name": "bgpmon_tc1_remove",
+        "operations": [
+            {
+                "op": "del",
+                "path": "/sonic-db:CONFIG_DB/localhost/BGP_MONITORS",
+            }
+        ],
+        "origin_json": {
+            "BGP_MONITORS": {
+                "10.10.10.10": {
+                    "admin_status": "up",
+                    "asn": "66666",
+                    "holdtime": "180",
+                    "keepalive": "60",
+                    "local_addr": "10.10.10.20",
+                    "name": "BGPMonitor",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                }
+            }
+        },
+        "target_json": {}
+    }
+]
+
+class TestGNMIConfigDbPatch:
+
+    def common_test_handler(self, test_data):
+        '''
+        Common code for all patch test
+        '''
+        if os.path.exists(patch_file):
+            os.system("rm " + patch_file)
+        create_checkpoint(checkpoint_file, json.dumps(test_data['origin_json']))
+        update_list = []
+        replace_list = []
+        delete_list = []
+        for i, data in enumerate(test_data["operations"]):
+            path = data["path"]
+            if data['op'] == "update":
+                value = json.dumps(data["value"])
+                file_name = "update" + str(i)
+                file_object = open(file_name, "w")
+                file_object.write(value)
+                file_object.close()
+                update_list.append(path + ":@./" + file_name)
+            elif data['op'] == "replace":
+                value = json.dumps(data["value"])
+                file_name = "replace" + str(i)
+                file_object = open(file_name, "w")
+                file_object.write(value)
+                file_object.close()
+                replace_list.append(path + ":@./" + file_name)
+            elif data['op'] == "del":
+                delete_list.append(path)
+            else:
+                pytest.fail("Invalid operation: %s" % data['op'])
+
+        # Send GNMI request
+        ret, msg = gnmi_set(delete_list, update_list, replace_list)
+        assert ret == 0, msg
+        assert os.path.exists(patch_file), "No patch file"
+        with open(patch_file,"r") as pf:
+            patch_json = json.load(pf)
+        # Apply patch to get json result
+        result = jsonpatch.apply_patch(test_data["origin_json"], patch_json)
+        # Compare json result
+        diff = jsonpatch.make_patch(result, test_data["target_json"])
+        assert len(diff.patch) == 0, "%s failed, generated json: %s" % (test_data["test_name"], str(result))
+
+    @pytest.mark.parametrize("test_data", test_data_bgp_prefix_patch)
+    def test_gnmi_bgp_prefix_patch(self, test_data):
+        '''
+        Generate GNMI request for BGP prefix and verify jsonpatch
+        '''
+        self.common_test_handler(test_data)
+ 
+    @pytest.mark.parametrize("test_data", test_data_bgp_sentinel_patch)
+    def test_gnmi_bgp_sentinel_patch(self, test_data):
+        '''
+        Generate GNMI request for BGP sentinel and verify jsonpatch
+        '''
+        self.common_test_handler(test_data)
+
+    @pytest.mark.parametrize("test_data", test_data_bgp_speaker_patch)
+    def test_gnmi_bgp_speaker_patch(self, test_data):
+        '''
+        Generate GNMI request for BGP speaker and verify jsonpatch
+        '''
+        self.common_test_handler(test_data)
+
+    @pytest.mark.parametrize("test_data", test_data_bgp_mon_patch)
+    def test_gnmi_bgp_mon_patch(self, test_data):
+        '''
+        Generate GNMI request for BGP monitor and verify jsonpatch
+        '''
+        self.common_test_handler(test_data)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
GCU has verified BGP configuration, we need to verify that GNMI can support the same BGP configuration.
Because GCU end2end test uses jsonpatch replace operation for BGP, we need to update GNMI replace operation for incremental config.
Golang does not have reliable library for jsonpatch.
Microsoft ADO: 27231737

#### How I did it
This unit test uses BGP configuration from GCU test.
This unit test generates GNMI request for BGP and use jsonpatch to verify patch file generated by GNMI server.
I also update gnmi replace implementation to support jsonpatch replace operation.
"config apply-patch" is equivalent to “config replace", so I use "config replace" for incremental config, and then we don't need to generate jsonpatch in golang.

#### How to verify it
Run gnmi unit test.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

