### PR TITLE
Improve GNMI incremental config and add unit test for BGP

### DIFF
--- a/sonic_data_client/client_test.go
+++ b/sonic_data_client/client_test.go
@@ -185,6 +185,88 @@ func TestJsonAddNegative(t *testing.T) {
 	}
 }
 
+func TestJsonReplace(t *testing.T) {
+	text := "{}"
+	err := ioutil.WriteFile(testFile, []byte(text), 0644)
+	if err != nil {
+		t.Errorf("Fail to create test file")
+	}
+	client, err := NewJsonClient(testFile)
+	if err != nil {
+		t.Errorf("Create client fail: %v", err)
+	}
+	path_list := [][]string {
+		[]string {
+			"DASH_QOS",
+		},
+		[]string {
+			"DASH_QOS",
+			"qos_02",
+		},
+		[]string {
+			"DASH_QOS",
+			"qos_03",
+			"bw",
+		},
+		[]string {
+			"DASH_VNET",
+			"vnet001",
+			"address_spaces",
+		},
+		[]string {
+			"DASH_VNET",
+			"vnet002",
+			"address_spaces",
+			"0",
+		},
+	}
+	value_list := []string {
+		`{"qos_01": {"bw": "54321", "cps": "1000", "flows": "300"}}`,
+		`{"bw": "10001", "cps": "1001", "flows": "101"}`,
+		`"20001"`,
+		`["10.250.0.0", "192.168.3.0", "139.66.72.9"]`,
+		`"6.6.6.6"`,
+	}
+	replace_value_list := []string {
+		`{"qos_01": {"bw": "12345", "cps": "2000", "flows": "500"}}`,
+		`{"bw": "20001", "cps": "2002", "flows": "300"}`,
+		`"6666"`,
+		`["10.250.0.1", "192.168.3.1", "139.66.72.10"]`,
+		`"8.8.8.8"`,
+	}
+	for i := 0; i < len(path_list); i++ {
+		path := path_list[i]
+		value := value_list[i]
+		replace_value := replace_value_list[i]
+		err = client.Add(path, value)
+		if err != nil {
+			t.Errorf("Add %v fail: %v", path, err)
+		}
+		err = client.Replace(path, replace_value)
+		if err != nil {
+			t.Errorf("Replace %v fail: %v", path, err)
+		}
+		res, err := client.Get(path)
+		if err != nil {
+			t.Errorf("Get %v fail: %v", path, err)
+		}
+		ok, err := JsonEqual([]byte(replace_value), res)
+		if err != nil {
+			t.Errorf("Compare json fail: %v", err)
+			return
+		}
+		if ok != true {
+			t.Errorf("%v and %v do not match", replace_value, string(res))
+		}
+	}
+	path := []string{}
+	res, err := client.Get(path)
+	if err != nil {
+		t.Errorf("Get %v fail: %v", path, err)
+	}
+	t.Logf("Result %s", string(res))
+}
+
 func TestJsonRemove(t *testing.T) {
 	text := "{}"
 	err := ioutil.WriteFile(testFile, []byte(text), 0644)

--- a/sonic_data_client/json_client.go
+++ b/sonic_data_client/json_client.go
@@ -282,8 +282,10 @@ func (c *JsonClient) Add(path []string, value string) error {
 		}
 		if id == len(vlist) {
 			vlist = append(vlist, "")
-			ventry[path[2]] = vlist
+		} else {
+			vlist = append(vlist[:id+1], vlist[id:]...)
 		}
+		ventry[path[2]] = vlist
 		v, err := parseJson([]byte(value))
 		if err != nil {
 			return fmt.Errorf("Fail to parse %v", value)
@@ -295,6 +297,14 @@ func (c *JsonClient) Add(path []string, value string) error {
 	}
 		
 	return nil
+}
+
+func (c *JsonClient) Replace(path []string, value string) error {
+	err := c.Remove(path)
+	if err != nil {
+		return err
+	}
+	return c.Add(path, value)
 }
 
 func (c *JsonClient) Remove(path []string) error {

--- a/test/test_gnmi_configdb.py
+++ b/test/test_gnmi_configdb.py
@@ -229,7 +229,13 @@ class TestGNMIConfigDb:
 
     @pytest.mark.parametrize("test_data", test_data_update_normal)
     def test_gnmi_incremental_replace(self, test_data):
-        create_checkpoint(checkpoint_file, '{}')
+        test_config = {
+            "PORT": {
+                'Ethernet4': {'admin_status': 'down'},
+                'Ethernet8': {'admin_status': 'down'}
+            }
+        }
+        create_checkpoint(checkpoint_file, json.dumps(test_config))
 
         replace_list = []
         for i, data in enumerate(test_data):

--- a/test/test_gnmi_configdb_patch.py
+++ b/test/test_gnmi_configdb_patch.py
@@ -338,6 +338,738 @@ test_data_aaa_patch = [
     }
 ]
 
+test_data_bgp_prefix_patch = [
+    {
+        "test_name": "bgp_prefix_tc1_add_config",
+        "operations": [
+            {
+                "op": "update",
+                "path": "/sonic-db:CONFIG_DB/localhost/BGP_ALLOWED_PREFIXES",
+                "value": {
+                    "DEPLOYMENT_ID|0|1010:1010": {
+                        "prefixes_v4": [
+                            "10.20.0.0/16"
+                        ],
+                        "prefixes_v6": [
+                            "fc01:20::/64"
+                        ]
+                    }
+                }
+            }
+        ],
+        "origin_json": {},
+        "target_json": {
+            "BGP_ALLOWED_PREFIXES": {
+                "DEPLOYMENT_ID|0|1010:1010": {
+                    "prefixes_v4": [
+                        "10.20.0.0/16"
+                    ],
+                    "prefixes_v6": [
+                        "fc01:20::/64"
+                    ]
+                }
+            }
+        }
+    },
+    {
+        "test_name": "bgp_prefix_tc1_replace",
+        "operations": [
+            {
+                "op": "replace",
+                "path": "/sonic-db:CONFIG_DB/localhost/BGP_ALLOWED_PREFIXES/DEPLOYMENT_ID\\|0\\|1010:1010/prefixes_v6/0",
+                "value": "fc01:30::/64"
+            },
+            {
+                "op": "replace",
+                "path": "/sonic-db:CONFIG_DB/localhost/BGP_ALLOWED_PREFIXES/DEPLOYMENT_ID\\|0\\|1010:1010/prefixes_v4/0",
+                "value": "10.30.0.0/16"
+            }
+        ],
+        "origin_json": {
+            "BGP_ALLOWED_PREFIXES": {
+                "DEPLOYMENT_ID|0|1010:1010": {
+                    "prefixes_v4": [
+                        "10.20.0.0/16"
+                    ],
+                    "prefixes_v6": [
+                        "fc01:20::/64"
+                    ]
+                }
+            }
+        },
+        "target_json": {
+            "BGP_ALLOWED_PREFIXES": {
+                "DEPLOYMENT_ID|0|1010:1010": {
+                    "prefixes_v4": [
+                        "10.30.0.0/16"
+                    ],
+                    "prefixes_v6": [
+                        "fc01:30::/64"
+                    ]
+                }
+            }
+        }
+    },
+    {
+        "test_name": "bgp_prefix_tc1_add",
+        "operations": [
+            {
+                "op": "update",
+                "path": "/sonic-db:CONFIG_DB/localhost/BGP_ALLOWED_PREFIXES/DEPLOYMENT_ID\\|0\\|1010:1010/prefixes_v6/0",
+                "value": "fc01:30::/64"
+            },
+            {
+                "op": "update",
+                "path": "/sonic-db:CONFIG_DB/localhost/BGP_ALLOWED_PREFIXES/DEPLOYMENT_ID\\|0\\|1010:1010/prefixes_v4/0",
+                "value": "10.30.0.0/16"
+            }
+        ],
+        "origin_json": {
+            "BGP_ALLOWED_PREFIXES": {
+                "DEPLOYMENT_ID|0|1010:1010": {
+                    "prefixes_v4": [
+                        "10.20.0.0/16"
+                    ],
+                    "prefixes_v6": [
+                        "fc01:20::/64"
+                    ]
+                }
+            }
+        },
+        "target_json": {
+            "BGP_ALLOWED_PREFIXES": {
+                "DEPLOYMENT_ID|0|1010:1010": {
+                    "prefixes_v4": [
+                        "10.30.0.0/16", "10.20.0.0/16"
+                    ],
+                    "prefixes_v6": [
+                        "fc01:30::/64", "fc01:20::/64"
+                    ]
+                }
+            }
+        }
+    },
+    {
+        "test_name": "bgp_prefix_tc1_remove",
+        "operations": [
+            {
+                "op": "del",
+                "path": "/sonic-db:CONFIG_DB/localhost/BGP_ALLOWED_PREFIXES"
+            }
+        ],
+        "origin_json": {
+            "BGP_ALLOWED_PREFIXES": {
+                "DEPLOYMENT_ID|0|1010:1010": {
+                    "prefixes_v4": [
+                        "10.30.0.0/16", "10.20.0.0/16"
+                    ],
+                    "prefixes_v6": [
+                        "fc01:30::/64", "fc01:20::/64"
+                    ]
+                }
+            }
+        },
+        "target_json": {}
+    }
+]
+
+test_data_bgp_sentinel_patch = [
+    {
+        "test_name": "bgp_sentinel_tc1_add_config",
+        "operations": [
+            {
+                "op": "update",
+                "path": "/sonic-db:CONFIG_DB/localhost/BGP_SENTINELS",
+                "value": {
+                    "BGPSentinel": {
+                        "ip_range": [
+                            "10.10.20.0/24"
+                        ],
+                        "name": "BGPSentinel",
+                        "src_address": "10.5.5.5"
+                    },
+                    "BGPSentinelV6": {
+                        "ip_range": [
+                            "2603:10a1:30a:8000::/59"
+                        ],
+                        "name": "BGPSentinelV6",
+                        "src_address": "fc00:fc00:0:10::5"
+                    }
+                }
+            }
+        ],
+        "origin_json": {},
+        "target_json": {
+            "BGP_SENTINELS": {
+                "BGPSentinel": {
+                    "ip_range": [
+                        "10.10.20.0/24"
+                    ],
+                    "name": "BGPSentinel",
+                    "src_address": "10.5.5.5"
+                },
+                "BGPSentinelV6": {
+                    "ip_range": [
+                        "2603:10a1:30a:8000::/59"
+                    ],
+                    "name": "BGPSentinelV6",
+                    "src_address": "fc00:fc00:0:10::5"
+                }
+            }
+        }
+    },
+    {
+        "test_name": "bgp_sentinel_tc1_add_dummy_ip_range",
+        "operations": [
+            {
+                "op": "update",
+                "path": "/sonic-db:CONFIG_DB/localhost/BGP_SENTINELS/BGPSentinel/ip_range/1",
+                "value": "10.255.0.0/25"
+            },
+            {
+                "op": "update",
+                "path": "/sonic-db:CONFIG_DB/localhost/BGP_SENTINELS/BGPSentinelV6/ip_range/1",
+                "value": "cc98:2008:2012:2022::/64"
+            }
+        ],
+        "origin_json": {
+            "BGP_SENTINELS": {
+                "BGPSentinel": {
+                    "ip_range": [
+                        "10.10.20.0/24"
+                    ],
+                    "name": "BGPSentinel",
+                    "src_address": "10.5.5.5"
+                },
+                "BGPSentinelV6": {
+                    "ip_range": [
+                        "2603:10a1:30a:8000::/59"
+                    ],
+                    "name": "BGPSentinelV6",
+                    "src_address": "fc00:fc00:0:10::5"
+                }
+            }
+        },
+        "target_json": {
+            "BGP_SENTINELS": {
+                "BGPSentinel": {
+                    "ip_range": [
+                        "10.10.20.0/24", "10.255.0.0/25"
+                    ],
+                    "name": "BGPSentinel",
+                    "src_address": "10.5.5.5"
+                },
+                "BGPSentinelV6": {
+                    "ip_range": [
+                        "2603:10a1:30a:8000::/59", "cc98:2008:2012:2022::/64"
+                    ],
+                    "name": "BGPSentinelV6",
+                    "src_address": "fc00:fc00:0:10::5"
+                }
+            }
+        }
+    },
+    {
+        "test_name": "bgp_sentinel_tc1_rm_dummy_ip_range",
+        "operations": [
+            {
+                "op": "del",
+                "path": "/sonic-db:CONFIG_DB/localhost/BGP_SENTINELS/BGPSentinel/ip_range/1",
+                "value": "10.255.0.0/25"
+            },
+            {
+                "op": "del",
+                "path": "/sonic-db:CONFIG_DB/localhost/BGP_SENTINELS/BGPSentinelV6/ip_range/1",
+                "value": "cc98:2008:2012:2022::/64"
+            }
+        ],
+        "origin_json": {
+            "BGP_SENTINELS": {
+                "BGPSentinel": {
+                    "ip_range": [
+                        "10.10.20.0/24", "10.255.0.0/25"
+                    ],
+                    "name": "BGPSentinel",
+                    "src_address": "10.5.5.5"
+                },
+                "BGPSentinelV6": {
+                    "ip_range": [
+                        "2603:10a1:30a:8000::/59", "cc98:2008:2012:2022::/64"
+                    ],
+                    "name": "BGPSentinelV6",
+                    "src_address": "fc00:fc00:0:10::5"
+                }
+            }
+        },
+        "target_json": {
+            "BGP_SENTINELS": {
+                "BGPSentinel": {
+                    "ip_range": [
+                        "10.10.20.0/24"
+                    ],
+                    "name": "BGPSentinel",
+                    "src_address": "10.5.5.5"
+                },
+                "BGPSentinelV6": {
+                    "ip_range": [
+                        "2603:10a1:30a:8000::/59"
+                    ],
+                    "name": "BGPSentinelV6",
+                    "src_address": "fc00:fc00:0:10::5"
+                }
+            }
+        }
+    },
+    {
+        "test_name": "bgp_sentinel_tc1_replace_src_address",
+        "operations": [
+            {
+                "op": "replace",
+                "path": "/sonic-db:CONFIG_DB/localhost/BGP_SENTINELS/BGPSentinel/src_address",
+                "value": "10.1.0.33"
+            },
+            {
+                "op": "replace",
+                "path": "/sonic-db:CONFIG_DB/localhost/BGP_SENTINELS/BGPSentinelV6/src_address",
+                "value": "fc00:1::33"
+            }
+        ],
+        "origin_json": {
+            "BGP_SENTINELS": {
+                "BGPSentinel": {
+                    "ip_range": [
+                        "10.10.20.0/24"
+                    ],
+                    "name": "BGPSentinel",
+                    "src_address": "10.5.5.5"
+                },
+                "BGPSentinelV6": {
+                    "ip_range": [
+                        "2603:10a1:30a:8000::/59"
+                    ],
+                    "name": "BGPSentinelV6",
+                    "src_address": "fc00:fc00:0:10::5"
+                }
+            }
+        },
+        "target_json": {
+            "BGP_SENTINELS": {
+                "BGPSentinel": {
+                    "ip_range": [
+                        "10.10.20.0/24"
+                    ],
+                    "name": "BGPSentinel",
+                    "src_address": "10.1.0.33"
+                },
+                "BGPSentinelV6": {
+                    "ip_range": [
+                        "2603:10a1:30a:8000::/59"
+                    ],
+                    "name": "BGPSentinelV6",
+                    "src_address": "fc00:1::33"
+                }
+            }
+        }
+    }
+]
+
+test_data_bgp_speaker_patch = [
+    {
+        "test_name": "bgp_speaker_tc1_add_config",
+        "operations": [
+            {
+                "op": "update",
+                "path": "/sonic-db:CONFIG_DB/localhost/BGP_PEER_RANGE",
+                "value": {
+                    "BGPSLBPassive": {
+                        "ip_range": [
+                            "10.255.0.0/25"
+                        ],
+                        "name": "BGPSLBPassive",
+                        "src_address": "10.1.0.33"
+                    },
+                    "BGPSLBPassiveV6": {
+                        "ip_range": [
+                            "cc98:2008:2012:2022::/64"
+                        ],
+                        "name": "BGPSLBPassiveV6",
+                        "src_address": "fc00:1::33"
+                    }
+                }
+            }
+        ],
+        "origin_json": {},
+        "target_json": {
+            "BGP_PEER_RANGE": {
+                "BGPSLBPassive": {
+                    "ip_range": [
+                        "10.255.0.0/25"
+                    ],
+                    "name": "BGPSLBPassive",
+                    "src_address": "10.1.0.33"
+                },
+                "BGPSLBPassiveV6": {
+                    "ip_range": [
+                        "cc98:2008:2012:2022::/64"
+                    ],
+                    "name": "BGPSLBPassiveV6",
+                    "src_address": "fc00:1::33"
+                }
+            }
+        }
+    },
+    {
+        "test_name": "bgp_speaker_tc1_add_dummy_ip_range",
+        "operations": [
+            {
+                "op": "update",
+                "path": "/sonic-db:CONFIG_DB/localhost/BGP_PEER_RANGE/BGPSLBPassive/ip_range/1",
+                "value": "20.255.0.0/25"
+            },
+            {
+                "op": "update",
+                "path": "/sonic-db:CONFIG_DB/localhost/BGP_PEER_RANGE/BGPSLBPassiveV6/ip_range/1",
+                "value": "cc98:2008:2012:2222::/64"
+            }
+        ],
+        "origin_json": {
+            "BGP_PEER_RANGE": {
+                "BGPSLBPassive": {
+                    "ip_range": [
+                        "10.255.0.0/25"
+                    ],
+                    "name": "BGPSLBPassive",
+                    "src_address": "10.1.0.33"
+                },
+                "BGPSLBPassiveV6": {
+                    "ip_range": [
+                        "cc98:2008:2012:2022::/64"
+                    ],
+                    "name": "BGPSLBPassiveV6",
+                    "src_address": "fc00:1::33"
+                }
+            }
+        },
+        "target_json": {
+            "BGP_PEER_RANGE": {
+                "BGPSLBPassive": {
+                    "ip_range": [
+                        "10.255.0.0/25", "20.255.0.0/25"
+                    ],
+                    "name": "BGPSLBPassive",
+                    "src_address": "10.1.0.33"
+                },
+                "BGPSLBPassiveV6": {
+                    "ip_range": [
+                        "cc98:2008:2012:2022::/64", "cc98:2008:2012:2222::/64"
+                    ],
+                    "name": "BGPSLBPassiveV6",
+                    "src_address": "fc00:1::33"
+                }
+            }
+        }
+    },
+    {
+        "test_name": "bgp_speaker_tc1_rm_dummy_ip_range",
+        "operations": [
+            {
+                "op": "del",
+                "path": "/sonic-db:CONFIG_DB/localhost/BGP_PEER_RANGE/BGPSLBPassive/ip_range/1"
+            },
+            {
+                "op": "del",
+                "path": "/sonic-db:CONFIG_DB/localhost/BGP_PEER_RANGE/BGPSLBPassiveV6/ip_range/1"
+            }
+        ],
+        "origin_json": {
+            "BGP_PEER_RANGE": {
+                "BGPSLBPassive": {
+                    "ip_range": [
+                        "10.255.0.0/25", "20.255.0.0/25"
+                    ],
+                    "name": "BGPSLBPassive",
+                    "src_address": "10.1.0.33"
+                },
+                "BGPSLBPassiveV6": {
+                    "ip_range": [
+                        "cc98:2008:2012:2022::/64", "cc98:2008:2012:2222::/64"
+                    ],
+                    "name": "BGPSLBPassiveV6",
+                    "src_address": "fc00:1::33"
+                }
+            }
+        },
+        "target_json": {
+            "BGP_PEER_RANGE": {
+                "BGPSLBPassive": {
+                    "ip_range": [
+                        "10.255.0.0/25"
+                    ],
+                    "name": "BGPSLBPassive",
+                    "src_address": "10.1.0.33"
+                },
+                "BGPSLBPassiveV6": {
+                    "ip_range": [
+                        "cc98:2008:2012:2022::/64"
+                    ],
+                    "name": "BGPSLBPassiveV6",
+                    "src_address": "fc00:1::33"
+                }
+            }
+        }
+    },
+    {
+        "test_name": "bgp_speaker_tc1_replace_src_address",
+        "operations": [
+            {
+                "op": "replace",
+                "path": "/sonic-db:CONFIG_DB/localhost/BGP_PEER_RANGE/BGPSLBPassive/src_address",
+                "value": "10.2.0.33"
+            },
+            {
+                "op": "replace",
+                "path": "/sonic-db:CONFIG_DB/localhost/BGP_PEER_RANGE/BGPSLBPassiveV6/src_address",
+                "value": "fc00:2::33"
+            }
+        ],
+        "origin_json": {
+            "BGP_PEER_RANGE": {
+                "BGPSLBPassive": {
+                    "ip_range": [
+                        "10.255.0.0/25"
+                    ],
+                    "name": "BGPSLBPassive",
+                    "src_address": "10.1.0.33"
+                },
+                "BGPSLBPassiveV6": {
+                    "ip_range": [
+                        "cc98:2008:2012:2022::/64"
+                    ],
+                    "name": "BGPSLBPassiveV6",
+                    "src_address": "fc00:1::33"
+                }
+            }
+        },
+        "target_json": {
+            "BGP_PEER_RANGE": {
+                "BGPSLBPassive": {
+                    "ip_range": [
+                        "10.255.0.0/25"
+                    ],
+                    "name": "BGPSLBPassive",
+                    "src_address": "10.2.0.33"
+                },
+                "BGPSLBPassiveV6": {
+                    "ip_range": [
+                        "cc98:2008:2012:2022::/64"
+                    ],
+                    "name": "BGPSLBPassiveV6",
+                    "src_address": "fc00:2::33"
+                }
+            }
+        }
+    }
+]
+
+test_data_bgp_mon_patch = [
+    {
+        "test_name": "bgpmon_tc1_add_init",
+        "operations": [
+            {
+                "op": "update",
+                "path": "/sonic-db:CONFIG_DB/localhost/BGP_MONITORS",
+                "value": {
+                    "10.10.10.10": {
+                        "admin_status": "up",
+                        "asn": "66666",
+                        "holdtime": "180",
+                        "keepalive": "60",
+                        "local_addr": "10.10.10.20",
+                        "name": "BGPMonitor",
+                        "nhopself": "0",
+                        "rrclient": "0"
+                    }
+                }
+            }
+        ],
+        "origin_json": {},
+        "target_json": {
+            "BGP_MONITORS": {
+                "10.10.10.10": {
+                    "admin_status": "up",
+                    "asn": "66666",
+                    "holdtime": "180",
+                    "keepalive": "60",
+                    "local_addr": "10.10.10.20",
+                    "name": "BGPMonitor",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                }
+            }
+        }
+    },
+    {
+        "test_name": "bgpmon_tc1_add_duplicate",
+        "operations": [
+            {
+                "op": "update",
+                "path": "/sonic-db:CONFIG_DB/localhost/BGP_MONITORS/10.10.10.10",
+                "value": {
+                    "admin_status": "up",
+                    "asn": "66666",
+                    "holdtime": "180",
+                    "keepalive": "60",
+                    "local_addr": "10.10.10.20",
+                    "name": "BGPMonitor",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                }
+            }
+        ],
+        "origin_json": {
+            "BGP_MONITORS": {
+                "10.10.10.10": {
+                    "admin_status": "up",
+                    "asn": "66666",
+                    "holdtime": "180",
+                    "keepalive": "60",
+                    "local_addr": "10.10.10.20",
+                    "name": "BGPMonitor",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                }
+            }
+        },
+        "target_json": {
+            "BGP_MONITORS": {
+                "10.10.10.10": {
+                    "admin_status": "up",
+                    "asn": "66666",
+                    "holdtime": "180",
+                    "keepalive": "60",
+                    "local_addr": "10.10.10.20",
+                    "name": "BGPMonitor",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                }
+            }
+        }
+    },
+    {
+        "test_name": "bgpmon_tc1_admin_change",
+        "operations": [
+            {
+                "op": "replace",
+                "path": "/sonic-db:CONFIG_DB/localhost/BGP_MONITORS/10.10.10.10/admin_status",
+                "value": "down"
+            }
+        ],
+        "origin_json": {
+            "BGP_MONITORS": {
+                "10.10.10.10": {
+                    "admin_status": "up",
+                    "asn": "66666",
+                    "holdtime": "180",
+                    "keepalive": "60",
+                    "local_addr": "10.10.10.20",
+                    "name": "BGPMonitor",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                }
+            }
+        },
+        "target_json": {
+            "BGP_MONITORS": {
+                "10.10.10.10": {
+                    "admin_status": "down",
+                    "asn": "66666",
+                    "holdtime": "180",
+                    "keepalive": "60",
+                    "local_addr": "10.10.10.20",
+                    "name": "BGPMonitor",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                }
+            }
+        }
+    },
+    {
+        "test_name": "bgpmon_tc1_ip_change",
+        "operations": [
+            {
+                "op": "del",
+                "path": "/sonic-db:CONFIG_DB/localhost/BGP_MONITORS/10.10.10.10",
+            },
+            {
+                "op": "update",
+                "path": "/sonic-db:CONFIG_DB/localhost/BGP_MONITORS/10.10.10.30",
+                "value": {
+                    "admin_status": "up",
+                    "asn": "66666",
+                    "holdtime": "180",
+                    "keepalive": "60",
+                    "local_addr": "10.10.10.20",
+                    "name": "BGPMonitor",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                }
+            }
+        ],
+        "origin_json": {
+            "BGP_MONITORS": {
+                "10.10.10.10": {
+                    "admin_status": "up",
+                    "asn": "66666",
+                    "holdtime": "180",
+                    "keepalive": "60",
+                    "local_addr": "10.10.10.20",
+                    "name": "BGPMonitor",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                }
+            }
+        },
+        "target_json": {
+            "BGP_MONITORS": {
+                "10.10.10.30": {
+                    "admin_status": "up",
+                    "asn": "66666",
+                    "holdtime": "180",
+                    "keepalive": "60",
+                    "local_addr": "10.10.10.20",
+                    "name": "BGPMonitor",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                }
+            }
+        }
+    },
+    {
+        "test_name": "bgpmon_tc1_remove",
+        "operations": [
+            {
+                "op": "del",
+                "path": "/sonic-db:CONFIG_DB/localhost/BGP_MONITORS",
+            }
+        ],
+        "origin_json": {
+            "BGP_MONITORS": {
+                "10.10.10.10": {
+                    "admin_status": "up",
+                    "asn": "66666",
+                    "holdtime": "180",
+                    "keepalive": "60",
+                    "local_addr": "10.10.10.20",
+                    "name": "BGPMonitor",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                }
+            }
+        },
+        "target_json": {}
+    }
+]
+
 class TestGNMIConfigDbPatch:
 
     def common_test_handler(self, test_data):
@@ -383,10 +1115,30 @@ class TestGNMIConfigDbPatch:
         diff = jsonpatch.make_patch(result, test_data["target_json"])
         assert len(diff.patch) == 0, "%s failed, generated json: %s" % (test_data["test_name"], str(result))
 
-    @pytest.mark.parametrize("test_data", test_data_aaa_patch)
-    def test_gnmi_aaa_patch(self, test_data):
+    @pytest.mark.parametrize("test_data", test_data_bgp_prefix_patch)
+    def test_gnmi_bgp_prefix_patch(self, test_data):
         '''
-        Generate GNMI request for AAA and verify jsonpatch
+        Generate GNMI request for BGP prefix and verify jsonpatch
+        '''
+        self.common_test_handler(test_data)
+ 
+    @pytest.mark.parametrize("test_data", test_data_bgp_sentinel_patch)
+    def test_gnmi_bgp_sentinel_patch(self, test_data):
+        '''
+        Generate GNMI request for BGP sentinel and verify jsonpatch
         '''
         self.common_test_handler(test_data)
 
+    @pytest.mark.parametrize("test_data", test_data_bgp_speaker_patch)
+    def test_gnmi_bgp_speaker_patch(self, test_data):
+        '''
+        Generate GNMI request for BGP speaker and verify jsonpatch
+        '''
+        self.common_test_handler(test_data)
+
+    @pytest.mark.parametrize("test_data", test_data_bgp_mon_patch)
+    def test_gnmi_bgp_mon_patch(self, test_data):
+        '''
+        Generate GNMI request for BGP monitor and verify jsonpatch
+        '''
+        self.common_test_handler(test_data)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
GCU has verified BGP configuration, we need to verify that GNMI can support the same BGP configuration.
Because GCU end2end test uses jsonpatch replace operation for BGP, we need to update GNMI replace operation for incremental config.
And we should not generate jsonpatch from string.
Microsoft ADO: 27231737

#### How I did it
This unit test uses BGP configuration from GCU test.
This unit test generates GNMI request for BGP and use jsonpatch to verify patch file generated by GNMI server.
I also update gnmi replace implementation to support jsonpatch replace operation.
I generate jsonpatch from map.

#### How to verify it
Run gnmi unit test.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

