### PR TITLE
Add unit test for monitor config

### DIFF
--- a/test/test_gnmi_configdb_patch.py
+++ b/test/test_gnmi_configdb_patch.py
@@ -2440,6 +2440,101 @@ test_data_mmu_dynamic_threshold_patch = [
     }
 ]
 
+test_data_monitor_config_patch = [
+    {
+        "test_name": "test_monitor_config_tc1_suite",
+        "operations": [
+            {
+                "op": "update",
+                "path": "/sonic-db:CONFIG_DB/localhost/ACL_TABLE/EVERFLOW_DSCP",
+                "value": {
+                    "policy_desc": "EVERFLOW_DSCP",
+                    "ports": ["Ethernet0"],
+                    "stage": "ingress",
+                    "type": "MIRROR_DSCP"
+                }
+            },
+            {
+                "op": "update",
+                "path": "/sonic-db:CONFIG_DB/localhost/ACL_RULE",
+                "value": {
+                    "EVERFLOW_DSCP|RULE_1": {
+                        "DSCP": "5",
+                        "MIRROR_INGRESS_ACTION": "mirror_session_dscp",
+                        "PRIORITY": "9999"
+                    }
+                }
+            },
+            {
+                "op": "update",
+                "path": "/sonic-db:CONFIG_DB/localhost/MIRROR_SESSION",
+                "value": {
+                    "mirror_session_dscp": {
+                        "dscp": "5",
+                        "dst_ip": "2.2.2.2",
+                        "policer": "policer_dscp",
+                        "src_ip": "1.1.1.1",
+                        "ttl": "32",
+                        "type": "ERSPAN"
+                    }
+                }
+            },
+            {
+                "op": "update",
+                "path": "/sonic-db:CONFIG_DB/localhost/POLICER",
+                "value": {
+                    "policer_dscp": {
+                        "meter_type": "bytes",
+                        "mode": "sr_tcm",
+                        "cir": "12500000",
+                        "cbs": "12500000",
+                        "red_packet_action": "drop"
+                    }
+                }
+            }
+        ],
+        "origin_json": {
+            "ACL_TABLE": {}
+        },
+        "target_json": {
+            "ACL_TABLE": {
+                "EVERFLOW_DSCP": {
+                    "policy_desc": "EVERFLOW_DSCP",
+                    "ports": ["Ethernet0"],
+                    "stage": "ingress",
+                    "type": "MIRROR_DSCP"
+                }
+            },
+            "ACL_RULE": {
+                "EVERFLOW_DSCP|RULE_1": {
+                    "DSCP": "5",
+                    "MIRROR_INGRESS_ACTION": "mirror_session_dscp",
+                    "PRIORITY": "9999"
+                }
+            },
+            "MIRROR_SESSION": {
+                "mirror_session_dscp": {
+                    "dscp": "5",
+                    "dst_ip": "2.2.2.2",
+                    "policer": "policer_dscp",
+                    "src_ip": "1.1.1.1",
+                    "ttl": "32",
+                    "type": "ERSPAN"
+                }
+            },
+            "POLICER": {
+                "policer_dscp": {
+                    "meter_type": "bytes",
+                    "mode": "sr_tcm",
+                    "cir": "12500000",
+                    "cbs": "12500000",
+                    "red_packet_action": "drop"
+                }
+            }
+        }
+    }
+]
+
 class TestGNMIConfigDbPatch:
 
     def common_test_handler(self, test_data):
@@ -2587,5 +2682,12 @@ class TestGNMIConfigDbPatch:
     def test_gnmi_mmu_dynamic_threshold_patch(self, test_data):
         '''
         Generate GNMI request for mmu dynamic threshold and verify jsonpatch
+        '''
+        self.common_test_handler(test_data)
+
+    @pytest.mark.parametrize("test_data", test_data_monitor_config_patch)
+    def test_gnmi_monitor_config_patch(self, test_data):
+        '''
+        Generate GNMI request for monitor config and verify jsonpatch
         '''
         self.common_test_handler(test_data)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
GCU has verified monitor config, we need to verify that GNMI can support the same monitor config.
Microsoft ADO: 27231840

#### How I did it
This unit test uses monitor config from GCU test.
This unit test generates GNMI request for monitor config and use jsonpatch to verify patch file generated by GNMI server.

#### How to verify it
Run GNMI unit test.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

