### PR TITLE
[Smartswitch] Yang model change for bridge midplane

### DIFF
--- a/sonic_data_client/client_test.go
+++ b/sonic_data_client/client_test.go
@@ -716,7 +716,7 @@ func TestGetDpuAddress(t *testing.T) {
 		t.Errorf("get DPU address should failed: %v, but get %s", err, address)
 	}
 
-	midPlaneTable.Hset("GLOBAL", "bridge", "bridge_midplane")
+	midPlaneTable.Hset("GLOBAL", "bridge", "bridge-midplane")
 	dpusTable.Hset("dpu0", "midplane_interface", "dpu0")
 
 	// test get DPU address when DHCP_SERVER_IPV4_PORT table not ready
@@ -725,7 +725,7 @@ func TestGetDpuAddress(t *testing.T) {
 		t.Errorf("get DPU address should failed: %v, but get %s", err, address)
 	}
 
-	dhcpPortTable.Hset("bridge_midplane|dpu0", "invalidfield", "")
+	dhcpPortTable.Hset("bridge-midplane|dpu0", "invalidfield", "")
 
 	// test get DPU address when DHCP_SERVER_IPV4_PORT table broken
 	address, err = getDpuAddress("dpu0")
@@ -733,7 +733,7 @@ func TestGetDpuAddress(t *testing.T) {
 		t.Errorf("get DPU address should failed: %v, but get %s", err, address)
 	}
 
-	dhcpPortTable.Hset("bridge_midplane|dpu0", "ips", "127.0.0.2,127.0.0.1")
+	dhcpPortTable.Hset("bridge-midplane|dpu0", "ips", "127.0.0.2,127.0.0.1")
 
 	// test get valid DPU address
 	address, err = getDpuAddress("dpu0")
@@ -789,9 +789,9 @@ func TestGetZmqClient(t *testing.T) {
 	var dpusTable = swsscommon.NewTable(configDb, "DPUS")
 	var dhcpPortTable = swsscommon.NewTable(configDb, "DHCP_SERVER_IPV4_PORT")
 
-	midPlaneTable.Hset("GLOBAL", "bridge", "bridge_midplane")
+	midPlaneTable.Hset("GLOBAL", "bridge", "bridge-midplane")
 	dpusTable.Hset("dpu0", "midplane_interface", "dpu0")
-	dhcpPortTable.Hset("bridge_midplane|dpu0", "ips", "127.0.0.2,127.0.0.1")
+	dhcpPortTable.Hset("bridge-midplane|dpu0", "ips", "127.0.0.2,127.0.0.1")
 
 	client, err := getZmqClient("dpu0", "")
 	if client != nil || err != nil {


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The yang model for bridge-midplane is not aligned with the actual implementation present in https://github.com/sonic-net/sonic-buildimage/pull/18178, 
This PR is to align the yang model to change `bridge_midplane` to `bridge-midplane` since this is the value used in the `systemd-networkd` in CONFIG_DB so that the yang validation does not fail

#### How I did it
Changed `bridge_midplane` to `bridge-midplane` at all locations 
#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

