### PR TITLE
Better format for gnoi_client.go

### DIFF
--- a/gnoi_client/gnoi_client.go
+++ b/gnoi_client/gnoi_client.go
@@ -1,51 +1,53 @@
 package main
 
 import (
-	"google.golang.org/grpc"
-	gnoi_system_pb "github.com/openconfig/gnoi/system"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"github.com/google/gnxi/utils/credentials"
 	gnoi_file_pb "github.com/openconfig/gnoi/file"
+	gnoi_system_pb "github.com/openconfig/gnoi/system"
 	spb "github.com/sonic-net/sonic-gnmi/proto/gnoi"
 	spb_jwt "github.com/sonic-net/sonic-gnmi/proto/gnoi/jwt"
-	"context"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 	"os"
 	"os/signal"
-	"fmt"
-	"flag"
-	"google.golang.org/grpc/metadata"
-	"github.com/google/gnxi/utils/credentials"
-	"encoding/json"
 )
 
 var (
-	module = flag.String("module", "System", "gNOI Module")
-	rpc = flag.String("rpc", "Time", "rpc call in specified module to call")
-	target = flag.String("target", "localhost:8080", "Address:port of gNOI Server")
-	args = flag.String("jsonin", "", "RPC Arguments in json format")
-	jwtToken = flag.String("jwt_token", "", "JWT Token if required")
+	module     = flag.String("module", "System", "gNOI Module")
+	rpc        = flag.String("rpc", "Time", "rpc call in specified module to call")
+	target     = flag.String("target", "localhost:8080", "Address:port of gNOI Server")
+	args       = flag.String("jsonin", "", "RPC Arguments in json format")
+	jwtToken   = flag.String("jwt_token", "", "JWT Token if required")
 	targetName = flag.String("target_name", "hostname.com", "The target name use to verify the hostname returned by TLS handshake")
 )
+
 func setUserCreds(ctx context.Context) context.Context {
 	if len(*jwtToken) > 0 {
 		ctx = metadata.AppendToOutgoingContext(ctx, "access_token", *jwtToken)
 	}
 	return ctx
 }
+
 func main() {
 	flag.Parse()
 	opts := credentials.ClientCredentials(*targetName)
 
-    ctx, cancel := context.WithCancel(context.Background())
-    go func() {
-            c := make(chan os.Signal, 1)
-            signal.Notify(c, os.Interrupt)
-            <-c
-            cancel()
-    }()
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		c := make(chan os.Signal, 1)
+		signal.Notify(c, os.Interrupt)
+		<-c
+		cancel()
+	}()
 	conn, err := grpc.Dial(*target, opts...)
 	if err != nil {
 		panic(err.Error())
 	}
-	
+
 	switch *module {
 	case "System":
 		sc := gnoi_system_pb.NewSystemClient(conn)
@@ -59,7 +61,7 @@ func main() {
 		case "RebootStatus":
 			systemRebootStatus(sc, ctx)
 		case "KillProcess":
-			killProcess(sc, ctx)
+			systemKillProcess(sc, ctx)
 		default:
 			panic("Invalid RPC Name")
 		}
@@ -78,25 +80,25 @@ func main() {
 			sonicShowTechSupport(sc, ctx)
 		case "copyConfig":
 			sc := spb.NewSonicServiceClient(conn)
-			copyConfig(sc, ctx)
+			sonicCopyConfig(sc, ctx)
 		case "authenticate":
 			sc := spb_jwt.NewSonicJwtServiceClient(conn)
-			authenticate(sc, ctx)
+			sonicAuthenticate(sc, ctx)
 		case "imageInstall":
 			sc := spb.NewSonicServiceClient(conn)
-			imageInstall(sc, ctx)
+			sonicImageInstall(sc, ctx)
 		case "imageDefault":
 			sc := spb.NewSonicServiceClient(conn)
-			imageDefault(sc, ctx)
+			sonicImageDefault(sc, ctx)
 		case "imageRemove":
 			sc := spb.NewSonicServiceClient(conn)
-			imageRemove(sc, ctx)
+			sonicImageRemove(sc, ctx)
 		case "refresh":
 			sc := spb_jwt.NewSonicJwtServiceClient(conn)
-			refresh(sc, ctx)
+			sonicRefresh(sc, ctx)
 		case "clearNeighbors":
 			sc := spb.NewSonicServiceClient(conn)
-			clearNeighbors(sc, ctx)
+			sonicClearNeighbors(sc, ctx)
 		default:
 			panic("Invalid RPC Name")
 		}
@@ -106,10 +108,11 @@ func main() {
 
 }
 
+// RPC for System Services
 func systemTime(sc gnoi_system_pb.SystemClient, ctx context.Context) {
 	fmt.Println("System Time")
 	ctx = setUserCreds(ctx)
-	resp,err := sc.Time(ctx, new(gnoi_system_pb.TimeRequest))
+	resp, err := sc.Time(ctx, new(gnoi_system_pb.TimeRequest))
 	if err != nil {
 		panic(err.Error())
 	}
@@ -120,45 +123,26 @@ func systemTime(sc gnoi_system_pb.SystemClient, ctx context.Context) {
 	fmt.Println(string(respstr))
 }
 
-func killProcess(sc gnoi_system_pb.SystemClient, ctx context.Context) {
+func systemKillProcess(sc gnoi_system_pb.SystemClient, ctx context.Context) {
 	fmt.Println("Kill Process with optional restart")
 	ctx = setUserCreds(ctx)
-	req := &gnoi_system_pb.KillProcessRequest {}
+	req := &gnoi_system_pb.KillProcessRequest{}
 	err := json.Unmarshal([]byte(*args), req)
 	if err != nil {
 		panic(err.Error())
 	}
-	_,err = sc.KillProcess(ctx, req)
+	_, err = sc.KillProcess(ctx, req)
 	if err != nil {
 		panic(err.Error())
 	}
-}
-
-func fileStat(fc gnoi_file_pb.FileClient, ctx context.Context) {
-	fmt.Println("File Stat")
-	ctx = setUserCreds(ctx)
-	req := &gnoi_file_pb.StatRequest {}
-	err := json.Unmarshal([]byte(*args), req)
-	if err != nil {
-		panic(err.Error())
-	}
-	resp,err := fc.Stat(ctx, req)
-	if err != nil {
-		panic(err.Error())
-	}
-	respstr, err := json.Marshal(resp)
-	if err != nil {
-		panic(err.Error())
-	}
-	fmt.Println(string(respstr))
 }
 
 func systemReboot(sc gnoi_system_pb.SystemClient, ctx context.Context) {
 	fmt.Println("System Reboot")
 	ctx = setUserCreds(ctx)
-	req := &gnoi_system_pb.RebootRequest {}
+	req := &gnoi_system_pb.RebootRequest{}
 	json.Unmarshal([]byte(*args), req)
-	_,err := sc.Reboot(ctx, req)
+	_, err := sc.Reboot(ctx, req)
 	if err != nil {
 		panic(err.Error())
 	}
@@ -167,9 +151,9 @@ func systemReboot(sc gnoi_system_pb.SystemClient, ctx context.Context) {
 func systemCancelReboot(sc gnoi_system_pb.SystemClient, ctx context.Context) {
 	fmt.Println("System CancelReboot")
 	ctx = setUserCreds(ctx)
-	req := &gnoi_system_pb.CancelRebootRequest {}
+	req := &gnoi_system_pb.CancelRebootRequest{}
 	json.Unmarshal([]byte(*args), req)
-	resp,err := sc.CancelReboot(ctx, req)
+	resp, err := sc.CancelReboot(ctx, req)
 	if err != nil {
 		panic(err.Error())
 	}
@@ -183,8 +167,8 @@ func systemCancelReboot(sc gnoi_system_pb.SystemClient, ctx context.Context) {
 func systemRebootStatus(sc gnoi_system_pb.SystemClient, ctx context.Context) {
 	fmt.Println("System RebootStatus")
 	ctx = setUserCreds(ctx)
-	req := &gnoi_system_pb.RebootStatusRequest {}
-	resp,err := sc.RebootStatus(ctx, req)
+	req := &gnoi_system_pb.RebootStatusRequest{}
+	resp, err := sc.RebootStatus(ctx, req)
 	if err != nil {
 		panic(err.Error())
 	}
@@ -195,18 +179,37 @@ func systemRebootStatus(sc gnoi_system_pb.SystemClient, ctx context.Context) {
 	fmt.Println(string(respstr))
 }
 
+// RPC for File Services
+func fileStat(fc gnoi_file_pb.FileClient, ctx context.Context) {
+	fmt.Println("File Stat")
+	ctx = setUserCreds(ctx)
+	req := &gnoi_file_pb.StatRequest{}
+	err := json.Unmarshal([]byte(*args), req)
+	if err != nil {
+		panic(err.Error())
+	}
+	resp, err := fc.Stat(ctx, req)
+	if err != nil {
+		panic(err.Error())
+	}
+	respstr, err := json.Marshal(resp)
+	if err != nil {
+		panic(err.Error())
+	}
+	fmt.Println(string(respstr))
+}
+
+// RPC for Sonic Services
 func sonicShowTechSupport(sc spb.SonicServiceClient, ctx context.Context) {
 	fmt.Println("Sonic ShowTechsupport")
 	ctx = setUserCreds(ctx)
-	req := &spb.TechsupportRequest {
-		Input: &spb.TechsupportRequest_Input{
-			
-		},
+	req := &spb.TechsupportRequest{
+		Input: &spb.TechsupportRequest_Input{},
 	}
 
 	json.Unmarshal([]byte(*args), req)
-	
-	resp,err := sc.ShowTechsupport(ctx, req)
+
+	resp, err := sc.ShowTechsupport(ctx, req)
 	if err != nil {
 		panic(err.Error())
 	}
@@ -217,7 +220,7 @@ func sonicShowTechSupport(sc spb.SonicServiceClient, ctx context.Context) {
 	fmt.Println(string(respstr))
 }
 
-func copyConfig(sc spb.SonicServiceClient, ctx context.Context) {
+func sonicCopyConfig(sc spb.SonicServiceClient, ctx context.Context) {
 	fmt.Println("Sonic CopyConfig")
 	ctx = setUserCreds(ctx)
 	req := &spb.CopyConfigRequest{
@@ -225,7 +228,7 @@ func copyConfig(sc spb.SonicServiceClient, ctx context.Context) {
 	}
 	json.Unmarshal([]byte(*args), req)
 
-	resp,err := sc.CopyConfig(ctx, req)
+	resp, err := sc.CopyConfig(ctx, req)
 
 	if err != nil {
 		panic(err.Error())
@@ -236,7 +239,8 @@ func copyConfig(sc spb.SonicServiceClient, ctx context.Context) {
 	}
 	fmt.Println(string(respstr))
 }
-func imageInstall(sc spb.SonicServiceClient, ctx context.Context) {
+
+func sonicImageInstall(sc spb.SonicServiceClient, ctx context.Context) {
 	fmt.Println("Sonic ImageInstall")
 	ctx = setUserCreds(ctx)
 	req := &spb.ImageInstallRequest{
@@ -244,7 +248,7 @@ func imageInstall(sc spb.SonicServiceClient, ctx context.Context) {
 	}
 	json.Unmarshal([]byte(*args), req)
 
-	resp,err := sc.ImageInstall(ctx, req)
+	resp, err := sc.ImageInstall(ctx, req)
 
 	if err != nil {
 		panic(err.Error())
@@ -255,7 +259,8 @@ func imageInstall(sc spb.SonicServiceClient, ctx context.Context) {
 	}
 	fmt.Println(string(respstr))
 }
-func imageRemove(sc spb.SonicServiceClient, ctx context.Context) {
+
+func sonicImageRemove(sc spb.SonicServiceClient, ctx context.Context) {
 	fmt.Println("Sonic ImageRemove")
 	ctx = setUserCreds(ctx)
 	req := &spb.ImageRemoveRequest{
@@ -263,7 +268,7 @@ func imageRemove(sc spb.SonicServiceClient, ctx context.Context) {
 	}
 	json.Unmarshal([]byte(*args), req)
 
-	resp,err := sc.ImageRemove(ctx, req)
+	resp, err := sc.ImageRemove(ctx, req)
 
 	if err != nil {
 		panic(err.Error())
@@ -275,7 +280,7 @@ func imageRemove(sc spb.SonicServiceClient, ctx context.Context) {
 	fmt.Println(string(respstr))
 }
 
-func imageDefault(sc spb.SonicServiceClient, ctx context.Context) {
+func sonicImageDefault(sc spb.SonicServiceClient, ctx context.Context) {
 	fmt.Println("Sonic ImageDefault")
 	ctx = setUserCreds(ctx)
 	req := &spb.ImageDefaultRequest{
@@ -283,7 +288,7 @@ func imageDefault(sc spb.SonicServiceClient, ctx context.Context) {
 	}
 	json.Unmarshal([]byte(*args), req)
 
-	resp,err := sc.ImageDefault(ctx, req)
+	resp, err := sc.ImageDefault(ctx, req)
 
 	if err != nil {
 		panic(err.Error())
@@ -295,14 +300,14 @@ func imageDefault(sc spb.SonicServiceClient, ctx context.Context) {
 	fmt.Println(string(respstr))
 }
 
-func authenticate(sc spb_jwt.SonicJwtServiceClient, ctx context.Context) {
+func sonicAuthenticate(sc spb_jwt.SonicJwtServiceClient, ctx context.Context) {
 	fmt.Println("Sonic Authenticate")
 	ctx = setUserCreds(ctx)
-	req := &spb_jwt.AuthenticateRequest {}
-	
+	req := &spb_jwt.AuthenticateRequest{}
+
 	json.Unmarshal([]byte(*args), req)
-	
-	resp,err := sc.Authenticate(ctx, req)
+
+	resp, err := sc.Authenticate(ctx, req)
 	if err != nil {
 		panic(err.Error())
 	}
@@ -313,14 +318,14 @@ func authenticate(sc spb_jwt.SonicJwtServiceClient, ctx context.Context) {
 	fmt.Println(string(respstr))
 }
 
-func refresh(sc spb_jwt.SonicJwtServiceClient, ctx context.Context) {
+func sonicRefresh(sc spb_jwt.SonicJwtServiceClient, ctx context.Context) {
 	fmt.Println("Sonic Refresh")
 	ctx = setUserCreds(ctx)
-	req := &spb_jwt.RefreshRequest {}
-	
+	req := &spb_jwt.RefreshRequest{}
+
 	json.Unmarshal([]byte(*args), req)
 
-	resp,err := sc.Refresh(ctx, req)
+	resp, err := sc.Refresh(ctx, req)
 	if err != nil {
 		panic(err.Error())
 	}
@@ -331,22 +336,22 @@ func refresh(sc spb_jwt.SonicJwtServiceClient, ctx context.Context) {
 	fmt.Println(string(respstr))
 }
 
-func clearNeighbors(sc spb.SonicServiceClient, ctx context.Context) {
-    fmt.Println("Sonic ClearNeighbors")
-    ctx = setUserCreds(ctx)
-    req := &spb.ClearNeighborsRequest{
-        Input: &spb.ClearNeighborsRequest_Input{},
-    }
-    json.Unmarshal([]byte(*args), req)
+func sonicClearNeighbors(sc spb.SonicServiceClient, ctx context.Context) {
+	fmt.Println("Sonic ClearNeighbors")
+	ctx = setUserCreds(ctx)
+	req := &spb.ClearNeighborsRequest{
+		Input: &spb.ClearNeighborsRequest_Input{},
+	}
+	json.Unmarshal([]byte(*args), req)
 
-    resp,err := sc.ClearNeighbors(ctx, req)
+	resp, err := sc.ClearNeighbors(ctx, req)
 
-    if err != nil {
-        panic(err.Error())
-    }
-    respstr, err := json.Marshal(resp)
-    if err != nil {
-        panic(err.Error())
-    }
-    fmt.Println(string(respstr))
+	if err != nil {
+		panic(err.Error())
+	}
+	respstr, err := json.Marshal(resp)
+	if err != nil {
+		panic(err.Error())
+	}
+	fmt.Println(string(respstr))
 }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Better organization and format for gnoi_client.go

#### How I did it
* `gofmt -w gnoi_client.go`
* Some client rpc entry point have service name preceding it (like `systemReboot`) and some doesn't (like `killProcess`). All entry point for rpc should have the service name preceding it.

#### How to verify it
This is a refactor. `make all` passes

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

