### PR TITLE
Add support for RebootMethod_HALT for Reboot API

### DIFF
--- a/common_utils/context.go
+++ b/common_utils/context.go
@@ -54,6 +54,7 @@ const (
 	DBUS_STOP_SERVICE
 	DBUS_RESTART_SERVICE
 	DBUS_FILE_STAT
+	DBUS_HALT_SYSTEM
 	COUNTER_SIZE
 )
 
@@ -91,6 +92,8 @@ func (c CounterType) String() string {
 		return "DBUS restart service"
 	case DBUS_FILE_STAT:
 		return "DBUS file stat"
+	case DBUS_HALT_SYSTEM:
+		return "DBUS halt system"
 	default:
 		return ""
 	}

--- a/sonic_service_client/dbus_client.go
+++ b/sonic_service_client/dbus_client.go
@@ -19,6 +19,7 @@ type Service interface {
 	StopService(service string) error
 	RestartService(service string) error
 	GetFileStat(path string) (map[string]string, error)
+	HaltSystem() error
 }
 
 type DbusClient struct {
@@ -190,4 +191,22 @@ func (c *DbusClient) GetFileStat(path string) (map[string]string, error) {
 	}
 	data, _ := result.(map[string]string)
 	return data, nil
+}
+
+func (c *DbusClient) HaltSystem() error {
+    // Increment the counter for the DBUS_HALT_SYSTEM event
+    common_utils.IncCounter(common_utils.DBUS_HALT_SYSTEM)
+
+    // Set the module name and update the D-Bus properties
+    modName := "systemd"
+    busName := c.busNamePrefix + modName
+    busPath := c.busPathPrefix + modName
+    intName := c.intNamePrefix + modName + ".execute_reboot"
+
+    //Set the method to HALT(3) the system
+    const RebootMethod_HALT = 3
+
+    // Invoke the D-Bus API to execute the halt command
+    _, err := DbusApi(busName, busPath, intName, 10, RebootMethod_HALT)
+    return err
 }

--- a/test/test_gnoi.py
+++ b/test/test_gnoi.py
@@ -21,6 +21,17 @@ class TestGNOI:
         assert ret == 0, 'Fail to read counter'
         assert new_cnt == old_cnt+1, 'DBUS API is not invoked'
 
+    def test_gnoi_reboot_halt(self):
+        ret, old_cnt = gnmi_dump('DBUS halt system')
+        assert ret == 0, 'Fail to read counter'
+
+        ret, msg = gnoi_reboot(3, 0, 'Test halt system')
+        assert ret == 0, msg
+
+        ret, new_cnt = gnmi_dump('DBUS halt system')
+        assert ret == 0, 'Fail to read counter'
+        assert new_cnt == old_cnt+1, 'DBUS API is not invoked'
+
     def test_gnoi_rebootstatus(self):
         ret, msg = gnoi_rebootstatus()
         assert ret != 0, 'RebootStatus should fail' + msg


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Add support for HALT reboot method for Reboot gNOI API

#### How I did it
Implement changes for HaltSystem() function to be called when HALT reboot method is invoked.

#### How to verify it
Unit tests

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

