### PR TITLE
Add unit test for IPV6

### DIFF
--- a/test/test_gnmi_configdb_patch.py
+++ b/test/test_gnmi_configdb_patch.py
@@ -2067,6 +2067,109 @@ test_data_incremental_qos_patch = [
     }
 ]
 
+test_data_ipv6_patch = [
+    {
+        "test_name": "add_deleted_ipv6_neighbor",
+        "operations": [
+            {
+                "op": "update",
+                "path": "/sonic-db:CONFIG_DB/localhost/BGP_NEIGHBOR/fc00::7a",
+                "value": {
+                    "admin_status": "up",
+                    "asn": "64600",
+                    "holdtime": "10",
+                    "keepalive": "3",
+                    "local_addr": "fc00::79",
+                    "name": "ARISTA03T1",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                }
+            }
+        ],
+        "origin_json": {
+            "BGP_NEIGHBOR": {}
+        },
+        "target_json": {
+            "BGP_NEIGHBOR": {
+                "fc00::7a": {
+                    "admin_status": "up",
+                    "asn": "64600",
+                    "holdtime": "10",
+                    "keepalive": "3",
+                    "local_addr": "fc00::79",
+                    "name": "ARISTA03T1",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                }
+            }
+        }
+    },
+    {
+        "test_name": "ipv6_neighbor_admin_change",
+        "operations": [
+            {
+                "op": "replace",
+                "path": "/sonic-db:CONFIG_DB/localhost/BGP_NEIGHBOR/fc00::7a/admin_status",
+                "value": "down"
+            }
+        ],
+        "origin_json": {
+            "BGP_NEIGHBOR": {
+                "fc00::7a": {
+                    "admin_status": "up",
+                    "asn": "64600",
+                    "holdtime": "10",
+                    "keepalive": "3",
+                    "local_addr": "fc00::79",
+                    "name": "ARISTA03T1",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                }
+            }
+        },
+        "target_json": {
+            "BGP_NEIGHBOR": {
+                "fc00::7a": {
+                    "admin_status": "down",
+                    "asn": "64600",
+                    "holdtime": "10",
+                    "keepalive": "3",
+                    "local_addr": "fc00::79",
+                    "name": "ARISTA03T1",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                }
+            }
+        }
+    },
+    {
+        "test_name": "delete_ipv6_neighbor",
+        "operations": [
+            {
+                "op": "del",
+                "path": "/sonic-db:CONFIG_DB/localhost/BGP_NEIGHBOR/fc00::7a"
+            }
+        ],
+        "origin_json": {
+            "BGP_NEIGHBOR": {
+                "fc00::7a": {
+                    "admin_status": "up",
+                    "asn": "64600",
+                    "holdtime": "10",
+                    "keepalive": "3",
+                    "local_addr": "fc00::79",
+                    "name": "ARISTA03T1",
+                    "nhopself": "0",
+                    "rrclient": "0"
+                }
+            }
+        },
+        "target_json": {
+            "BGP_NEIGHBOR": {}
+        }
+    }
+]
+
 class TestGNMIConfigDbPatch:
 
     def common_test_handler(self, test_data):
@@ -2186,5 +2289,12 @@ class TestGNMIConfigDbPatch:
     def test_gnmi_incremental_qos_patch(self, test_data):
         '''
         Generate GNMI request for incremental qos and verify jsonpatch
+        '''
+        self.common_test_handler(test_data)
+
+    @pytest.mark.parametrize("test_data", test_data_ipv6_patch)
+    def test_gnmi_ipv6_patch(self, test_data):
+        '''
+        Generate GNMI request for ipv6 and verify jsonpatch
         '''
         self.common_test_handler(test_data)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
GCU has verified IPV6 configuration, we need to verify that GNMI can support the same IPV6 configuration.
Microsoft ADO: 27231810

#### How I did it
This unit test uses IPV6 configuration from GCU test.
This unit test generates GNMI request for IPV6 configuration and use jsonpatch to verify patch file generated by GNMI server.

#### How to verify it
Run GNMI unit test.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

