### PR TITLE
fix the wrong key in DPU address get from DHCP_SERVER_IPV4_PORT table Issue #288

### DIFF
--- a/sonic_data_client/client_test.go
+++ b/sonic_data_client/client_test.go
@@ -733,7 +733,7 @@ func TestGetDpuAddress(t *testing.T) {
 		t.Errorf("get DPU address should failed: %v, but get %s", err, address)
 	}
 
-	dhcpPortTable.Hset("bridge_midplane|dpu0", "ips", "127.0.0.2,127.0.0.1")
+	dhcpPortTable.Hset("bridge_midplane|dpu0", "ips@", "127.0.0.2,127.0.0.1")
 
 	// test get valid DPU address
 	address, err = getDpuAddress("dpu0")

--- a/sonic_data_client/mixed_db_client.go
+++ b/sonic_data_client/mixed_db_client.go
@@ -129,7 +129,7 @@ func getDpuAddress(dpuId string) (string, error) {
 
 	// get DPR address by DPU ID and brdige plane
 	var dhcpPortKey = bridgePlane + "|" + dpuInterface
-	dpuAddresses, err := Hget(configDbConnector, "DHCP_SERVER_IPV4_PORT", dhcpPortKey, "ips");
+	dpuAddresses, err := Hget(configDbConnector, "DHCP_SERVER_IPV4_PORT", dhcpPortKey, "ips@");
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Fixes #288
#### Why I did it
gnmi_set.go:203] Set failed: rpc error: code = NotFound desc = Get ZMQ client failed: Get ZMQ address failed: Get DPU address failed: Can't read bridge-midplane|dpu1:ips from DHCP_SERVER_IPV4_PORT table

#### How I did it
Modified the key from ips to ips@ as expected in the table

#### How to verify it
Executed my gnmi client and was able to retrieve the entry successfully

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
Modified the key used for DPU address retrieval by gnmi_set from DHCP_SERVER_IPV4_PORT table

#### Link to config_db schema for YANG module changes
N/A

#### A picture of a cute animal (not mandatory but encouraged)

