### PR TITLE
Add unit test for vlan interface

### DIFF
--- a/test/test_gnmi_configdb_patch.py
+++ b/test/test_gnmi_configdb_patch.py
@@ -2931,6 +2931,152 @@ test_data_syslog_patch = [
     }
 ]
 
+test_data_vlan_interface_patch = [
+    {
+        "test_name": "vlan_interface_tc1_add_new",
+        "operations": [
+            {
+                "op": "update",
+                "path": r"/sonic-db:CONFIG_DB/localhost/VLAN_INTERFACE/Vlan1001",
+                "value": {}
+            },
+            {
+                "op": "update",
+                "path": r"/sonic-db:CONFIG_DB/localhost/VLAN_INTERFACE/Vlan1001\|192.168.8.1~121",
+                "value": {}
+            },
+            {
+                "op": "update",
+                "path": r"/sonic-db:CONFIG_DB/localhost/VLAN_INTERFACE/Vlan1001\|fc02:2000::1~164",
+                "value": {}
+            },
+            {
+                "op": "update",
+                "path": r"/sonic-db:CONFIG_DB/localhost/VLAN/Vlan1001",
+                "value": {
+                    "vlanid": "1001"
+                }
+            }
+        ],
+        "origin_json": {
+            "VLAN_INTERFACE": {},
+            "VLAN": {}
+        },
+        "target_json": {
+            "VLAN_INTERFACE": {
+                "Vlan1001": {},
+                "Vlan1001|192.168.8.1/21": {},
+                "Vlan1001|fc02:2000::1/64": {}
+            },
+            "VLAN": {
+                "Vlan1001": {
+                    "vlanid": "1001"
+                }
+            }
+        }
+    },
+    {
+        "test_name": "vlan_interface_tc1_add_replace",
+        "operations": [
+            {
+                "op": "del",
+                "path": r"/sonic-db:CONFIG_DB/localhost/VLAN_INTERFACE/Vlan1001\|192.168.8.1~121"
+            },
+            {
+                "op": "del",
+                "path": r"/sonic-db:CONFIG_DB/localhost/VLAN_INTERFACE/Vlan1001\|fc02:2000::1~164"
+            },
+            {
+                "op": "update",
+                "path": r"/sonic-db:CONFIG_DB/localhost/VLAN_INTERFACE/Vlan1001\|192.168.8.2~121",
+                "value": {}
+            },
+            {
+                "op": "update",
+                "path": r"/sonic-db:CONFIG_DB/localhost/VLAN_INTERFACE/Vlan1001\|fc02:2000::2~164",
+                "value": {}
+            }
+        ],
+        "origin_json": {
+            "VLAN_INTERFACE": {
+                "Vlan1001": {},
+                "Vlan1001|192.168.8.1/21": {},
+                "Vlan1001|fc02:2000::1/64": {}
+            },
+            "VLAN": {
+                "Vlan1001": {
+                    "vlanid": "1001"
+                }
+            }
+        },
+        "target_json": {
+            "VLAN_INTERFACE": {
+                "Vlan1001": {},
+                "Vlan1001|192.168.8.2/21": {},
+                "Vlan1001|fc02:2000::2/64": {}
+            },
+            "VLAN": {
+                "Vlan1001": {
+                    "vlanid": "1001"
+                }
+            }
+        }
+    },
+    {
+        "test_name": "vlan_interface_tc1_remove",
+        "operations": [
+            {
+                "op": "del",
+                "path": "/sonic-db:CONFIG_DB/localhost/VLAN_INTERFACE"
+            }
+        ],
+        "origin_json": {
+            "VLAN_INTERFACE": {
+                "Vlan1001": {},
+                "Vlan1001|192.168.8.1/21": {},
+                "Vlan1001|fc02:2000::1/64": {}
+            },
+            "VLAN": {
+                "Vlan1001": {
+                    "vlanid": "1001"
+                }
+            }
+        },
+        "target_json": {
+            "VLAN": {
+                "Vlan1001": {
+                    "vlanid": "1001"
+                }
+            }
+        }
+    },
+    {
+        "test_name": "test_vlan_interface_tc2_incremental_change",
+        "operations": [
+            {
+                "op": "update",
+                "path": "/sonic-db:CONFIG_DB/localhost/VLAN/Vlan1001/description",
+                "value": "incremental test for Vlan1001"
+            }
+        ],
+        "origin_json": {
+            "VLAN": {
+                "Vlan1001": {
+                    "vlanid": "1001"
+                }
+            }
+        },
+        "target_json": {
+            "VLAN": {
+                "Vlan1001": {
+                    "vlanid": "1001",
+                    "description": "incremental test for Vlan1001"
+                }
+            }
+        }
+    }
+]
+
 class TestGNMIConfigDbPatch:
 
     def common_test_handler(self, test_data):
@@ -3120,5 +3266,12 @@ class TestGNMIConfigDbPatch:
     def test_gnmi_syslog_patch(self, test_data):
         '''
         Generate GNMI request for syslog and verify jsonpatch
+        '''
+        self.common_test_handler(test_data)
+
+    @pytest.mark.parametrize("test_data", test_data_vlan_interface_patch)
+    def test_gnmi_vlan_interface_patch(self, test_data):
+        '''
+        Generate GNMI request for vlan interface and verify jsonpatch
         '''
         self.common_test_handler(test_data)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
GCU has verified vlan interface config, we need to verify that GNMI can support the same vlan interface config.
Microsoft ADO: 27231884

#### How I did it
This unit test uses vlan interface config from GCU test.
This unit test generates GNMI request for vlan interface config and use jsonpatch to verify patch file generated by GNMI server.

#### How to verify it
Run GNMI unit test

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

