### PR TITLE
Add unit test for syslog config

### DIFF
--- a/test/test_gnmi_configdb_patch.py
+++ b/test/test_gnmi_configdb_patch.py
@@ -2849,6 +2849,88 @@ test_data_portchannel_interface_patch = [
     }
 ]
 
+test_data_syslog_patch = [
+    {
+        "test_name": "syslog_server_tc1_add_init",
+        "operations": [
+            {
+                "op": "update",
+                "path": "/sonic-db:CONFIG_DB/localhost/SYSLOG_SERVER",
+                "value": {
+                    "10.0.0.5": {},
+                    "cc98:2008::1": {}
+                }
+            }
+        ],
+        "origin_json": {
+            "SYSLOG_SERVER": {}
+        },
+        "target_json": {
+            "SYSLOG_SERVER": {
+                "10.0.0.5": {},
+                "cc98:2008::1": {}
+            }
+        }
+    },
+    {
+        "test_name": "syslog_server_tc1_replace",
+        "operations": [
+            {
+                "op": "del",
+                "path": "/sonic-db:CONFIG_DB/localhost/SYSLOG_SERVER/10.0.0.5"
+            },
+            {
+                "op": "del",
+                "path": "/sonic-db:CONFIG_DB/localhost/SYSLOG_SERVER/cc98:2008::1"
+            },
+            {
+                "op": "update",
+                "path": "/sonic-db:CONFIG_DB/localhost/SYSLOG_SERVER/10.0.0.6",
+                "value": {}
+            },
+            {
+                "op": "update",
+                "path": "/sonic-db:CONFIG_DB/localhost/SYSLOG_SERVER/cc98:2008::2",
+                "value": {}
+            }
+        ],
+        "origin_json": {
+            "SYSLOG_SERVER": {
+                "10.0.0.5": {},
+                "cc98:2008::1": {}
+            }
+        },
+        "target_json": {
+            "SYSLOG_SERVER": {
+                "10.0.0.6": {},
+                "cc98:2008::2": {}
+            }
+        }
+    },
+    {
+        "test_name": "syslog_server_tc1_remove",
+        "operations": [
+            {
+                "op": "del",
+                "path": "/sonic-db:CONFIG_DB/localhost/SYSLOG_SERVER/10.0.0.5"
+            },
+            {
+                "op": "del",
+                "path": "/sonic-db:CONFIG_DB/localhost/SYSLOG_SERVER/cc98:2008::1"
+            }
+        ],
+        "origin_json": {
+            "SYSLOG_SERVER": {
+                "10.0.0.5": {},
+                "cc98:2008::1": {}
+            }
+        },
+        "target_json": {
+            "SYSLOG_SERVER": {}
+        }
+    }
+]
+
 class TestGNMIConfigDbPatch:
 
     def common_test_handler(self, test_data):
@@ -3031,5 +3113,12 @@ class TestGNMIConfigDbPatch:
     def test_gnmi_portchannel_interface_patch(self, test_data):
         '''
         Generate GNMI request for portchannel interface and verify jsonpatch
+        '''
+        self.common_test_handler(test_data)
+
+    @pytest.mark.parametrize("test_data", test_data_syslog_patch)
+    def test_gnmi_syslog_patch(self, test_data):
+        '''
+        Generate GNMI request for syslog and verify jsonpatch
         '''
         self.common_test_handler(test_data)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
GCU has verified syslog config, we need to verify that GNMI can support the same syslog config.
Microsoft ADO: 27231882

#### How I did it
This unit test uses syslog config from GCU test.
This unit test generates GNMI request for syslog config and use jsonpatch to verify patch file generated by GNMI server.

#### How to verify it
Run GNMI unit test

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

