### PR TITLE
Add cert multiple roles support

### DIFF
--- a/gnmi_server/clientCertAuth.go
+++ b/gnmi_server/clientCertAuth.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/golang/glog"

--- a/gnmi_server/clientCertAuth.go
+++ b/gnmi_server/clientCertAuth.go
@@ -265,6 +265,10 @@ func PopulateAuthStructByCommonName(certCommonName string, auth *common_utils.Au
 		if fieldValuePairs.Has_key("role@") {
 			var role = fieldValuePairs.Get("role@")
 			auth.Roles = strings.Split(role, ",")
+		} else if fieldValuePairs.Has_key("role") {
+			// Backward compatibility for single role DB schema
+			var role = fieldValuePairs.Get("role")
+			auth.Roles = []string{role}
 		}
 	} else {
 		glog.Warningf("Failed to retrieve cert common name mapping; %s", certCommonName)

--- a/gnmi_server/clientCertAuth.go
+++ b/gnmi_server/clientCertAuth.go
@@ -263,7 +263,7 @@ func PopulateAuthStructByCommonName(certCommonName string, auth *common_utils.Au
 	if fieldValuePairs.Size() > 0 {
 		if fieldValuePairs.Has_key("role") {
 			var role = fieldValuePairs.Get("role")
-			auth.Roles = []string{role}
+			auth.Roles = strings.Split(role, ",")
 		}
 	} else {
 		glog.Warningf("Failed to retrieve cert common name mapping; %s", certCommonName)

--- a/gnmi_server/clientCertAuth.go
+++ b/gnmi_server/clientCertAuth.go
@@ -262,8 +262,8 @@ func PopulateAuthStructByCommonName(certCommonName string, auth *common_utils.Au
 
 	var fieldValuePairs = configDbConnector.Get_entry(serviceConfigTableName, certCommonName)
 	if fieldValuePairs.Size() > 0 {
-		if fieldValuePairs.Has_key("role") {
-			var role = fieldValuePairs.Get("role")
+		if fieldValuePairs.Has_key("role@") {
+			var role = fieldValuePairs.Get("role@")
 			auth.Roles = strings.Split(role, ",")
 		}
 	} else {

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -4871,7 +4871,7 @@ func TestClientCertAuthenAndAuthor(t *testing.T) {
 	// check get 1 cert name
 	ctx, cancel = CreateAuthorizationCtx()
 	configDb.Flushdb()
-	gnmiTable.Hset("certname1", "role", "readwrite")
+	gnmiTable.Hset("certname1", "role@", "readwrite")
 	ctx, err = ClientCertAuthenAndAuthor(ctx, "GNMI_CLIENT_CERT", false)
 	if err != nil {
 		t.Errorf("CommonNameMatch with correct cert name should success: %v", err)
@@ -4882,8 +4882,8 @@ func TestClientCertAuthenAndAuthor(t *testing.T) {
 	// check get multiple cert names
 	ctx, cancel = CreateAuthorizationCtx()
 	configDb.Flushdb()
-	gnmiTable.Hset("certname1", "role", "readwrite")
-	gnmiTable.Hset("certname2", "role", "readonly")
+	gnmiTable.Hset("certname1", "role@", "readwrite")
+	gnmiTable.Hset("certname2", "role@", "readonly")
 	ctx, err = ClientCertAuthenAndAuthor(ctx, "GNMI_CLIENT_CERT", false)
 	if err != nil {
 		t.Errorf("CommonNameMatch with correct cert name should success: %v", err)
@@ -4894,7 +4894,7 @@ func TestClientCertAuthenAndAuthor(t *testing.T) {
 	// check a invalid cert cname
 	ctx, cancel = CreateAuthorizationCtx()
 	configDb.Flushdb()
-	gnmiTable.Hset("certname2", "role", "readonly")
+	gnmiTable.Hset("certname2", "role@", "readonly")
 	ctx, err = ClientCertAuthenAndAuthor(ctx, "GNMI_CLIENT_CERT", false)
 	if err == nil {
 		t.Errorf("CommonNameMatch with invalid cert name should fail: %v", err)
@@ -4925,7 +4925,7 @@ func TestAuthenticate(t *testing.T) {
 	cfg := &Config{ConfigTableName: tableName, UserAuth: AuthTypes{"password": false, "cert": true, "jwt": false}}
 	ctx, cancel := CreateAuthorizationCtx()
 	configDb.Flushdb()
-	gnmiTable.Hset("certname1", "role", "readonly")
+	gnmiTable.Hset("certname1", "role@", "readonly")
 	// Call authenticate to verify the user's role. This should fail if the role is "readonly".
 	_, err = authenticate(cfg, ctx, true)
 	if err == nil {

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -4871,6 +4871,71 @@ func TestClientCertAuthenAndAuthor(t *testing.T) {
 	// check get 1 cert name
 	ctx, cancel = CreateAuthorizationCtx()
 	configDb.Flushdb()
+	gnmiTable.Hset("certname1", "role", "readwrite")
+	ctx, err = ClientCertAuthenAndAuthor(ctx, "GNMI_CLIENT_CERT", false)
+	if err != nil {
+		t.Errorf("CommonNameMatch with correct cert name should success: %v", err)
+	}
+
+	cancel()
+
+	// check get multiple cert names
+	ctx, cancel = CreateAuthorizationCtx()
+	configDb.Flushdb()
+	gnmiTable.Hset("certname1", "role", "readwrite")
+	gnmiTable.Hset("certname2", "role", "readonly")
+	ctx, err = ClientCertAuthenAndAuthor(ctx, "GNMI_CLIENT_CERT", false)
+	if err != nil {
+		t.Errorf("CommonNameMatch with correct cert name should success: %v", err)
+	}
+
+	cancel()
+
+	// check a invalid cert cname
+	ctx, cancel = CreateAuthorizationCtx()
+	configDb.Flushdb()
+	gnmiTable.Hset("certname2", "role", "readonly")
+	ctx, err = ClientCertAuthenAndAuthor(ctx, "GNMI_CLIENT_CERT", false)
+	if err == nil {
+		t.Errorf("CommonNameMatch with invalid cert name should fail: %v", err)
+	}
+
+	cancel()
+
+	swsscommon.DeleteTable(gnmiTable)
+	swsscommon.DeleteDBConnector(configDb)
+}
+
+func TestClientCertAuthenAndAuthorMultiRole(t *testing.T) {
+	if !swsscommon.SonicDBConfigIsInit() {
+		swsscommon.SonicDBConfigInitialize()
+	}
+
+	var configDb = swsscommon.NewDBConnector("CONFIG_DB", uint(0), true)
+	var gnmiTable = swsscommon.NewTable(configDb, "GNMI_CLIENT_CERT")
+	configDb.Flushdb()
+
+	// initialize err variable
+	err := status.Error(codes.Unauthenticated, "")
+
+	// when config table is empty, will authorize with PopulateAuthStruct
+	mockpopulate := gomonkey.ApplyFunc(PopulateAuthStruct, func(username string, auth *common_utils.AuthInfo, r []string) error {
+		return nil
+	})
+	defer mockpopulate.Reset()
+
+	// check auth with nil cert name
+	ctx, cancel := CreateAuthorizationCtx()
+	ctx, err = ClientCertAuthenAndAuthor(ctx, "", false)
+	if err != nil {
+		t.Errorf("CommonNameMatch with empty config table should success: %v", err)
+	}
+
+	cancel()
+
+	// check get 1 cert name
+	ctx, cancel = CreateAuthorizationCtx()
+	configDb.Flushdb()
 	gnmiTable.Hset("certname1", "role@", "readwrite")
 	ctx, err = ClientCertAuthenAndAuthor(ctx, "GNMI_CLIENT_CERT", false)
 	if err != nil {


### PR DESCRIPTION
Add cert multiple roles support

#### Why I did it
Some scenarios need GNMI support multiple roles

#### How I did it
Change CONFIG_DB schema and read multiple roles from CONFIG_DB

#### How to verify it
Manually test.
Add new UT.

#### Work item tracking
Microsoft ADO (number only): 31561802

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
Add cert multiple roles support

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

