### PR TITLE
Fix a panic by gnmi subscribe to DB change with invalid xpath

### DIFF
--- a/gnmi_server/client_subscribe.go
+++ b/gnmi_server/client_subscribe.go
@@ -179,11 +179,12 @@ func (c *Client) Run(stream gnmipb.GNMI_SubscribeServer) (err error) {
 		/* For any other target or no target create new Transl Client. */
 		dc, err = sdc.NewTranslClient(prefix, paths, ctx, extensions, sdc.TranslWildcardOption{})
 	}
-	defer dc.Close()
 
 	if err != nil {
 		return grpc.Errorf(codes.NotFound, "%v", err)
 	}
+
+	defer dc.Close()
 
 	switch mode {
 	case gnmipb.SubscriptionList_STREAM:


### PR DESCRIPTION
#### Why I did it
It is found that if I run gnmi subscribe to db change with an invalid xpath, gnmi server has a panic because of nil pointer dereference. 

Test is against multi-asic chassis. In telemtery test test_on_change_updates is did not handle the multi-asic properly which sends out gnmi subscribe like this: python /root/gnxi/gnmi_cli_py/py_gnmicli.py -g -t 10.250.6.233 -p 50052 -m subscribe -x NEIGH_STATE_TABLE -xt STATE_DB -o ndastreamingservertest --subscribe_mode 0 --submode 1 --interval 0 --update_count 2 --create_connections 1

gnmi container restarts with a panic. 

Correct CLI commands should be: python /root/gnxi/gnmi_cli_py/py_gnmicli.py -g -t 10.250.6.233 -p 50052 -m subscribe -x NEIGH_STATE_TABLE/asic0 -xt STATE_DB -o ndastreamingservertest --subscribe_mode 0 --submode 1 --interval 0 --update_count 2 --create_connections 1

#### How I did it
Fix the deference of nil pointer with this scenario.

#### How to verify it
With modified code, the above CLI will not cause gnmi panic. The connection is properly closed.

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [X] 202405


