### PR TITLE
Improve GNMI native to support COUNTERS_DB

### DIFF
--- a/sonic_data_client/mixed_db_client.go
+++ b/sonic_data_client/mixed_db_client.go
@@ -635,6 +635,13 @@ func (c *MixedDbClient) getDbtablePath(path *gnmipb.Path, value *gnmipb.TypedVal
 	tblPath.tableName = ""
 	if len(stringSlice) > 1 {
 		tblPath.tableName = stringSlice[1]
+		// tables in COUNTERS_DB other than COUNTERS table doesn't have keys
+		// Insert a dummy table key
+		if tblPath.dbName == "COUNTERS_DB" && tblPath.tableName != "COUNTERS" {
+			index := 2
+			stringSlice = append(stringSlice[:index+1], stringSlice[index:]...)
+			stringSlice[index] = ""
+		}
 	}
 	tblPath.delimitor = separator
 	tblPath.operation = opRemove

--- a/test/test_gnmi_countersdb.py
+++ b/test/test_gnmi_countersdb.py
@@ -1,7 +1,7 @@
 
 import os
 import time
-from utils import gnmi_set, gnmi_get, gnmi_dump
+from utils import gnmi_get, gnmi_subscribe_poll
 
 import pytest
 
@@ -19,3 +19,31 @@ class TestGNMICountersDb:
 
         ret, msg_list = gnmi_get(get_list)
         assert ret == 0, 'Fail to read COUNTERS table, ' + msg_list[0]
+
+    def test_gnmi_get_table_02(self):
+        get_list = ['/sonic-db:COUNTERS_DB/localhost/COUNTERS/oid:0x1000000000003']
+
+        ret, msg_list = gnmi_get(get_list)
+        assert ret == 0, 'Fail to read COUNTERS table, ' + msg_list[0]
+
+    def test_gnmi_get_table_03(self):
+        get_list = ['/sonic-db:COUNTERS_DB/localhost/COUNTERS_PORT_NAME_MAP/Ethernet10']
+
+        ret, msg_list = gnmi_get(get_list)
+        assert ret == 0, 'Fail to read COUNTERS table, ' + msg_list[0]
+
+    def test_gnmi_poll_table_01(self):
+        path = "/COUNTERS_DB/localhost/COUNTERS_PORT_NAME_MAP/Ethernet10"
+        cnt = 3
+        interval = 1
+        ret, msg = gnmi_subscribe_poll(path, interval, cnt, timeout=0)
+        assert ret == 0, 'Fail to subscribe: ' + msg
+        assert msg.count("COUNTERS_PORT_NAME_MAP") == cnt, 'Invalid result: ' + msg
+
+    def test_gnmi_poll_table_02(self):
+        path = "/COUNTERS_DB/localhost/COUNTERS/oid:0x1000000000003"
+        cnt = 3
+        interval = 1
+        ret, msg = gnmi_subscribe_poll(path, interval, cnt, timeout=0)
+        assert ret == 0, 'Fail to subscribe: ' + msg
+        assert msg.count("oid:0x1000000000003") == cnt, 'Invalid result: ' + msg


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
gnmi native subscribe API needs to support COUNTERS_DB.
Microsoft ADO: 25282671

#### How I did it
Improve GNMI to support COUNTERS_DB.
Add unit test to verify subscribe poll mode with COUNTERS_DB.

#### How to verify it
Run gnmi unit test.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

