### PR TITLE
Add unit test for k8s config

### DIFF
--- a/test/test_gnmi_configdb_patch.py
+++ b/test/test_gnmi_configdb_patch.py
@@ -2170,6 +2170,144 @@ test_data_ipv6_patch = [
     }
 ]
 
+test_data_k8s_config_patch = [
+    {
+        "test_name": "K8SEMPTYTOHALFPATCH",
+        "operations": [
+            {
+                "op": "update",
+                "path": "/sonic-db:CONFIG_DB/localhost/KUBERNETES_MASTER",
+                "value": {"SERVER": {}}
+            }
+        ],
+        "origin_json": {
+            "KUBERNETES_MASTER": {}
+        },
+        "target_json": {
+            "KUBERNETES_MASTER": {
+                "SERVER": {}
+            }
+        }
+    },
+    {
+        "test_name": "K8SHALFTOFULLPATCH",
+        "operations": [
+            {
+                "op": "update",
+                "path": "/sonic-db:CONFIG_DB/localhost/KUBERNETES_MASTER/SERVER/disable",
+                "value": "false"
+            },
+            {
+                "op": "update",
+                "path": "/sonic-db:CONFIG_DB/localhost/KUBERNETES_MASTER/SERVER/ip",
+                "value": "k8svip.ap.gbl"
+            }
+        ],
+        "origin_json": {
+            "KUBERNETES_MASTER": {
+                "SERVER": {
+                    "disable": "true",
+                    "ip": ""
+                }
+            }
+        },
+        "target_json": {
+            "KUBERNETES_MASTER": {
+                "SERVER": {
+                    "disable": "false",
+                    "ip": "k8svip.ap.gbl"
+                }
+            }
+        }
+    },
+    {
+        "test_name": "K8SFULLTOHALFPATCH",
+        "operations": [
+            {
+                "op": "del",
+                "path": "/sonic-db:CONFIG_DB/localhost/KUBERNETES_MASTER/SERVER/disable"
+            },
+            {
+                "op": "del",
+                "path": "/sonic-db:CONFIG_DB/localhost/KUBERNETES_MASTER/SERVER/ip"
+            }
+        ],
+        "origin_json": {
+            "KUBERNETES_MASTER": {
+                "SERVER": {
+                    "disable": "true",
+                    "ip": ""
+                }
+            }
+        },
+        "target_json": {
+            "KUBERNETES_MASTER": {
+                "SERVER": {}
+            }
+        }
+    },
+    {
+        "test_name": "K8SHALFTOEMPTYPATCH",
+        "operations": [
+            {
+                "op": "del",
+                "path": "/sonic-db:CONFIG_DB/localhost/KUBERNETES_MASTER"
+            }
+        ],
+        "origin_json": {
+            "KUBERNETES_MASTER": {
+                "SERVER": {
+                    "disable": "true",
+                    "ip": ""
+                }
+            }
+        },
+        "target_json": {}
+    },
+    {
+        "test_name": "K8SHALFTOEMPTYPATCH",
+        "operations": [
+            {
+                "op": "del",
+                "path": "/sonic-db:CONFIG_DB/localhost/KUBERNETES_MASTER"
+            }
+        ],
+        "origin_json": {
+            "KUBERNETES_MASTER": {
+                "SERVER": {
+                    "disable": "true",
+                    "ip": ""
+                }
+            }
+        },
+        "target_json": {}
+    },
+    {
+        "test_name": "K8SEMPTYTOFULLPATCH",
+        "operations": [
+            {
+                "op": "update",
+                "path": "/sonic-db:CONFIG_DB/localhost/KUBERNETES_MASTER",
+                "value": {
+                    "SERVER": {
+                        "disable": "false",
+                        "ip": "k8svip.ap.gbl"
+                    }
+                }
+            }
+        ],
+        "origin_json": {},
+        "target_json": {
+            "KUBERNETES_MASTER": {
+                "SERVER": {
+                    "disable": "false",
+                    "ip": "k8svip.ap.gbl"
+                }
+            }
+        }
+    }
+]
+
 class TestGNMIConfigDbPatch:
 
     def common_test_handler(self, test_data):
@@ -2296,5 +2434,12 @@ class TestGNMIConfigDbPatch:
     def test_gnmi_ipv6_patch(self, test_data):
         '''
         Generate GNMI request for ipv6 and verify jsonpatch
+        '''
+        self.common_test_handler(test_data)
+
+    @pytest.mark.parametrize("test_data", test_data_k8s_config_patch)
+    def test_gnmi_k8s_config_patch(self, test_data):
+        '''
+        Generate GNMI request for k8s config and verify jsonpatch
         '''
         self.common_test_handler(test_data)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
GCU has verified K8S configuration, we need to verify that GNMI can support the same K8S configuration.
Microsoft ADO: 27231816

#### How I did it
This unit test uses K8S configuration from GCU test.
This unit test generates GNMI request for K8S configuration and use jsonpatch to verify patch file generated by GNMI server.

#### How to verify it
Run GNMI unit test.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

