### PR TITLE
Better modularization for gnoi_client.go

### DIFF
--- a/gnoi_client/config/flag.go
+++ b/gnoi_client/config/flag.go
@@ -1,0 +1,18 @@
+package config
+
+import (
+	"flag"
+)
+
+var (
+	Module     = flag.String("module", "System", "gNOI Module")
+	Rpc        = flag.String("rpc", "Time", "rpc call in specified module to call")
+	Target     = flag.String("target", "localhost:8080", "Address:port of gNOI Server")
+	Args       = flag.String("jsonin", "", "RPC Arguments in json format")
+	JwtToken   = flag.String("jwt_token", "", "JWT Token if required")
+	TargetName = flag.String("target_name", "hostname.com", "The target name use to verify the hostname returned by TLS handshake")
+)
+
+func ParseFlag() {
+	flag.Parse()
+}

--- a/gnoi_client/file/file.go
+++ b/gnoi_client/file/file.go
@@ -1,0 +1,31 @@
+package file
+
+import (
+	"context"
+	"fmt"
+	"encoding/json"
+	pb 	"github.com/openconfig/gnoi/file"
+	"github.com/sonic-net/sonic-gnmi/gnoi_client/utils"
+	"github.com/sonic-net/sonic-gnmi/gnoi_client/config"
+	"google.golang.org/grpc"
+)
+
+func Stat(conn *grpc.ClientConn, ctx context.Context) {
+	fmt.Println("File Stat")
+	ctx = utils.SetUserCreds(ctx)
+	fc := pb.NewFileClient(conn)
+	req := &pb.StatRequest{}
+	err := json.Unmarshal([]byte(*config.Args), req)
+	if err != nil {
+		panic(err.Error())
+	}
+	resp, err := fc.Stat(ctx, req)
+	if err != nil {
+		panic(err.Error())
+	}
+	respstr, err := json.Marshal(resp)
+	if err != nil {
+		panic(err.Error())
+	}
+	fmt.Println(string(respstr))
+}

--- a/gnoi_client/gnoi_client.go
+++ b/gnoi_client/gnoi_client.go
@@ -1,51 +1,53 @@
 package main
 
 import (
-	"google.golang.org/grpc"
-	gnoi_system_pb "github.com/openconfig/gnoi/system"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"github.com/google/gnxi/utils/credentials"
 	gnoi_file_pb "github.com/openconfig/gnoi/file"
+	gnoi_system_pb "github.com/openconfig/gnoi/system"
 	spb "github.com/sonic-net/sonic-gnmi/proto/gnoi"
 	spb_jwt "github.com/sonic-net/sonic-gnmi/proto/gnoi/jwt"
-	"context"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 	"os"
 	"os/signal"
-	"fmt"
-	"flag"
-	"google.golang.org/grpc/metadata"
-	"github.com/google/gnxi/utils/credentials"
-	"encoding/json"
 )
 
 var (
-	module = flag.String("module", "System", "gNOI Module")
-	rpc = flag.String("rpc", "Time", "rpc call in specified module to call")
-	target = flag.String("target", "localhost:8080", "Address:port of gNOI Server")
-	args = flag.String("jsonin", "", "RPC Arguments in json format")
-	jwtToken = flag.String("jwt_token", "", "JWT Token if required")
+	module     = flag.String("module", "System", "gNOI Module")
+	rpc        = flag.String("rpc", "Time", "rpc call in specified module to call")
+	target     = flag.String("target", "localhost:8080", "Address:port of gNOI Server")
+	args       = flag.String("jsonin", "", "RPC Arguments in json format")
+	jwtToken   = flag.String("jwt_token", "", "JWT Token if required")
 	targetName = flag.String("target_name", "hostname.com", "The target name use to verify the hostname returned by TLS handshake")
 )
+
 func setUserCreds(ctx context.Context) context.Context {
 	if len(*jwtToken) > 0 {
 		ctx = metadata.AppendToOutgoingContext(ctx, "access_token", *jwtToken)
 	}
 	return ctx
 }
+
 func main() {
 	flag.Parse()
 	opts := credentials.ClientCredentials(*targetName)
 
-    ctx, cancel := context.WithCancel(context.Background())
-    go func() {
-            c := make(chan os.Signal, 1)
-            signal.Notify(c, os.Interrupt)
-            <-c
-            cancel()
-    }()
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		c := make(chan os.Signal, 1)
+		signal.Notify(c, os.Interrupt)
+		<-c
+		cancel()
+	}()
 	conn, err := grpc.Dial(*target, opts...)
 	if err != nil {
 		panic(err.Error())
 	}
-	
+
 	switch *module {
 	case "System":
 		sc := gnoi_system_pb.NewSystemClient(conn)
@@ -59,7 +61,7 @@ func main() {
 		case "RebootStatus":
 			systemRebootStatus(sc, ctx)
 		case "KillProcess":
-			killProcess(sc, ctx)
+			systemKillProcess(sc, ctx)
 		default:
 			panic("Invalid RPC Name")
 		}
@@ -78,25 +80,25 @@ func main() {
 			sonicShowTechSupport(sc, ctx)
 		case "copyConfig":
 			sc := spb.NewSonicServiceClient(conn)
-			copyConfig(sc, ctx)
+			sonicCopyConfig(sc, ctx)
 		case "authenticate":
 			sc := spb_jwt.NewSonicJwtServiceClient(conn)
-			authenticate(sc, ctx)
+			sonicAuthenticate(sc, ctx)
 		case "imageInstall":
 			sc := spb.NewSonicServiceClient(conn)
-			imageInstall(sc, ctx)
+			sonicImageInstall(sc, ctx)
 		case "imageDefault":
 			sc := spb.NewSonicServiceClient(conn)
-			imageDefault(sc, ctx)
+			sonicImageDefault(sc, ctx)
 		case "imageRemove":
 			sc := spb.NewSonicServiceClient(conn)
-			imageRemove(sc, ctx)
+			sonicImageRemove(sc, ctx)
 		case "refresh":
 			sc := spb_jwt.NewSonicJwtServiceClient(conn)
-			refresh(sc, ctx)
+			sonicRefresh(sc, ctx)
 		case "clearNeighbors":
 			sc := spb.NewSonicServiceClient(conn)
-			clearNeighbors(sc, ctx)
+			sonicClearNeighbors(sc, ctx)
 		default:
 			panic("Invalid RPC Name")
 		}
@@ -106,10 +108,11 @@ func main() {
 
 }
 
+// RPC for System Services
 func systemTime(sc gnoi_system_pb.SystemClient, ctx context.Context) {
 	fmt.Println("System Time")
 	ctx = setUserCreds(ctx)
-	resp,err := sc.Time(ctx, new(gnoi_system_pb.TimeRequest))
+	resp, err := sc.Time(ctx, new(gnoi_system_pb.TimeRequest))
 	if err != nil {
 		panic(err.Error())
 	}
@@ -120,45 +123,26 @@ func systemTime(sc gnoi_system_pb.SystemClient, ctx context.Context) {
 	fmt.Println(string(respstr))
 }
 
-func killProcess(sc gnoi_system_pb.SystemClient, ctx context.Context) {
+func systemKillProcess(sc gnoi_system_pb.SystemClient, ctx context.Context) {
 	fmt.Println("Kill Process with optional restart")
 	ctx = setUserCreds(ctx)
-	req := &gnoi_system_pb.KillProcessRequest {}
+	req := &gnoi_system_pb.KillProcessRequest{}
 	err := json.Unmarshal([]byte(*args), req)
 	if err != nil {
 		panic(err.Error())
 	}
-	_,err = sc.KillProcess(ctx, req)
+	_, err = sc.KillProcess(ctx, req)
 	if err != nil {
 		panic(err.Error())
 	}
-}
-
-func fileStat(fc gnoi_file_pb.FileClient, ctx context.Context) {
-	fmt.Println("File Stat")
-	ctx = setUserCreds(ctx)
-	req := &gnoi_file_pb.StatRequest {}
-	err := json.Unmarshal([]byte(*args), req)
-	if err != nil {
-		panic(err.Error())
-	}
-	resp,err := fc.Stat(ctx, req)
-	if err != nil {
-		panic(err.Error())
-	}
-	respstr, err := json.Marshal(resp)
-	if err != nil {
-		panic(err.Error())
-	}
-	fmt.Println(string(respstr))
 }
 
 func systemReboot(sc gnoi_system_pb.SystemClient, ctx context.Context) {
 	fmt.Println("System Reboot")
 	ctx = setUserCreds(ctx)
-	req := &gnoi_system_pb.RebootRequest {}
+	req := &gnoi_system_pb.RebootRequest{}
 	json.Unmarshal([]byte(*args), req)
-	_,err := sc.Reboot(ctx, req)
+	_, err := sc.Reboot(ctx, req)
 	if err != nil {
 		panic(err.Error())
 	}
@@ -167,9 +151,9 @@ func systemReboot(sc gnoi_system_pb.SystemClient, ctx context.Context) {
 func systemCancelReboot(sc gnoi_system_pb.SystemClient, ctx context.Context) {
 	fmt.Println("System CancelReboot")
 	ctx = setUserCreds(ctx)
-	req := &gnoi_system_pb.CancelRebootRequest {}
+	req := &gnoi_system_pb.CancelRebootRequest{}
 	json.Unmarshal([]byte(*args), req)
-	resp,err := sc.CancelReboot(ctx, req)
+	resp, err := sc.CancelReboot(ctx, req)
 	if err != nil {
 		panic(err.Error())
 	}
@@ -183,8 +167,8 @@ func systemCancelReboot(sc gnoi_system_pb.SystemClient, ctx context.Context) {
 func systemRebootStatus(sc gnoi_system_pb.SystemClient, ctx context.Context) {
 	fmt.Println("System RebootStatus")
 	ctx = setUserCreds(ctx)
-	req := &gnoi_system_pb.RebootStatusRequest {}
-	resp,err := sc.RebootStatus(ctx, req)
+	req := &gnoi_system_pb.RebootStatusRequest{}
+	resp, err := sc.RebootStatus(ctx, req)
 	if err != nil {
 		panic(err.Error())
 	}
@@ -195,18 +179,37 @@ func systemRebootStatus(sc gnoi_system_pb.SystemClient, ctx context.Context) {
 	fmt.Println(string(respstr))
 }
 
+// RPC for File Services
+func fileStat(fc gnoi_file_pb.FileClient, ctx context.Context) {
+	fmt.Println("File Stat")
+	ctx = setUserCreds(ctx)
+	req := &gnoi_file_pb.StatRequest{}
+	err := json.Unmarshal([]byte(*args), req)
+	if err != nil {
+		panic(err.Error())
+	}
+	resp, err := fc.Stat(ctx, req)
+	if err != nil {
+		panic(err.Error())
+	}
+	respstr, err := json.Marshal(resp)
+	if err != nil {
+		panic(err.Error())
+	}
+	fmt.Println(string(respstr))
+}
+
+// RPC for Sonic Services
 func sonicShowTechSupport(sc spb.SonicServiceClient, ctx context.Context) {
 	fmt.Println("Sonic ShowTechsupport")
 	ctx = setUserCreds(ctx)
-	req := &spb.TechsupportRequest {
-		Input: &spb.TechsupportRequest_Input{
-			
-		},
+	req := &spb.TechsupportRequest{
+		Input: &spb.TechsupportRequest_Input{},
 	}
 
 	json.Unmarshal([]byte(*args), req)
-	
-	resp,err := sc.ShowTechsupport(ctx, req)
+
+	resp, err := sc.ShowTechsupport(ctx, req)
 	if err != nil {
 		panic(err.Error())
 	}
@@ -217,7 +220,7 @@ func sonicShowTechSupport(sc spb.SonicServiceClient, ctx context.Context) {
 	fmt.Println(string(respstr))
 }
 
-func copyConfig(sc spb.SonicServiceClient, ctx context.Context) {
+func sonicCopyConfig(sc spb.SonicServiceClient, ctx context.Context) {
 	fmt.Println("Sonic CopyConfig")
 	ctx = setUserCreds(ctx)
 	req := &spb.CopyConfigRequest{
@@ -225,7 +228,7 @@ func copyConfig(sc spb.SonicServiceClient, ctx context.Context) {
 	}
 	json.Unmarshal([]byte(*args), req)
 
-	resp,err := sc.CopyConfig(ctx, req)
+	resp, err := sc.CopyConfig(ctx, req)
 
 	if err != nil {
 		panic(err.Error())
@@ -236,7 +239,8 @@ func copyConfig(sc spb.SonicServiceClient, ctx context.Context) {
 	}
 	fmt.Println(string(respstr))
 }
-func imageInstall(sc spb.SonicServiceClient, ctx context.Context) {
+
+func sonicImageInstall(sc spb.SonicServiceClient, ctx context.Context) {
 	fmt.Println("Sonic ImageInstall")
 	ctx = setUserCreds(ctx)
 	req := &spb.ImageInstallRequest{
@@ -244,7 +248,7 @@ func imageInstall(sc spb.SonicServiceClient, ctx context.Context) {
 	}
 	json.Unmarshal([]byte(*args), req)
 
-	resp,err := sc.ImageInstall(ctx, req)
+	resp, err := sc.ImageInstall(ctx, req)
 
 	if err != nil {
 		panic(err.Error())
@@ -255,7 +259,8 @@ func imageInstall(sc spb.SonicServiceClient, ctx context.Context) {
 	}
 	fmt.Println(string(respstr))
 }
-func imageRemove(sc spb.SonicServiceClient, ctx context.Context) {
+
+func sonicImageRemove(sc spb.SonicServiceClient, ctx context.Context) {
 	fmt.Println("Sonic ImageRemove")
 	ctx = setUserCreds(ctx)
 	req := &spb.ImageRemoveRequest{
@@ -263,7 +268,7 @@ func imageRemove(sc spb.SonicServiceClient, ctx context.Context) {
 	}
 	json.Unmarshal([]byte(*args), req)
 
-	resp,err := sc.ImageRemove(ctx, req)
+	resp, err := sc.ImageRemove(ctx, req)
 
 	if err != nil {
 		panic(err.Error())
@@ -275,7 +280,7 @@ func imageRemove(sc spb.SonicServiceClient, ctx context.Context) {
 	fmt.Println(string(respstr))
 }
 
-func imageDefault(sc spb.SonicServiceClient, ctx context.Context) {
+func sonicImageDefault(sc spb.SonicServiceClient, ctx context.Context) {
 	fmt.Println("Sonic ImageDefault")
 	ctx = setUserCreds(ctx)
 	req := &spb.ImageDefaultRequest{
@@ -283,7 +288,7 @@ func imageDefault(sc spb.SonicServiceClient, ctx context.Context) {
 	}
 	json.Unmarshal([]byte(*args), req)
 
-	resp,err := sc.ImageDefault(ctx, req)
+	resp, err := sc.ImageDefault(ctx, req)
 
 	if err != nil {
 		panic(err.Error())
@@ -295,14 +300,14 @@ func imageDefault(sc spb.SonicServiceClient, ctx context.Context) {
 	fmt.Println(string(respstr))
 }
 
-func authenticate(sc spb_jwt.SonicJwtServiceClient, ctx context.Context) {
+func sonicAuthenticate(sc spb_jwt.SonicJwtServiceClient, ctx context.Context) {
 	fmt.Println("Sonic Authenticate")
 	ctx = setUserCreds(ctx)
-	req := &spb_jwt.AuthenticateRequest {}
-	
+	req := &spb_jwt.AuthenticateRequest{}
+
 	json.Unmarshal([]byte(*args), req)
-	
-	resp,err := sc.Authenticate(ctx, req)
+
+	resp, err := sc.Authenticate(ctx, req)
 	if err != nil {
 		panic(err.Error())
 	}
@@ -313,14 +318,14 @@ func authenticate(sc spb_jwt.SonicJwtServiceClient, ctx context.Context) {
 	fmt.Println(string(respstr))
 }
 
-func refresh(sc spb_jwt.SonicJwtServiceClient, ctx context.Context) {
+func sonicRefresh(sc spb_jwt.SonicJwtServiceClient, ctx context.Context) {
 	fmt.Println("Sonic Refresh")
 	ctx = setUserCreds(ctx)
-	req := &spb_jwt.RefreshRequest {}
-	
+	req := &spb_jwt.RefreshRequest{}
+
 	json.Unmarshal([]byte(*args), req)
 
-	resp,err := sc.Refresh(ctx, req)
+	resp, err := sc.Refresh(ctx, req)
 	if err != nil {
 		panic(err.Error())
 	}
@@ -331,22 +336,22 @@ func refresh(sc spb_jwt.SonicJwtServiceClient, ctx context.Context) {
 	fmt.Println(string(respstr))
 }
 
-func clearNeighbors(sc spb.SonicServiceClient, ctx context.Context) {
-    fmt.Println("Sonic ClearNeighbors")
-    ctx = setUserCreds(ctx)
-    req := &spb.ClearNeighborsRequest{
-        Input: &spb.ClearNeighborsRequest_Input{},
-    }
-    json.Unmarshal([]byte(*args), req)
+func sonicClearNeighbors(sc spb.SonicServiceClient, ctx context.Context) {
+	fmt.Println("Sonic ClearNeighbors")
+	ctx = setUserCreds(ctx)
+	req := &spb.ClearNeighborsRequest{
+		Input: &spb.ClearNeighborsRequest_Input{},
+	}
+	json.Unmarshal([]byte(*args), req)
 
-    resp,err := sc.ClearNeighbors(ctx, req)
+	resp, err := sc.ClearNeighbors(ctx, req)
 
-    if err != nil {
-        panic(err.Error())
-    }
-    respstr, err := json.Marshal(resp)
-    if err != nil {
-        panic(err.Error())
-    }
-    fmt.Println(string(respstr))
+	if err != nil {
+		panic(err.Error())
+	}
+	respstr, err := json.Marshal(resp)
+	if err != nil {
+		panic(err.Error())
+	}
+	fmt.Println(string(respstr))
 }

--- a/gnoi_client/gnoi_client.go
+++ b/gnoi_client/gnoi_client.go
@@ -2,15 +2,11 @@ package main
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 	"github.com/google/gnxi/utils/credentials"
-	gnoi_file_pb "github.com/openconfig/gnoi/file"
-	spb "github.com/sonic-net/sonic-gnmi/proto/gnoi"
-	spb_jwt "github.com/sonic-net/sonic-gnmi/proto/gnoi/jwt"
 	"github.com/sonic-net/sonic-gnmi/gnoi_client/config"
-	"github.com/sonic-net/sonic-gnmi/gnoi_client/utils"
 	"github.com/sonic-net/sonic-gnmi/gnoi_client/system"
+	"github.com/sonic-net/sonic-gnmi/gnoi_client/file"
+	"github.com/sonic-net/sonic-gnmi/gnoi_client/sonic"
 	"google.golang.org/grpc"
 	"os"
 	"os/signal"
@@ -49,39 +45,30 @@ func main() {
 			panic("Invalid RPC Name")
 		}
 	case "File":
-		fc := gnoi_file_pb.NewFileClient(conn)
 		switch *config.Rpc {
 		case "Stat":
-			fileStat(fc, ctx)
+			file.Stat(conn, ctx)
 		default:
 			panic("Invalid RPC Name")
 		}
 	case "Sonic":
 		switch *config.Rpc {
 		case "showtechsupport":
-			sc := spb.NewSonicServiceClient(conn)
-			sonicShowTechSupport(sc, ctx)
+			sonic.ShowTechSupport(conn, ctx)
 		case "copyConfig":
-			sc := spb.NewSonicServiceClient(conn)
-			sonicCopyConfig(sc, ctx)
+			sonic.CopyConfig(conn, ctx)
 		case "authenticate":
-			sc := spb_jwt.NewSonicJwtServiceClient(conn)
-			sonicAuthenticate(sc, ctx)
+			sonic.Authenticate(conn, ctx)
 		case "imageInstall":
-			sc := spb.NewSonicServiceClient(conn)
-			sonicImageInstall(sc, ctx)
+			sonic.ImageInstall(conn, ctx)
 		case "imageDefault":
-			sc := spb.NewSonicServiceClient(conn)
-			sonicImageDefault(sc, ctx)
+			sonic.ImageDefault(conn, ctx)
 		case "imageRemove":
-			sc := spb.NewSonicServiceClient(conn)
-			sonicImageRemove(sc, ctx)
+			sonic.ImageRemove(conn, ctx)
 		case "refresh":
-			sc := spb_jwt.NewSonicJwtServiceClient(conn)
-			sonicRefresh(sc, ctx)
+			sonic.Refresh(conn, ctx)
 		case "clearNeighbors":
-			sc := spb.NewSonicServiceClient(conn)
-			sonicClearNeighbors(sc, ctx)
+			sonic.ClearNeighbors(conn, ctx)
 		default:
 			panic("Invalid RPC Name")
 		}
@@ -89,181 +76,4 @@ func main() {
 		panic("Invalid Module Name")
 	}
 
-}
-
-// RPC for File Services
-func fileStat(fc gnoi_file_pb.FileClient, ctx context.Context) {
-	fmt.Println("File Stat")
-	ctx = utils.SetUserCreds(ctx)
-	req := &gnoi_file_pb.StatRequest{}
-	err := json.Unmarshal([]byte(*config.Args), req)
-	if err != nil {
-		panic(err.Error())
-	}
-	resp, err := fc.Stat(ctx, req)
-	if err != nil {
-		panic(err.Error())
-	}
-	respstr, err := json.Marshal(resp)
-	if err != nil {
-		panic(err.Error())
-	}
-	fmt.Println(string(respstr))
-}
-
-// RPC for Sonic Services
-func sonicShowTechSupport(sc spb.SonicServiceClient, ctx context.Context) {
-	fmt.Println("Sonic ShowTechsupport")
-	ctx = utils.SetUserCreds(ctx)
-	req := &spb.TechsupportRequest{
-		Input: &spb.TechsupportRequest_Input{},
-	}
-
-	json.Unmarshal([]byte(*config.Args), req)
-
-	resp, err := sc.ShowTechsupport(ctx, req)
-	if err != nil {
-		panic(err.Error())
-	}
-	respstr, err := json.Marshal(resp)
-	if err != nil {
-		panic(err.Error())
-	}
-	fmt.Println(string(respstr))
-}
-
-func sonicCopyConfig(sc spb.SonicServiceClient, ctx context.Context) {
-	fmt.Println("Sonic CopyConfig")
-	ctx = utils.SetUserCreds(ctx)
-	req := &spb.CopyConfigRequest{
-		Input: &spb.CopyConfigRequest_Input{},
-	}
-	json.Unmarshal([]byte(*config.Args), req)
-
-	resp, err := sc.CopyConfig(ctx, req)
-
-	if err != nil {
-		panic(err.Error())
-	}
-	respstr, err := json.Marshal(resp)
-	if err != nil {
-		panic(err.Error())
-	}
-	fmt.Println(string(respstr))
-}
-
-func sonicImageInstall(sc spb.SonicServiceClient, ctx context.Context) {
-	fmt.Println("Sonic ImageInstall")
-	ctx = utils.SetUserCreds(ctx)
-	req := &spb.ImageInstallRequest{
-		Input: &spb.ImageInstallRequest_Input{},
-	}
-	json.Unmarshal([]byte(*config.Args), req)
-
-	resp, err := sc.ImageInstall(ctx, req)
-
-	if err != nil {
-		panic(err.Error())
-	}
-	respstr, err := json.Marshal(resp)
-	if err != nil {
-		panic(err.Error())
-	}
-	fmt.Println(string(respstr))
-}
-
-func sonicImageRemove(sc spb.SonicServiceClient, ctx context.Context) {
-	fmt.Println("Sonic ImageRemove")
-	ctx = utils.SetUserCreds(ctx)
-	req := &spb.ImageRemoveRequest{
-		Input: &spb.ImageRemoveRequest_Input{},
-	}
-	json.Unmarshal([]byte(*config.Args), req)
-
-	resp, err := sc.ImageRemove(ctx, req)
-
-	if err != nil {
-		panic(err.Error())
-	}
-	respstr, err := json.Marshal(resp)
-	if err != nil {
-		panic(err.Error())
-	}
-	fmt.Println(string(respstr))
-}
-
-func sonicImageDefault(sc spb.SonicServiceClient, ctx context.Context) {
-	fmt.Println("Sonic ImageDefault")
-	ctx = utils.SetUserCreds(ctx)
-	req := &spb.ImageDefaultRequest{
-		Input: &spb.ImageDefaultRequest_Input{},
-	}
-	json.Unmarshal([]byte(*config.Args), req)
-
-	resp, err := sc.ImageDefault(ctx, req)
-
-	if err != nil {
-		panic(err.Error())
-	}
-	respstr, err := json.Marshal(resp)
-	if err != nil {
-		panic(err.Error())
-	}
-	fmt.Println(string(respstr))
-}
-
-func sonicAuthenticate(sc spb_jwt.SonicJwtServiceClient, ctx context.Context) {
-	fmt.Println("Sonic Authenticate")
-	ctx = utils.SetUserCreds(ctx)
-	req := &spb_jwt.AuthenticateRequest{}
-
-	json.Unmarshal([]byte(*config.Args), req)
-
-	resp, err := sc.Authenticate(ctx, req)
-	if err != nil {
-		panic(err.Error())
-	}
-	respstr, err := json.Marshal(resp)
-	if err != nil {
-		panic(err.Error())
-	}
-	fmt.Println(string(respstr))
-}
-
-func sonicRefresh(sc spb_jwt.SonicJwtServiceClient, ctx context.Context) {
-	fmt.Println("Sonic Refresh")
-	ctx = utils.SetUserCreds(ctx)
-	req := &spb_jwt.RefreshRequest{}
-
-	json.Unmarshal([]byte(*config.Args), req)
-
-	resp, err := sc.Refresh(ctx, req)
-	if err != nil {
-		panic(err.Error())
-	}
-	respstr, err := json.Marshal(resp)
-	if err != nil {
-		panic(err.Error())
-	}
-	fmt.Println(string(respstr))
-}
-
-func sonicClearNeighbors(sc spb.SonicServiceClient, ctx context.Context) {
-	fmt.Println("Sonic ClearNeighbors")
-	ctx = utils.SetUserCreds(ctx)
-	req := &spb.ClearNeighborsRequest{
-		Input: &spb.ClearNeighborsRequest_Input{},
-	}
-	json.Unmarshal([]byte(*config.Args), req)
-
-	resp, err := sc.ClearNeighbors(ctx, req)
-
-	if err != nil {
-		panic(err.Error())
-	}
-	respstr, err := json.Marshal(resp)
-	if err != nil {
-		panic(err.Error())
-	}
-	fmt.Println(string(respstr))
 }

--- a/gnoi_client/gnoi_client.go
+++ b/gnoi_client/gnoi_client.go
@@ -10,18 +10,12 @@ import (
 	spb "github.com/sonic-net/sonic-gnmi/proto/gnoi"
 	spb_jwt "github.com/sonic-net/sonic-gnmi/proto/gnoi/jwt"
 	"github.com/sonic-net/sonic-gnmi/gnoi_client/config"
+	"github.com/sonic-net/sonic-gnmi/gnoi_client/utils"
+	"github.com/sonic-net/sonic-gnmi/gnoi_client/system"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/metadata"
 	"os"
 	"os/signal"
 )
-
-func setUserCreds(ctx context.Context) context.Context {
-	if len(*config.JwtToken) > 0 {
-		ctx = metadata.AppendToOutgoingContext(ctx, "access_token", *config.JwtToken)
-	}
-	return ctx
-}
 
 func main() {
 	config.ParseFlag()
@@ -44,7 +38,7 @@ func main() {
 		sc := gnoi_system_pb.NewSystemClient(conn)
 		switch *config.Rpc {
 		case "Time":
-			systemTime(sc, ctx)
+			system.Time(conn, ctx)
 		case "Reboot":
 			systemReboot(sc, ctx)
 		case "CancelReboot":
@@ -102,7 +96,7 @@ func main() {
 // RPC for System Services
 func systemTime(sc gnoi_system_pb.SystemClient, ctx context.Context) {
 	fmt.Println("System Time")
-	ctx = setUserCreds(ctx)
+	ctx = utils.SetUserCreds(ctx)
 	resp, err := sc.Time(ctx, new(gnoi_system_pb.TimeRequest))
 	if err != nil {
 		panic(err.Error())
@@ -116,7 +110,7 @@ func systemTime(sc gnoi_system_pb.SystemClient, ctx context.Context) {
 
 func systemKillProcess(sc gnoi_system_pb.SystemClient, ctx context.Context) {
 	fmt.Println("Kill Process with optional restart")
-	ctx = setUserCreds(ctx)
+	ctx = utils.SetUserCreds(ctx)
 	req := &gnoi_system_pb.KillProcessRequest{}
 	err := json.Unmarshal([]byte(*config.Args), req)
 	if err != nil {
@@ -130,7 +124,7 @@ func systemKillProcess(sc gnoi_system_pb.SystemClient, ctx context.Context) {
 
 func systemReboot(sc gnoi_system_pb.SystemClient, ctx context.Context) {
 	fmt.Println("System Reboot")
-	ctx = setUserCreds(ctx)
+	ctx = utils.SetUserCreds(ctx)
 	req := &gnoi_system_pb.RebootRequest{}
 	json.Unmarshal([]byte(*config.Args), req)
 	_, err := sc.Reboot(ctx, req)
@@ -141,7 +135,7 @@ func systemReboot(sc gnoi_system_pb.SystemClient, ctx context.Context) {
 
 func systemCancelReboot(sc gnoi_system_pb.SystemClient, ctx context.Context) {
 	fmt.Println("System CancelReboot")
-	ctx = setUserCreds(ctx)
+	ctx = utils.SetUserCreds(ctx)
 	req := &gnoi_system_pb.CancelRebootRequest{}
 	json.Unmarshal([]byte(*config.Args), req)
 	resp, err := sc.CancelReboot(ctx, req)
@@ -157,7 +151,7 @@ func systemCancelReboot(sc gnoi_system_pb.SystemClient, ctx context.Context) {
 
 func systemRebootStatus(sc gnoi_system_pb.SystemClient, ctx context.Context) {
 	fmt.Println("System RebootStatus")
-	ctx = setUserCreds(ctx)
+	ctx = utils.SetUserCreds(ctx)
 	req := &gnoi_system_pb.RebootStatusRequest{}
 	resp, err := sc.RebootStatus(ctx, req)
 	if err != nil {
@@ -173,7 +167,7 @@ func systemRebootStatus(sc gnoi_system_pb.SystemClient, ctx context.Context) {
 // RPC for File Services
 func fileStat(fc gnoi_file_pb.FileClient, ctx context.Context) {
 	fmt.Println("File Stat")
-	ctx = setUserCreds(ctx)
+	ctx = utils.SetUserCreds(ctx)
 	req := &gnoi_file_pb.StatRequest{}
 	err := json.Unmarshal([]byte(*config.Args), req)
 	if err != nil {
@@ -193,7 +187,7 @@ func fileStat(fc gnoi_file_pb.FileClient, ctx context.Context) {
 // RPC for Sonic Services
 func sonicShowTechSupport(sc spb.SonicServiceClient, ctx context.Context) {
 	fmt.Println("Sonic ShowTechsupport")
-	ctx = setUserCreds(ctx)
+	ctx = utils.SetUserCreds(ctx)
 	req := &spb.TechsupportRequest{
 		Input: &spb.TechsupportRequest_Input{},
 	}
@@ -213,7 +207,7 @@ func sonicShowTechSupport(sc spb.SonicServiceClient, ctx context.Context) {
 
 func sonicCopyConfig(sc spb.SonicServiceClient, ctx context.Context) {
 	fmt.Println("Sonic CopyConfig")
-	ctx = setUserCreds(ctx)
+	ctx = utils.SetUserCreds(ctx)
 	req := &spb.CopyConfigRequest{
 		Input: &spb.CopyConfigRequest_Input{},
 	}
@@ -233,7 +227,7 @@ func sonicCopyConfig(sc spb.SonicServiceClient, ctx context.Context) {
 
 func sonicImageInstall(sc spb.SonicServiceClient, ctx context.Context) {
 	fmt.Println("Sonic ImageInstall")
-	ctx = setUserCreds(ctx)
+	ctx = utils.SetUserCreds(ctx)
 	req := &spb.ImageInstallRequest{
 		Input: &spb.ImageInstallRequest_Input{},
 	}
@@ -253,7 +247,7 @@ func sonicImageInstall(sc spb.SonicServiceClient, ctx context.Context) {
 
 func sonicImageRemove(sc spb.SonicServiceClient, ctx context.Context) {
 	fmt.Println("Sonic ImageRemove")
-	ctx = setUserCreds(ctx)
+	ctx = utils.SetUserCreds(ctx)
 	req := &spb.ImageRemoveRequest{
 		Input: &spb.ImageRemoveRequest_Input{},
 	}
@@ -273,7 +267,7 @@ func sonicImageRemove(sc spb.SonicServiceClient, ctx context.Context) {
 
 func sonicImageDefault(sc spb.SonicServiceClient, ctx context.Context) {
 	fmt.Println("Sonic ImageDefault")
-	ctx = setUserCreds(ctx)
+	ctx = utils.SetUserCreds(ctx)
 	req := &spb.ImageDefaultRequest{
 		Input: &spb.ImageDefaultRequest_Input{},
 	}
@@ -293,7 +287,7 @@ func sonicImageDefault(sc spb.SonicServiceClient, ctx context.Context) {
 
 func sonicAuthenticate(sc spb_jwt.SonicJwtServiceClient, ctx context.Context) {
 	fmt.Println("Sonic Authenticate")
-	ctx = setUserCreds(ctx)
+	ctx = utils.SetUserCreds(ctx)
 	req := &spb_jwt.AuthenticateRequest{}
 
 	json.Unmarshal([]byte(*config.Args), req)
@@ -311,7 +305,7 @@ func sonicAuthenticate(sc spb_jwt.SonicJwtServiceClient, ctx context.Context) {
 
 func sonicRefresh(sc spb_jwt.SonicJwtServiceClient, ctx context.Context) {
 	fmt.Println("Sonic Refresh")
-	ctx = setUserCreds(ctx)
+	ctx = utils.SetUserCreds(ctx)
 	req := &spb_jwt.RefreshRequest{}
 
 	json.Unmarshal([]byte(*config.Args), req)
@@ -329,7 +323,7 @@ func sonicRefresh(sc spb_jwt.SonicJwtServiceClient, ctx context.Context) {
 
 func sonicClearNeighbors(sc spb.SonicServiceClient, ctx context.Context) {
 	fmt.Println("Sonic ClearNeighbors")
-	ctx = setUserCreds(ctx)
+	ctx = utils.SetUserCreds(ctx)
 	req := &spb.ClearNeighborsRequest{
 		Input: &spb.ClearNeighborsRequest_Input{},
 	}

--- a/gnoi_client/gnoi_client.go
+++ b/gnoi_client/gnoi_client.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"github.com/google/gnxi/utils/credentials"
 	gnoi_file_pb "github.com/openconfig/gnoi/file"
-	gnoi_system_pb "github.com/openconfig/gnoi/system"
 	spb "github.com/sonic-net/sonic-gnmi/proto/gnoi"
 	spb_jwt "github.com/sonic-net/sonic-gnmi/proto/gnoi/jwt"
 	"github.com/sonic-net/sonic-gnmi/gnoi_client/config"
@@ -35,18 +34,17 @@ func main() {
 
 	switch *config.Module {
 	case "System":
-		sc := gnoi_system_pb.NewSystemClient(conn)
 		switch *config.Rpc {
 		case "Time":
 			system.Time(conn, ctx)
 		case "Reboot":
-			systemReboot(sc, ctx)
+			system.Reboot(conn, ctx)
 		case "CancelReboot":
-			systemCancelReboot(sc, ctx)
+			system.CancelReboot(conn, ctx)
 		case "RebootStatus":
-			systemRebootStatus(sc, ctx)
+			system.RebootStatus(conn, ctx)
 		case "KillProcess":
-			systemKillProcess(sc, ctx)
+			system.KillProcess(conn, ctx)
 		default:
 			panic("Invalid RPC Name")
 		}
@@ -91,77 +89,6 @@ func main() {
 		panic("Invalid Module Name")
 	}
 
-}
-
-// RPC for System Services
-func systemTime(sc gnoi_system_pb.SystemClient, ctx context.Context) {
-	fmt.Println("System Time")
-	ctx = utils.SetUserCreds(ctx)
-	resp, err := sc.Time(ctx, new(gnoi_system_pb.TimeRequest))
-	if err != nil {
-		panic(err.Error())
-	}
-	respstr, err := json.Marshal(resp)
-	if err != nil {
-		panic(err.Error())
-	}
-	fmt.Println(string(respstr))
-}
-
-func systemKillProcess(sc gnoi_system_pb.SystemClient, ctx context.Context) {
-	fmt.Println("Kill Process with optional restart")
-	ctx = utils.SetUserCreds(ctx)
-	req := &gnoi_system_pb.KillProcessRequest{}
-	err := json.Unmarshal([]byte(*config.Args), req)
-	if err != nil {
-		panic(err.Error())
-	}
-	_, err = sc.KillProcess(ctx, req)
-	if err != nil {
-		panic(err.Error())
-	}
-}
-
-func systemReboot(sc gnoi_system_pb.SystemClient, ctx context.Context) {
-	fmt.Println("System Reboot")
-	ctx = utils.SetUserCreds(ctx)
-	req := &gnoi_system_pb.RebootRequest{}
-	json.Unmarshal([]byte(*config.Args), req)
-	_, err := sc.Reboot(ctx, req)
-	if err != nil {
-		panic(err.Error())
-	}
-}
-
-func systemCancelReboot(sc gnoi_system_pb.SystemClient, ctx context.Context) {
-	fmt.Println("System CancelReboot")
-	ctx = utils.SetUserCreds(ctx)
-	req := &gnoi_system_pb.CancelRebootRequest{}
-	json.Unmarshal([]byte(*config.Args), req)
-	resp, err := sc.CancelReboot(ctx, req)
-	if err != nil {
-		panic(err.Error())
-	}
-	respstr, err := json.Marshal(resp)
-	if err != nil {
-		panic(err.Error())
-	}
-	fmt.Println(string(respstr))
-}
-
-func systemRebootStatus(sc gnoi_system_pb.SystemClient, ctx context.Context) {
-	fmt.Println("System RebootStatus")
-	ctx = utils.SetUserCreds(ctx)
-	req := &gnoi_system_pb.RebootStatusRequest{}
-	resp, err := sc.RebootStatus(ctx, req)
-	if err != nil {
-		panic(err.Error())
-	}
-	respstr, err := json.Marshal(resp)
-	if err != nil {
-		panic(err.Error())
-	}
-	fmt.Println(string(respstr))
 }
 
 // RPC for File Services

--- a/gnoi_client/sonic/jwt.go
+++ b/gnoi_client/sonic/jwt.go
@@ -1,0 +1,46 @@
+package sonic
+
+import (
+	"context"
+	"fmt"
+	"encoding/json"
+	pb "github.com/sonic-net/sonic-gnmi/proto/gnoi/jwt"
+	"github.com/sonic-net/sonic-gnmi/gnoi_client/utils"
+	"github.com/sonic-net/sonic-gnmi/gnoi_client/config"
+	"google.golang.org/grpc"
+)
+
+func Authenticate(conn *grpc.ClientConn, ctx context.Context) {
+	fmt.Println("Sonic Authenticate")
+	ctx = utils.SetUserCreds(ctx)
+	sc := pb.NewSonicJwtServiceClient(conn)
+	req := &pb.AuthenticateRequest{}
+	json.Unmarshal([]byte(*config.Args), req)
+
+	resp, err := sc.Authenticate(ctx, req)
+	if err != nil {
+		panic(err.Error())
+	}
+	respstr, err := json.Marshal(resp)
+	if err != nil {
+		panic(err.Error())
+	}
+	fmt.Println(string(respstr))
+}
+
+func Refresh(conn *grpc.ClientConn, ctx context.Context) {
+	fmt.Println("Sonic Refresh")
+	ctx = utils.SetUserCreds(ctx)
+	sc := pb.NewSonicJwtServiceClient(conn)
+	req := &pb.RefreshRequest{}
+	json.Unmarshal([]byte(*config.Args), req)
+	resp, err := sc.Refresh(ctx, req)
+	if err != nil {
+		panic(err.Error())
+	}
+	respstr, err := json.Marshal(resp)
+	if err != nil {
+		panic(err.Error())
+	}
+	fmt.Println(string(respstr))
+}

--- a/gnoi_client/sonic/sonic.go
+++ b/gnoi_client/sonic/sonic.go
@@ -1,0 +1,132 @@
+package sonic
+
+import (
+	"context"
+	"fmt"
+	"encoding/json"
+	pb "github.com/sonic-net/sonic-gnmi/proto/gnoi"
+	"github.com/sonic-net/sonic-gnmi/gnoi_client/utils"
+	"github.com/sonic-net/sonic-gnmi/gnoi_client/config"
+	"google.golang.org/grpc"
+)
+
+func ShowTechSupport(conn *grpc.ClientConn, ctx context.Context) {
+	fmt.Println("Sonic ShowTechsupport")
+	ctx = utils.SetUserCreds(ctx)
+	sc := pb.NewSonicServiceClient(conn)
+	req := &pb.TechsupportRequest{
+		Input: &pb.TechsupportRequest_Input{},
+	}
+
+	json.Unmarshal([]byte(*config.Args), req)
+
+	resp, err := sc.ShowTechsupport(ctx, req)
+	if err != nil {
+		panic(err.Error())
+	}
+	respstr, err := json.Marshal(resp)
+	if err != nil {
+		panic(err.Error())
+	}
+	fmt.Println(string(respstr))
+}
+
+func CopyConfig(conn *grpc.ClientConn, ctx context.Context) {
+	fmt.Println("Sonic CopyConfig")
+	ctx = utils.SetUserCreds(ctx)
+	sc := pb.NewSonicServiceClient(conn)
+	req := &pb.CopyConfigRequest{
+		Input: &pb.CopyConfigRequest_Input{},
+	}
+	json.Unmarshal([]byte(*config.Args), req)
+	resp, err := sc.CopyConfig(ctx, req)
+
+	if err != nil {
+		panic(err.Error())
+	}
+	respstr, err := json.Marshal(resp)
+	if err != nil {
+		panic(err.Error())
+	}
+	fmt.Println(string(respstr))
+}
+
+func ImageInstall(conn *grpc.ClientConn, ctx context.Context) {
+	fmt.Println("Sonic ImageInstall")
+	ctx = utils.SetUserCreds(ctx)
+	sc := pb.NewSonicServiceClient(conn)
+	req := &pb.ImageInstallRequest{
+		Input: &pb.ImageInstallRequest_Input{},
+	}
+	json.Unmarshal([]byte(*config.Args), req)
+
+	resp, err := sc.ImageInstall(ctx, req)
+
+	if err != nil {
+		panic(err.Error())
+	}
+	respstr, err := json.Marshal(resp)
+	if err != nil {
+		panic(err.Error())
+	}
+	fmt.Println(string(respstr))
+}
+
+func ImageRemove(conn *grpc.ClientConn, ctx context.Context) {
+	fmt.Println("Sonic ImageRemove")
+	ctx = utils.SetUserCreds(ctx)
+	sc := pb.NewSonicServiceClient(conn)
+	req := &pb.ImageRemoveRequest{
+		Input: &pb.ImageRemoveRequest_Input{},
+	}
+	json.Unmarshal([]byte(*config.Args), req)
+
+	resp, err := sc.ImageRemove(ctx, req)
+
+	if err != nil {
+		panic(err.Error())
+	}
+	respstr, err := json.Marshal(resp)
+	if err != nil {
+		panic(err.Error())
+	}
+	fmt.Println(string(respstr))
+}
+
+func ImageDefault(conn *grpc.ClientConn, ctx context.Context) {
+	fmt.Println("Sonic ImageDefault")
+	ctx = utils.SetUserCreds(ctx)
+	sc := pb.NewSonicServiceClient(conn)
+	req := &pb.ImageDefaultRequest{
+		Input: &pb.ImageDefaultRequest_Input{},
+	}
+	json.Unmarshal([]byte(*config.Args), req)
+	resp, err := sc.ImageDefault(ctx, req)
+	if err != nil {
+		panic(err.Error())
+	}
+	respstr, err := json.Marshal(resp)
+	if err != nil {
+		panic(err.Error())
+	}
+	fmt.Println(string(respstr))
+}
+
+func ClearNeighbors(conn *grpc.ClientConn, ctx context.Context) {
+	fmt.Println("Sonic ClearNeighbors")
+	ctx = utils.SetUserCreds(ctx)
+	sc := pb.NewSonicServiceClient(conn)
+	req := &pb.ClearNeighborsRequest{
+		Input: &pb.ClearNeighborsRequest_Input{},
+	}
+	json.Unmarshal([]byte(*config.Args), req)
+	resp, err := sc.ClearNeighbors(ctx, req)
+	if err != nil {
+		panic(err.Error())
+	}
+	respstr, err := json.Marshal(resp)
+	if err != nil {
+		panic(err.Error())
+	}
+	fmt.Println(string(respstr))
+}

--- a/gnoi_client/system/kill_process.go
+++ b/gnoi_client/system/kill_process.go
@@ -1,0 +1,26 @@
+package system
+
+import (
+	"context"
+	"fmt"
+	"encoding/json"
+	pb 	"github.com/openconfig/gnoi/system"
+	"github.com/sonic-net/sonic-gnmi/gnoi_client/utils"
+	"github.com/sonic-net/sonic-gnmi/gnoi_client/config"
+	"google.golang.org/grpc"
+)
+
+func KillProcess(conn *grpc.ClientConn, ctx context.Context) {
+	fmt.Println("Kill Process with optional restart")
+	ctx = utils.SetUserCreds(ctx)
+	sc := pb.NewSystemClient(conn)
+	req := &pb.KillProcessRequest{}
+	err := json.Unmarshal([]byte(*config.Args), req)
+	if err != nil {
+		panic(err.Error())
+	}
+	_, err = sc.KillProcess(ctx, req)
+	if err != nil {
+		panic(err.Error())
+	}
+}

--- a/gnoi_client/system/reboot.go
+++ b/gnoi_client/system/reboot.go
@@ -1,0 +1,56 @@
+package system
+
+import (
+	"context"
+	"fmt"
+	"encoding/json"
+	pb 	"github.com/openconfig/gnoi/system"
+	"github.com/sonic-net/sonic-gnmi/gnoi_client/utils"
+	"github.com/sonic-net/sonic-gnmi/gnoi_client/config"
+	"google.golang.org/grpc"
+)
+
+func Reboot(conn *grpc.ClientConn, ctx context.Context) {
+	fmt.Println("System Reboot")
+	ctx = utils.SetUserCreds(ctx)
+	sc := pb.NewSystemClient(conn)
+	req := &pb.RebootRequest{}
+	json.Unmarshal([]byte(*config.Args), req)
+	_, err := sc.Reboot(ctx, req)
+	if err != nil {
+		panic(err.Error())
+	}
+}
+
+func CancelReboot(conn *grpc.ClientConn, ctx context.Context) {
+	fmt.Println("System CancelReboot")
+	ctx = utils.SetUserCreds(ctx)
+	sc := pb.NewSystemClient(conn)
+	req := &pb.CancelRebootRequest{}
+	json.Unmarshal([]byte(*config.Args), req)
+	resp, err := sc.CancelReboot(ctx, req)
+	if err != nil {
+		panic(err.Error())
+	}
+	respstr, err := json.Marshal(resp)
+	if err != nil {
+		panic(err.Error())
+	}
+	fmt.Println(string(respstr))
+}
+
+func RebootStatus(conn *grpc.ClientConn, ctx context.Context) {
+	fmt.Println("System RebootStatus")
+	ctx = utils.SetUserCreds(ctx)
+	sc := pb.NewSystemClient(conn)
+	req := &pb.RebootStatusRequest{}
+	resp, err := sc.RebootStatus(ctx, req)
+	if err != nil {
+		panic(err.Error())
+	}
+	respstr, err := json.Marshal(resp)
+	if err != nil {
+		panic(err.Error())
+	}
+	fmt.Println(string(respstr))
+}

--- a/gnoi_client/system/time.go
+++ b/gnoi_client/system/time.go
@@ -1,0 +1,25 @@
+package system
+
+import (
+	"context"
+	"fmt"
+	"encoding/json"
+	pb 	"github.com/openconfig/gnoi/system"
+	"github.com/sonic-net/sonic-gnmi/gnoi_client/utils"
+	"google.golang.org/grpc"
+)
+
+func Time(conn *grpc.ClientConn, ctx context.Context) {
+	fmt.Println("System Time")
+	ctx = utils.SetUserCreds(ctx)
+	sc := pb.NewSystemClient(conn)
+	resp, err := sc.Time(ctx, new(pb.TimeRequest))
+	if err != nil {
+		panic(err.Error())
+	}
+	respstr, err := json.Marshal(resp)
+	if err != nil {
+		panic(err.Error())
+	}
+	fmt.Println(string(respstr))
+}

--- a/gnoi_client/utils/creds.go
+++ b/gnoi_client/utils/creds.go
@@ -1,0 +1,14 @@
+package utils
+
+import (
+	"context"
+	"google.golang.org/grpc/metadata"
+	"github.com/sonic-net/sonic-gnmi/gnoi_client/config"
+)
+
+func SetUserCreds(ctx context.Context) context.Context {
+	if len(*config.JwtToken) > 0 {
+		ctx = metadata.AppendToOutgoingContext(ctx, "access_token", *config.JwtToken)
+	}
+	return ctx
+}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The gnoi/gnmi code in sonic-gnmi have some diamond dependency problems since different code can dependent on different version of gnoi/gnmi, leading to inability to implement newer services such as `containerz`, which comes after gnoi v0.4.0. Golang with its `go mod vendor` offers a way to solve this problem. But the code needs to be properly modularized to take advantage of this.

#### How I did it
Untangle gnoi_client.go into separate modules such as `config`, `util`, `system`, `file` and `sonic`.

#### How to verify it
built and unit tested, also verified by copying the new gnoi_client binary to a VS and run sonic-mgmt gnoi_kill_process test.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

