### PR TITLE
Add unit test for portchannel interface

### DIFF
--- a/test/test_gnmi_configdb_patch.py
+++ b/test/test_gnmi_configdb_patch.py
@@ -2744,6 +2744,111 @@ test_data_pg_headroom_patch = [
     }
 ]
 
+test_data_portchannel_interface_patch = [
+    {
+        "test_name": "portchannel_interface_tc1_add_and_rm",
+        "operations": [
+            {
+                "op": "del",
+                "path": r"/sonic-db:CONFIG_DB/localhost/PORTCHANNEL_INTERFACE/PortChannel101\|10.0.0.150~131"
+            },
+            {
+                "op": "del",
+                "path": r"/sonic-db:CONFIG_DB/localhost/PORTCHANNEL_INTERFACE/PortChannel101\|fc00::170~1126"
+            },
+            {
+                "op": "update",
+                "path": r"/sonic-db:CONFIG_DB/localhost/PORTCHANNEL_INTERFACE/PortChannel101\|10.0.0.151~131",
+                "value": {}
+            },
+            {
+                "op": "update",
+                "path": r"/sonic-db:CONFIG_DB/localhost/PORTCHANNEL_INTERFACE/PortChannel101\|fc00::171~1126",
+                "value": {}
+            }
+        ],
+        "origin_json": {
+            "PORTCHANNEL_INTERFACE": {
+                "PortChannel101|10.0.0.150/31": {},
+                "PortChannel101|fc00::170/126": {},
+            }
+        },
+        "target_json": {
+            "PORTCHANNEL_INTERFACE": {
+                "PortChannel101|10.0.0.151/31": {},
+                "PortChannel101|fc00::171/126": {},
+            }
+        }
+    },
+    {
+        "test_name": "portchannel_interface_tc2_replace",
+        "operations": [
+            {
+                "op": "replace",
+                "path": "/sonic-db:CONFIG_DB/localhost/PORTCHANNEL_INTERFACE/PortChannel101/mtu",
+                "value": "3324"
+            },
+            {
+                "op": "replace",
+                "path": "/sonic-db:CONFIG_DB/localhost/PORTCHANNEL_INTERFACE/PortChannel101/min_links",
+                "value": "2"
+            },
+            {
+                "op": "replace",
+                "path": "/sonic-db:CONFIG_DB/localhost/PORTCHANNEL_INTERFACE/PortChannel101/admin_status",
+                "value": "down"
+            }
+        ],
+        "origin_json": {
+            "PORTCHANNEL_INTERFACE": {
+                "PortChannel101": {
+                    "mtu": "1500",
+                    "min_links": "1",
+                    "admin_status": "up"
+                }
+            }
+        },
+        "target_json": {
+            "PORTCHANNEL_INTERFACE": {
+                "PortChannel101": {
+                    "mtu": "3324",
+                    "min_links": "2",
+                    "admin_status": "down"
+                }
+            }
+        }
+    },
+    {
+        "test_name": "portchannel_interface_tc2_incremental",
+        "operations": [
+            {
+                "op": "update",
+                "path": "/sonic-db:CONFIG_DB/localhost/PORTCHANNEL_INTERFACE/PortChannel101/description",
+                "value": "Description for PortChannel101"
+            }
+        ],
+        "origin_json": {
+            "PORTCHANNEL_INTERFACE": {
+                "PortChannel101": {
+                    "mtu": "1500",
+                    "min_links": "1",
+                    "admin_status": "up"
+                }
+            }
+        },
+        "target_json": {
+            "PORTCHANNEL_INTERFACE": {
+                "PortChannel101": {
+                    "mtu": "1500",
+                    "min_links": "1",
+                    "admin_status": "up",
+                    "description": "Description for PortChannel101"
+                }
+            }
+        }
+    }
+]
+
 class TestGNMIConfigDbPatch:
 
     def common_test_handler(self, test_data):
@@ -2919,5 +3024,12 @@ class TestGNMIConfigDbPatch:
     def test_gnmi_pg_headroom_patch(self, test_data):
         '''
         Generate GNMI request for pg headroom and verify jsonpatch
+        '''
+        self.common_test_handler(test_data)
+
+    @pytest.mark.parametrize("test_data", test_data_portchannel_interface_patch)
+    def test_gnmi_portchannel_interface_patch(self, test_data):
+        '''
+        Generate GNMI request for portchannel interface and verify jsonpatch
         '''
         self.common_test_handler(test_data)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
GCU has verified portchannel interface config, we need to verify that GNMI can support the same portchannel interface config.
Microsoft ADO: 27231875

#### How I did it
This unit test uses portchannel interface config from GCU test.
This unit test generates GNMI request for portchannel interface config and use jsonpatch to verify patch file generated by GNMI server.

#### How to verify it
Run GNMI unit test

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

