### PR TITLE
Add unit test for pfcwd status

### DIFF
--- a/test/test_gnmi_configdb_patch.py
+++ b/test/test_gnmi_configdb_patch.py
@@ -2644,6 +2644,79 @@ test_data_pfcwd_interval_patch = [
     }
 ]
 
+test_data_pfcwd_status_patch = [
+    {
+        "test_name": "test_start_pfcwd",
+        "operations": [
+            {
+                "op": "update",
+                "path": "/sonic-db:CONFIG_DB/localhost/PFC_WD/Ethernet0",
+                "value": {
+                    "action": "drop",
+                    "detection_time": "400",
+                    "restoration_time": "400"
+                }
+            },
+            {
+                "op": "update",
+                "path": "/sonic-db:CONFIG_DB/localhost/PFC_WD/Ethernet4",
+                "value": {
+                    "action": "drop",
+                    "detection_time": "400",
+                    "restoration_time": "400"
+                }
+            }
+        ],
+        "origin_json": {
+            "PFC_WD": {}
+        },
+        "target_json": {
+            "PFC_WD": {
+                "Ethernet0": {
+                    "action": "drop",
+                    "detection_time": "400",
+                    "restoration_time": "400"
+                },
+                "Ethernet4": {
+                    "action": "drop",
+                    "detection_time": "400",
+                    "restoration_time": "400"
+                }
+            }
+        }
+    },
+    {
+        "test_name": "test_stop_pfcwd",
+        "operations": [
+            {
+                "op": "del",
+                "path": "/sonic-db:CONFIG_DB/localhost/PFC_WD/Ethernet0"
+            },
+            {
+                "op": "del",
+                "path": "/sonic-db:CONFIG_DB/localhost/PFC_WD/Ethernet4"
+            }
+        ],
+        "origin_json": {
+            "PFC_WD": {
+                "Ethernet0": {
+                    "action": "drop",
+                    "detection_time": "400",
+                    "restoration_time": "400"
+                },
+                "Ethernet4": {
+                    "action": "drop",
+                    "detection_time": "400",
+                    "restoration_time": "400"
+                }
+            }
+        },
+        "target_json": {
+            "PFC_WD": {}
+        }
+    }
+]
+
 class TestGNMIConfigDbPatch:
 
     def common_test_handler(self, test_data):
@@ -2805,5 +2878,12 @@ class TestGNMIConfigDbPatch:
     def test_gnmi_pfcwd_interval_patch(self, test_data):
         '''
         Generate GNMI request for pfcwd interval and verify jsonpatch
+        '''
+        self.common_test_handler(test_data)
+
+    @pytest.mark.parametrize("test_data", test_data_pfcwd_status_patch)
+    def test_gnmi_pfcwd_status_patch(self, test_data):
+        '''
+        Generate GNMI request for pfcwd status and verify jsonpatch
         '''
         self.common_test_handler(test_data)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
GCU has verified pfcwd status config, we need to verify that GNMI can support the same pfcwd status config.
Microsoft ADO: 27231866

#### How I did it
This unit test uses pfcwd status config from GCU test.
This unit test generates GNMI request for pfcwd status config and use jsonpatch to verify patch file generated by GNMI server.

#### How to verify it
Run GNMI unit test.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

