### PR TITLE
[dash] add zmq_dpu_proxy_address_base parameter to telemetry.go

### DIFF
--- a/gnmi_server/client_subscribe.go
+++ b/gnmi_server/client_subscribe.go
@@ -161,7 +161,7 @@ func (c *Client) Run(stream gnmipb.GNMI_SubscribeServer) (err error) {
 	if origin == "openconfig" {
 		dc, err = sdc.NewTranslClient(prefix, paths, ctx, extensions, sdc.TranslWildcardOption{})
 	} else if IsNativeOrigin(origin) {
-		dc, err = sdc.NewMixedDbClient(paths, prefix, origin, gnmipb.Encoding_JSON_IETF, "", "")
+		dc, err = sdc.NewMixedDbClient(paths, prefix, origin, gnmipb.Encoding_JSON_IETF, "", "", "")
 	} else if len(origin) != 0 {
 		return grpc.Errorf(codes.Unimplemented, "Unsupported origin: %s", origin)
 	} else if target == "" {

--- a/gnmi_server/server.go
+++ b/gnmi_server/server.go
@@ -83,6 +83,7 @@ type Config struct {
 	EnableTranslibWrite bool
 	EnableNativeWrite   bool
 	ZmqPort             string
+	DpuProxyBaseAddr    string
 	IdleConnDuration    int
 	ConfigTableName     string
 	Vrf                 string
@@ -410,7 +411,7 @@ func (s *Server) Get(ctx context.Context, req *gnmipb.GetRequest) (*gnmipb.GetRe
 			}
 		}
 		if check := IsNativeOrigin(origin); check {
-			dc, err = sdc.NewMixedDbClient(paths, prefix, origin, encoding, s.config.ZmqPort, s.config.Vrf)
+			dc, err = sdc.NewMixedDbClient(paths, prefix, origin, encoding, s.config.ZmqPort, s.config.Vrf, s.config.DpuProxyBaseAddr)
 		} else {
 			dc, err = sdc.NewTranslClient(prefix, paths, ctx, extensions)
 		}
@@ -508,7 +509,7 @@ func (s *Server) Set(ctx context.Context, req *gnmipb.SetRequest) (*gnmipb.SetRe
 			common_utils.IncCounter(common_utils.GNMI_SET_FAIL)
 			return nil, grpc.Errorf(codes.Unimplemented, "GNMI native write is disabled")
 		}
-		dc, err = sdc.NewMixedDbClient(paths, prefix, origin, encoding, s.config.ZmqPort, s.config.Vrf)
+		dc, err = sdc.NewMixedDbClient(paths, prefix, origin, encoding, s.config.ZmqPort, s.config.Vrf, s.config.DpuProxyBaseAddr)
 	} else {
 		if s.config.EnableTranslibWrite == false {
 			common_utils.IncCounter(common_utils.GNMI_SET_FAIL)
@@ -585,7 +586,7 @@ func (s *Server) Capabilities(ctx context.Context, req *gnmipb.CapabilityRequest
 	var supportedModels []gnmipb.ModelData
 	dc, _ := sdc.NewTranslClient(nil, nil, ctx, extensions)
 	supportedModels = append(supportedModels, dc.Capabilities()...)
-	dc, _ = sdc.NewMixedDbClient(nil, nil, "", gnmipb.Encoding_JSON_IETF, s.config.ZmqPort, s.config.Vrf)
+	dc, _ = sdc.NewMixedDbClient(nil, nil, "", gnmipb.Encoding_JSON_IETF, s.config.ZmqPort, s.config.Vrf, s.config.DpuProxyBaseAddr)
 	supportedModels = append(supportedModels, dc.Capabilities()...)
 
 	suppModels := make([]*gnmipb.ModelData, len(supportedModels))

--- a/sonic_data_client/client_test.go
+++ b/sonic_data_client/client_test.go
@@ -756,17 +756,17 @@ func TestGetDpuAddress(t *testing.T) {
 	}
 
 	// test get ZMQ address
-	address, err = getZmqAddress("dpu0", "1234")
+	address, err = getZmqAddress("dpu0", "1234", "")
 	if address != "tcp://127.0.0.2:1234" {
 		t.Errorf("get invalid DPU address failed")
 	}
 
-	address, err = getZmqAddress("dpu0", "")
+	address, err = getZmqAddress("dpu0", "", "")
 	if err == nil {
 		t.Errorf("get invalid ZMQ address failed")
 	}
 
-	address, err = getZmqAddress("", "1234")
+	address, err = getZmqAddress("", "1234", "")
 	if err == nil {
 		t.Errorf("get invalid ZMQ address failed")
 	}
@@ -775,6 +775,37 @@ func TestGetDpuAddress(t *testing.T) {
 	swsscommon.DeleteTable(dpusTable)
 	swsscommon.DeleteTable(dhcpPortTable)
 	swsscommon.DeleteDBConnector(configDb)
+}
+
+func TestGetDpuProxyAddress(t *testing.T) {
+	address, err := getDpuProxyAddress("dpu1", "127.0.10.10")
+	if err != nil {
+		t.Errorf("get DPU address failed")
+	}
+
+	if address != "127.0.10.11" {
+		t.Errorf("invalid DPU address")
+	}
+
+	address, err = getDpuProxyAddress("dpu_no_index", "127.0.10.10")
+	if err == nil {
+		t.Errorf("get with invalid DPU failed")
+	}
+
+	address, err = getDpuProxyAddress("dpu1", "invalid IP")
+	if err == nil {
+		t.Errorf("get with invalid base address failed")
+	}
+
+	address, err = getDpuProxyAddress("dpu1", "::1")
+	if err == nil {
+		t.Errorf("get with IPv6 base address failed")
+	}
+
+	address, err = getDpuProxyAddress("dpu300", "127.0.10.10")
+	if err == nil {
+		t.Errorf("get with dpu index out of range failed")
+	}
 }
 
 func TestGetZmqClient(t *testing.T) {
@@ -793,17 +824,17 @@ func TestGetZmqClient(t *testing.T) {
 	dpusTable.Hset("dpu0", "midplane_interface", "dpu0")
 	dhcpPortTable.Hset("bridge-midplane|dpu0", "ips@", "127.0.0.2,127.0.0.1")
 
-	client, err := getZmqClient("dpu0", "", "")
+	client, err := getZmqClient("dpu0", "", "", "")
 	if client != nil || err != nil {
 		t.Errorf("empty ZMQ port should not get ZMQ client")
 	}
 
-	client, err = getZmqClient("dpu0", "1234", "")
+	client, err = getZmqClient("dpu0", "1234", "", "")
 	if client == nil {
 		t.Errorf("get ZMQ client failed")
 	}
 
-	client, err = getZmqClient("", "1234", "")
+	client, err = getZmqClient("", "1234", "", "")
 	if client == nil {
 		t.Errorf("get ZMQ client failed")
 	}

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -46,6 +46,7 @@ type TelemetryConfig struct {
 	ConfigTableName       *string
 	ZmqAddress            *string
 	ZmqPort               *string
+	DashProxyAddr         *string
 	Insecure              *bool
 	NoTLS                 *bool
 	AllowNoClientCert     *bool
@@ -155,6 +156,7 @@ func setupFlags(fs *flag.FlagSet) (*TelemetryConfig, *gnmi.Config, error) {
 		ConfigTableName:       fs.String("config_table_name", "", "Config table name"),
 		ZmqAddress:            fs.String("zmq_address", "", "Orchagent ZMQ address, deprecated, please use zmq_port."),
 		ZmqPort:               fs.String("zmq_port", "", "Orchagent ZMQ port, when not set or empty string telemetry server will switch to Redis based communication channel."),
+		DashProxyAddr:         fs.String("zmq_dpu_proxy_address_base", "", "Dash offload manager ZMQ base address, when set, the DPU configuration will be send to the proxy address instead of directly to the DPU."),
 		Insecure:              fs.Bool("insecure", false, "Skip providing TLS cert and key, for testing only!"),
 		NoTLS:                 fs.Bool("noTLS", false, "disable TLS, for testing only!"),
 		AllowNoClientCert:     fs.Bool("allow_no_client_auth", false, "When set, telemetry server will request but not require a client certificate."),
@@ -242,6 +244,7 @@ func setupFlags(fs *flag.FlagSet) (*TelemetryConfig, *gnmi.Config, error) {
 	}
 
 	cfg.ZmqPort = zmqPort
+	cfg.DpuProxyBaseAddr = *telemetryCfg.DashProxyAddr
 
 	return telemetryCfg, cfg, nil
 }


### PR DESCRIPTION
#### Why I did it
This allows to configure the gnmi server to send the DASH configuration to the DashOffloadManager instead of the DPU

#### How I did it
Added a new flag "zmq_dpu_proxy_address_base" to telemetry.go

#### How to verify it
Manual test

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

