### PR TITLE
Add a Close method to DBusClient and use it in GNMI server

### DIFF
--- a/gnmi_server/gnoi.go
+++ b/gnmi_server/gnoi.go
@@ -29,6 +29,7 @@ func ReadFileStat(path string) (*gnoi_file_pb.StatInfo, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer sc.Close()
 
 	log.V(2).Infof("Reading file stat at path %s...", path)
 	data, err := sc.GetFileStat(path)
@@ -100,6 +101,8 @@ func KillOrRestartProcess(restart bool, serviceName string) error {
 	if err != nil {
 		return err
 	}
+	defer sc.Close()
+
 	if restart {
 		log.V(2).Infof("Restarting service %s...", serviceName)
 		err = sc.RestartService(serviceName)
@@ -129,6 +132,7 @@ func (srv *OSServer) Verify(ctx context.Context, req *gnoi_os_pb.VerifyRequest) 
 		log.V(2).Infof("Failed to create dbus client: %v", err)
 		return nil, err
 	}
+	defer dbus.Close()
 
 	image_json, err := dbus.ListImages()
 	if err != nil {
@@ -186,6 +190,7 @@ func HaltSystem() error {
 	if err != nil {
 		return err
 	}
+	defer sc.Close()
 
 	log.V(2).Infof("Halting the system..")
 	err = sc.HaltSystem()
@@ -201,6 +206,8 @@ func RebootSystem(fileName string) error {
 	if err != nil {
 		return err
 	}
+	defer sc.Close()
+
 	err = sc.ConfigReload(fileName)
 	return err
 }

--- a/sonic_service_client/dbus_client.go
+++ b/sonic_service_client/dbus_client.go
@@ -11,6 +11,10 @@ import (
 )
 
 type Service interface {
+	// Close the connection to the D-Bus
+	Close() error
+
+	// SONiC Host Service D-Bus API
 	ConfigReload(fileName string) error
 	ConfigSave(fileName string) error
 	ApplyPatchYang(fileName string) error
@@ -34,15 +38,25 @@ type DbusClient struct {
 }
 
 func NewDbusClient() (Service, error) {
+	log.Infof("DbusClient: NewDbusClient")
+
 	var client DbusClient
 	var err error
-
 	client.busNamePrefix = "org.SONiC.HostService."
 	client.busPathPrefix = "/org/SONiC/HostService/"
 	client.intNamePrefix = "org.SONiC.HostService."
 	err = nil
 
 	return &client, err
+}
+
+// Close the connection to the D-Bus.
+func (c *DbusClient) Close() error {
+	log.Infof("DbusClient: Close")
+	if c.channel != nil {
+		close(c.channel)
+	}
+	return nil
 }
 
 func DbusApi(busName string, busPath string, intName string, timeout int, args ...interface{}) (interface{}, error) {

--- a/sonic_service_client/dbus_client_test.go
+++ b/sonic_service_client/dbus_client_test.go
@@ -29,6 +29,25 @@ func TestCloseClient(t *testing.T) {
 	}
 }
 
+func TestCloseClientWithChannel(t *testing.T) {
+	client, err := NewDbusClient()
+	if err != nil {
+		t.Errorf("NewDbusClient failed: %v", err)
+	}
+	client.(*DbusClient).channel = make(chan struct{})
+	err = client.Close()
+	if err != nil {
+		t.Errorf("Close should pass: %v", err)
+	}
+
+	select {
+	case <-client.(*DbusClient).channel:
+		// Channel is closed
+	default:
+		t.Errorf("Channel should be closed")
+	}
+}
+
 func TestSystemBusNegative(t *testing.T) {
 	client, err := NewDbusClient()
 	if err != nil {

--- a/sonic_service_client/dbus_client_test.go
+++ b/sonic_service_client/dbus_client_test.go
@@ -8,6 +8,27 @@ import (
 	"github.com/godbus/dbus/v5"
 )
 
+func TestNewDbusClient(t *testing.T) {
+	client, err := NewDbusClient()
+	if err != nil {
+		t.Errorf("NewDbusClient failed: %v", err)
+	}
+	if client == nil {
+		t.Errorf("NewDbusClient failed: %v", client)
+	}
+}
+
+func TestCloseClient(t *testing.T) {
+	client, err := NewDbusClient()
+	if err != nil {
+		t.Errorf("NewDbusClient failed: %v", err)
+	}
+	err = client.Close()
+	if err != nil {
+		t.Errorf("Close should pass: %v", err)
+	}
+}
+
 func TestSystemBusNegative(t *testing.T) {
 	client, err := NewDbusClient()
 	if err != nil {


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
DBusClient lacks a close method. We need to rely on GC to close the connection.

#### How I did it
Add a Close method to DBusClient and use it in GNMI server

#### How to verify it
unit test and on DUT.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

