### PR TITLE
Add unit test for ntp

### DIFF
--- a/test/test_gnmi_configdb_patch.py
+++ b/test/test_gnmi_configdb_patch.py
@@ -2535,6 +2535,90 @@ test_data_monitor_config_patch = [
     }
 ]
 
+test_data_ntp_patch = [
+    {
+        "test_name": "ntp_server_tc1_add_config",
+        "operations": [
+            {
+                "op": "update",
+                "path": "/sonic-db:CONFIG_DB/localhost/NTP_SERVER",
+                "value": {
+                    "10.0.0.1": {
+                        "resolve_as": "10.0.0.1",
+                        "association_type": "server",
+                        "iburst": "on"
+                    }
+                }
+            }
+        ],
+        "origin_json": {},
+        "target_json": {
+            "NTP_SERVER": {
+                "10.0.0.1": {
+                    "resolve_as": "10.0.0.1",
+                    "association_type": "server",
+                    "iburst": "on"
+                }
+            }
+        }
+    },
+    {
+        "test_name": "ntp_server_tc1_replace",
+        "operations": [
+            {
+                "op": "del",
+                "path": "/sonic-db:CONFIG_DB/localhost/NTP_SERVER/10.0.0.1"
+            },
+            {
+                "op": "update",
+                "path": "/sonic-db:CONFIG_DB/localhost/NTP_SERVER/10.0.0.2",
+                "value": {
+                    "resolve_as": "10.0.0.2",
+                    "association_type": "server",
+                    "iburst": "on"
+                }
+            }
+        ],
+        "origin_json": {
+            "NTP_SERVER": {
+                "10.0.0.1": {
+                    "resolve_as": "10.0.0.1",
+                    "association_type": "server",
+                    "iburst": "on"
+                }
+            }
+        },
+        "target_json": {
+            "NTP_SERVER": {
+                "10.0.0.1": {
+                    "resolve_as": "10.0.0.2",
+                    "association_type": "server",
+                    "iburst": "on"
+                }
+            }
+        }
+    },
+    {
+        "test_name": "ntp_server_tc1_remove",
+        "operations": [
+            {
+                "op": "del",
+                "path": "/sonic-db:CONFIG_DB/localhost/NTP_SERVER"
+            }
+        ],
+        "origin_json": {
+            "NTP_SERVER": {
+                "10.0.0.1": {
+                    "resolve_as": "10.0.0.1",
+                    "association_type": "server",
+                    "iburst": "on"
+                }
+            }
+        },
+        "target_json": {}
+    }
+]
+
 class TestGNMIConfigDbPatch:
 
     def common_test_handler(self, test_data):


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
GCU has verified ntp config, we need to verify that GNMI can support the same ntp config.
Microsoft ADO: 27231846

#### How I did it
This unit test uses ntp config from GCU test.
This unit test generates GNMI request for ntp config and use jsonpatch to verify patch file generated by GNMI server.

#### How to verify it
Run GNMI unit test.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

