### PR TITLE
Add unit test for eth interface

### DIFF
--- a/test/test_gnmi_configdb_patch.py
+++ b/test/test_gnmi_configdb_patch.py
@@ -1745,6 +1745,212 @@ test_data_ecn_config_patch = [
     }
 ]
 
+test_data_eth_interface_patch = [
+    {
+        "test_name": "test_replace_lanes",
+        "operations": [
+            {
+                "op": "replace",
+                "path": "/sonic-db:CONFIG_DB/localhost/PORT/Ethernet0/lanes",
+                "value": "1,2,3,5"
+            }
+        ],
+        "origin_json": {
+            "PORT": {
+                "Ethernet0": {
+                    "lanes": "1,2,3,4"
+                }
+            }
+        },
+        "target_json": {
+            "PORT": {
+                "Ethernet0": {
+                    "lanes": "1,2,3,5"
+                }
+            }
+        }
+    },
+    {
+        "test_name": "test_replace_mtu",
+        "operations": [
+            {
+                "op": "replace",
+                "path": "/sonic-db:CONFIG_DB/localhost/PORT/Ethernet0/mtu",
+                "value": "1514"
+            }
+        ],
+        "origin_json": {
+            "PORT": {
+                "Ethernet0": {
+                    "mtu": "1500"
+                }
+            }
+        },
+        "target_json": {
+            "PORT": {
+                "Ethernet0": {
+                    "mtu": "1514"
+                }
+            }
+        }
+    },
+    {
+        "test_name": "test_toggle_pfc_asym",
+        "operations": [
+            {
+                "op": "replace",
+                "path": "/sonic-db:CONFIG_DB/localhost/PORT/Ethernet0/pfc_asym",
+                "value": "off"
+            }
+        ],
+        "origin_json": {
+            "PORT": {
+                "Ethernet0": {
+                    "pfc_asym": "on"
+                }
+            }
+        },
+        "target_json": {
+            "PORT": {
+                "Ethernet0": {
+                    "pfc_asym": "off"
+                }
+            }
+        }
+    },
+    {
+        "test_name": "test_replace_fec",
+        "operations": [
+            {
+                "op": "replace",
+                "path": "/sonic-db:CONFIG_DB/localhost/PORT/Ethernet0/fec",
+                "value": "rs"
+            }
+        ],
+        "origin_json": {
+            "PORT": {
+                "Ethernet0": {
+                    "fec": "fc"
+                }
+            }
+        },
+        "target_json": {
+            "PORT": {
+                "Ethernet0": {
+                    "fec": "rs"
+                }
+            }
+        }
+    },
+    {
+        "test_name": "test_update_valid_index",
+        "operations": [
+            {
+                "op": "replace",
+                "path": "/sonic-db:CONFIG_DB/localhost/PORT/Ethernet0/index",
+                "value": "2"
+            },
+            {
+                "op": "replace",
+                "path": "/sonic-db:CONFIG_DB/localhost/PORT/Ethernet4/index",
+                "value": "1"
+            }
+        ],
+        "origin_json": {
+            "PORT": {
+                "Ethernet0": {
+                    "index": "1"
+                },
+                "Ethernet4": {
+                    "index": "2"
+                }
+            }
+        },
+        "target_json": {
+            "PORT": {
+                "Ethernet0": {
+                    "index": "2"
+                },
+                "Ethernet4": {
+                    "index": "1"
+                }
+            }
+        }
+    },
+    {
+        "test_name": "test_update_speed",
+        "operations": [
+            {
+                "op": "replace",
+                "path": "/sonic-db:CONFIG_DB/localhost/PORT/Ethernet0/speed",
+                "value": "2000"
+            }
+        ],
+        "origin_json": {
+            "PORT": {
+                "Ethernet0": {
+                    "speed": "1000"
+                }
+            }
+        },
+        "target_json": {
+            "PORT": {
+                "Ethernet0": {
+                    "speed": "2000"
+                }
+            }
+        }
+    },
+    {
+        "test_name": "test_update_description",
+        "operations": [
+            {
+                "op": "replace",
+                "path": "/sonic-db:CONFIG_DB/localhost/PORT/Ethernet0/description",
+                "value": "Updated description"
+            }
+        ],
+        "origin_json": {
+            "PORT": {
+                "Ethernet0": {
+                    "description": ""
+                }
+            }
+        },
+        "target_json": {
+            "PORT": {
+                "Ethernet0": {
+                    "description": "Updated description"
+                }
+            }
+        }
+    },
+    {
+        "test_name": "test_eth_interface_admin_change",
+        "operations": [
+            {
+                "op": "replace",
+                "path": "/sonic-db:CONFIG_DB/localhost/PORT/Ethernet0/admin_status",
+                "value": "down"
+            }
+        ],
+        "origin_json": {
+            "PORT": {
+                "Ethernet0": {
+                    "admin_status": "up"
+                }
+            }
+        },
+        "target_json": {
+            "PORT": {
+                "Ethernet0": {
+                    "admin_status": "down"
+                }
+            }
+        }
+    }
+]
+
 class TestGNMIConfigDbPatch:
 
     def common_test_handler(self, test_data):
@@ -1850,5 +2056,12 @@ class TestGNMIConfigDbPatch:
     def test_gnmi_ecn_config_patch(self, test_data):
         '''
         Generate GNMI request for ecn config and verify jsonpatch
+        '''
+        self.common_test_handler(test_data)
+
+    @pytest.mark.parametrize("test_data", test_data_eth_interface_patch)
+    def test_gnmi_eth_interface_patch(self, test_data):
+        '''
+        Generate GNMI request for eth interface and verify jsonpatch
         '''
         self.common_test_handler(test_data)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
GCU has verified eth interface, we need to verify that GNMI can support the same eth interface.
Microsoft ADO: 27231799

#### How I did it
This unit test uses eth interface from GCU test.
This unit test generates GNMI request for eth interface and use jsonpatch to verify patch file generated by GNMI server.

#### How to verify it
Run GNMI unit test.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

