### PR TITLE
Add unit test for DHCP relay

### DIFF
--- a/test/test_gnmi_configdb_patch.py
+++ b/test/test_gnmi_configdb_patch.py
@@ -1222,6 +1222,85 @@ test_data_cacl_patch = [
     }
 ]
 
+test_data_dhcp_relay_patch = [
+    {
+        "test_name": "test_dhcp_relay_tc2_add_exist",
+        "operations": [
+            {
+                "op": "update",
+                "path": "/sonic-db:CONFIG_DB/localhost/VLAN/Vlan100/dhcp_servers/0",
+                "value": "192.0.100.1"
+            }
+        ],
+        "origin_json": {
+            "VLAN": {
+                "Vlan100": {
+                    "dhcp_servers": ["192.1.0.1"]
+                }
+            }
+        },
+        "target_json": {
+            "VLAN": {
+                "Vlan100": {
+                    "dhcp_servers": ["192.0.100.1", "192.1.0.1"]
+                }
+            }
+        }
+    },
+    {
+        "test_name": "test_dhcp_relay_tc3_add_and_rm",
+        "operations": [
+            {
+                "op": "del",
+                "path": "/sonic-db:CONFIG_DB/localhost/VLAN/Vlan100/dhcp_servers/3"
+            },
+            {
+                "op": "update",
+                "path": "/sonic-db:CONFIG_DB/localhost/VLAN/Vlan100/dhcp_servers/4",
+                "value": "192.0.200.5"
+            }
+        ],
+        "origin_json": {
+            "VLAN": {
+                "Vlan100": {
+                    "dhcp_servers": ["192.0.100.1", "192.0.100.2", "192.0.100.3", "192.0.100.4", "192.0.100.5"]
+                }
+            }
+        },
+        "target_json": {
+            "VLAN": {
+                "Vlan100": {
+                    "dhcp_servers": ["192.0.100.1", "192.0.100.2", "192.0.100.3", "192.0.100.5", "192.0.200.5"]
+                }
+            }
+        }
+    },
+    {
+        "test_name": "test_dhcp_relay_tc4_replace",
+        "operations": [
+            {
+                "op": "replace",
+                "path": "/sonic-db:CONFIG_DB/localhost/VLAN/Vlan100/dhcp_servers/0",
+                "value": "192.0.100.8"
+            }
+        ],
+        "origin_json": {
+            "VLAN": {
+                "Vlan100": {
+                    "dhcp_servers": ["192.0.100.1", "192.0.100.2", "192.0.100.3", "192.0.100.4", "192.0.100.5"]
+                }
+            }
+        },
+        "target_json": {
+            "VLAN": {
+                "Vlan100": {
+                    "dhcp_servers": ["192.0.100.8", "192.0.100.2", "192.0.100.3", "192.0.100.4", "192.0.100.5"]
+                }
+            }
+        }
+    }
+]
+
 class TestGNMIConfigDbPatch:
 
     def common_test_handler(self, test_data):
@@ -1306,5 +1385,12 @@ class TestGNMIConfigDbPatch:
     def test_gnmi_cacl_patch(self, test_data):
         '''
         Generate GNMI request for CACL and verify jsonpatch
+        '''
+        self.common_test_handler(test_data)
+
+    @pytest.mark.parametrize("test_data", test_data_dhcp_relay_patch)
+    def test_gnmi_dhcp_relay_patch(self, test_data):
+        '''
+        Generate GNMI request for dhcp relay and verify jsonpatch
         '''
         self.common_test_handler(test_data)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
GCU has verified DHCP relay configuration, we need to verify that GNMI can support the same DHCP relay configuration.
Microsoft ADO: 27231787

#### How I did it
This unit test uses DHCP relay configuration from GCU test.
This unit test generates GNMI request for DHCP relay and use jsonpatch to verify patch file generated by GNMI server.

#### How to verify it
Run gnmi unit test.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

