### PR TITLE
Add swss-common log level support to GNMI service

### DIFF
--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -26,6 +26,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/keepalive"
+	"github.com/sonic-net/sonic-gnmi/swsscommon"
 )
 
 type ServerControlValue int
@@ -87,6 +88,9 @@ func runTelemetry(args []string) error {
 	if err != nil {
 		return err
 	}
+
+	// enable swss-common debug level
+	swsscommon.LoggerLinkToDbNative("telemetry")
 
 	var wg sync.WaitGroup
 	// serverControlSignal channel is a channel that will be used to notify gnmi server to start, stop, restart, depending of syscall or cert updates


### PR DESCRIPTION
Add swss-common log level support to GNMI service

#### Why I did it
Improve GNMI debug experience

#### How I did it
Initialize swss-common log level thread when GNMI start.

#### How to verify it
Manually test:

admin@vlab-01:~$ swssloglevel -l NOTICE -c telemetry
admin@vlab-01:~$ sudo tail -f /var/log/syslog
2024 Nov 22 05:30:03.876827 vlab-01 DEBUG gnmi#telemetry: :> select: enter
2024 Nov 22 05:30:04.734015 vlab-01 INFO systemd[1]: Starting sysstat-collect.service - system activity accounting tool...
2024 Nov 22 05:30:04.740683 vlab-01 INFO systemd[1]: Starting logrotate.service - Rotate log files...
2024 Nov 22 05:30:04.750069 vlab-01 DEBUG gnmi#telemetry: :< select: exit
2024 Nov 22 05:30:04.754189 vlab-01 DEBUG gnmi#telemetry: :- swssPrioNotify: Changing logger minPrio to NOTICE



Add new UT.

#### Work item tracking
Microsoft ADO (number only): 30298614

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
Add swss-common log level support to GNMI service

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

