### PR TITLE
Fix roles checking if cname not exist

### DIFF
--- a/gnmi_server/server.go
+++ b/gnmi_server/server.go
@@ -270,7 +270,7 @@ func authenticate(config *Config, ctx context.Context, writeAccess bool) (contex
 			success = true
 		}
 		// role must be readwrite to support write access
-		if writeAccess && config.ConfigTableName != "" {
+		if success && writeAccess && config.ConfigTableName != "" {
 			role := rc.Auth.Roles[0]
 			if role != WriteAccessMode {
 				return ctx, fmt.Errorf("%s does not have write access, %s", rc.Auth.User, role)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
Microsoft ADO: 30073317

#### Why I did it
GNMI crashed if there's no cname in GNMI_CLIENT_CERT table

#### How I did it
Check previous result before taking action

#### How to verify it
Run gnmi unit test and end to end test

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

