### PR TITLE
Add unit test for pg headroom

### DIFF
--- a/test/test_gnmi_configdb_patch.py
+++ b/test/test_gnmi_configdb_patch.py
@@ -2717,6 +2717,33 @@ test_data_pfcwd_status_patch = [
     }
 ]
 
+test_data_pg_headroom_patch = [
+    {
+        "test_name": "test_pg_headroom_update",
+        "operations": [
+            {
+                "op": "replace",
+                "path": "/sonic-db:CONFIG_DB/localhost/BUFFER_PROFILE/pg_lossless_100000_300m_profile/xoff",
+                "value": "160001"
+            }
+        ],
+        "origin_json": {
+            "BUFFER_PROFILE": {
+                "pg_lossless_100000_300m_profile": {
+                    "xoff": "160000"
+                },
+            }
+        },
+        "target_json": {
+            "BUFFER_PROFILE": {
+                "pg_lossless_100000_300m_profile": {
+                    "xoff": "160001"
+                },
+            }
+        }
+    }
+]
+
 class TestGNMIConfigDbPatch:
 
     def common_test_handler(self, test_data):
@@ -2885,5 +2912,12 @@ class TestGNMIConfigDbPatch:
     def test_gnmi_pfcwd_status_patch(self, test_data):
         '''
         Generate GNMI request for pfcwd status and verify jsonpatch
+        '''
+        self.common_test_handler(test_data)
+
+    @pytest.mark.parametrize("test_data", test_data_pg_headroom_patch)
+    def test_gnmi_pg_headroom_patch(self, test_data):
+        '''
+        Generate GNMI request for pg headroom and verify jsonpatch
         '''
         self.common_test_handler(test_data)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
GCU has verified pg headroom config, we need to verify that GNMI can support the same pg headroom config.
Microsoft ADO: 27231872

#### How I did it
This unit test uses pg headroom config from GCU test.
This unit test generates GNMI request for pg headroom config and use jsonpatch to verify patch file generated by GNMI server.

#### How to verify it
Run GNMI unit test

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

