### PR TITLE
Add unit test for ECN config

### DIFF
--- a/test/test_gnmi_configdb_patch.py
+++ b/test/test_gnmi_configdb_patch.py
@@ -1704,6 +1704,47 @@ test_data_dynamic_acl_patch = [
     }
 ]
 
+test_data_ecn_config_patch = [
+    {
+        "test_name": "test_ecn_config_updates",
+        "operations": [
+            {
+                "op": "replace",
+                "path": "/sonic-db:CONFIG_DB/localhost/WRED_PROFILE/AZURE_LOSSLESS/green_min_threshold",
+                "value": "2000001"
+            },
+            {
+                "op": "replace",
+                "path": "/sonic-db:CONFIG_DB/localhost/WRED_PROFILE/AZURE_LOSSLESS/green_max_threshold",
+                "value": "10000001"
+            },
+            {
+                "op": "replace",
+                "path": "/sonic-db:CONFIG_DB/localhost/WRED_PROFILE/AZURE_LOSSLESS/green_drop_probability",
+                "value": "6"
+            },
+        ],
+        "origin_json": {
+            "WRED_PROFILE": {
+                "AZURE_LOSSLESS": {
+                    "green_min_threshold": "2000000",
+                    "green_max_threshold": "10000000",
+                    "green_drop_probability": "5"
+                }
+            }
+        },
+        "target_json": {
+            "WRED_PROFILE": {
+                "AZURE_LOSSLESS": {
+                    "green_min_threshold": "2000001",
+                    "green_max_threshold": "10000001",
+                    "green_drop_probability": "6"
+                }
+            }
+        }
+    }
+]
+
 class TestGNMIConfigDbPatch:
 
     def common_test_handler(self, test_data):
@@ -1802,5 +1843,12 @@ class TestGNMIConfigDbPatch:
     def test_gnmi_dynamic_acl_patch(self, test_data):
         '''
         Generate GNMI request for dynamic acl and verify jsonpatch
+        '''
+        self.common_test_handler(test_data)
+
+    @pytest.mark.parametrize("test_data", test_data_ecn_config_patch)
+    def test_gnmi_ecn_config_patch(self, test_data):
+        '''
+        Generate GNMI request for ecn config and verify jsonpatch
         '''
         self.common_test_handler(test_data)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
GCU has verified ECN config, we need to verify that GNMI can support the same ECN config.
Microsoft ADO: 27231797

#### How I did it
This unit test uses ECN config from GCU test.
This unit test generates GNMI request for DHCP relay and use jsonpatch to verify patch file generated by GNMI server.

#### How to verify it
Run GNMI unit test.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

