### PR TITLE
Fix issue with getting DPU IP address from DHCP_SERVER_IPV4_PORT table

### DIFF
--- a/sonic_data_client/client_test.go
+++ b/sonic_data_client/client_test.go
@@ -733,7 +733,7 @@ func TestGetDpuAddress(t *testing.T) {
 		t.Errorf("get DPU address should failed: %v, but get %s", err, address)
 	}
 
-	dhcpPortTable.Hset("bridge-midplane|dpu0", "ips", "127.0.0.2,127.0.0.1")
+	dhcpPortTable.Hset("bridge-midplane|dpu0", "ips@", "127.0.0.2,127.0.0.1")
 
 	// test get valid DPU address
 	address, err = getDpuAddress("dpu0")
@@ -791,7 +791,7 @@ func TestGetZmqClient(t *testing.T) {
 
 	midPlaneTable.Hset("GLOBAL", "bridge", "bridge-midplane")
 	dpusTable.Hset("dpu0", "midplane_interface", "dpu0")
-	dhcpPortTable.Hset("bridge-midplane|dpu0", "ips", "127.0.0.2,127.0.0.1")
+	dhcpPortTable.Hset("bridge-midplane|dpu0", "ips@", "127.0.0.2,127.0.0.1")
 
 	client, err := getZmqClient("dpu0", "")
 	if client != nil || err != nil {

--- a/sonic_data_client/mixed_db_client.go
+++ b/sonic_data_client/mixed_db_client.go
@@ -129,7 +129,7 @@ func getDpuAddress(dpuId string) (string, error) {
 
 	// get DPR address by DPU ID and brdige plane
 	var dhcpPortKey = bridgePlane + "|" + dpuInterface
-	dpuAddresses, err := Hget(configDbConnector, "DHCP_SERVER_IPV4_PORT", dhcpPortKey, "ips");
+	dpuAddresses, err := Hget(configDbConnector, "DHCP_SERVER_IPV4_PORT", dhcpPortKey, "ips@");
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix issue with getting DPU IP address from DHCP_SERVER_IPV4_PORT table
```
result     = ['Performing SetRequest Update, encoding=JSON_IETF  to  10.210.25.4  with the following gNMI Path\n ------------------... Get ZMQ address failed: Get DPU address failed: Can't read bridge-midplane|dpu0:ips from DHCP_SERVER_IPV4_PORT table"]
```
#### How I did it
The DPU IP addresses in `DHCP_SERVER_IPV4_PORT` table are stored in the list container:
```
    "DHCP_SERVER_IPV4_PORT": {
        "bridge-midplane|dpu0": {
            "ips": [
                "169.254.200.1"
            ]
        },
        "bridge-midplane|dpu1": {
            "ips": [
                "169.254.200.2"
            ]
        },
        "bridge-midplane|dpu2": {
            "ips": [
                "169.254.200.3"
            ]
        },
        "bridge-midplane|dpu3": {
            "ips": [
                "169.254.200.4"
            ]
        }
    },
```
Use the correct key to access the container:
```
sonic-db-cli CONFIG_DB hgetall "DHCP_SERVER_IPV4_PORT|bridge-midplane|dpu0"
{'ips@': '169.254.200.1'}
```

#### How to verify it
ZMQ client on the NPU should be able to get an IP address of the DPU to establish a connection.  

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

