### PR TITLE
Issue #357: Use ConfigReplace when full config is sent over gNMI

### DIFF
--- a/common_utils/context.go
+++ b/common_utils/context.go
@@ -58,6 +58,7 @@ const (
 	DBUS_IMAGE_INSTALL
 	DBUS_IMAGE_LIST
 	DBUS_IMAGE_ACTIVATE
+	DBUS_CONFIG_REPLACE
 	COUNTER_SIZE
 )
 
@@ -103,6 +104,8 @@ func (c CounterType) String() string {
 		return "DBUS image list"
 	case DBUS_IMAGE_ACTIVATE:
 		return "DBUS image activate"
+	case DBUS_CONFIG_REPLACE:
+		return "DBUS config replace"
 	default:
 		return ""
 	}

--- a/sonic_service_client/dbus_client.go
+++ b/sonic_service_client/dbus_client.go
@@ -16,6 +16,7 @@ type Service interface {
 
 	// SONiC Host Service D-Bus API
 	ConfigReload(fileName string) error
+	ConfigReplace(fileName string) error
 	ConfigSave(fileName string) error
 	ApplyPatchYang(fileName string) error
 	ApplyPatchDb(fileName string) error
@@ -124,6 +125,16 @@ func (c *DbusClient) ConfigReload(config string) error {
 	busPath := c.busPathPrefix + modName
 	intName := c.intNamePrefix + modName + ".reload"
 	_, err := DbusApi(busName, busPath, intName, 60, config)
+	return err
+}
+
+func (c *DbusClient) ConfigReplace(config string) error {
+	common_utils.IncCounter(common_utils.DBUS_CONFIG_REPLACE)
+	modName := "gcu"
+	busName := c.busNamePrefix + modName
+	busPath := c.busPathPrefix + modName
+	intName := c.intNamePrefix + modName + ".replace_db"
+	_, err := DbusApi(busName, busPath, intName, 600, config)
 	return err
 }
 

--- a/sonic_service_client/dbus_client_test.go
+++ b/sonic_service_client/dbus_client_test.go
@@ -223,6 +223,67 @@ func TestConfigReloadTimeout(t *testing.T) {
 	}
 }
 
+func TestConfigReplace(t *testing.T) {
+	mock1 := gomonkey.ApplyFunc(dbus.SystemBus, func() (conn *dbus.Conn, err error) {
+		return &dbus.Conn{}, nil
+	})
+	defer mock1.Reset()
+	mock2 := gomonkey.ApplyMethod(reflect.TypeOf(&dbus.Object{}), "Go", func(obj *dbus.Object, method string, flags dbus.Flags, ch chan *dbus.Call, args ...interface{}) *dbus.Call {
+		if method != "org.SONiC.HostService.gcu.replace_db" {
+			t.Errorf("Wrong method: %v", method)
+		}
+		ret := &dbus.Call{}
+		ret.Err = nil
+		ret.Body = make([]interface{}, 2)
+		ret.Body[0] = int32(0)
+		ch <- ret
+		return &dbus.Call{}
+	})
+	defer mock2.Reset()
+
+	client, err := NewDbusClient()
+	if err != nil {
+		t.Errorf("NewDbusClient failed: %v", err)
+	}
+	err = client.ConfigReplace("abc")
+	if err != nil {
+		t.Errorf("ConfigReplace should pass: %v", err)
+	}
+}
+
+func TestConfigReplaceNegative(t *testing.T) {
+	err_msg := "This is the mock error message"
+	mock1 := gomonkey.ApplyFunc(dbus.SystemBus, func() (conn *dbus.Conn, err error) {
+		return &dbus.Conn{}, nil
+	})
+	defer mock1.Reset()
+	mock2 := gomonkey.ApplyMethod(reflect.TypeOf(&dbus.Object{}), "Go", func(obj *dbus.Object, method string, flags dbus.Flags, ch chan *dbus.Call, args ...interface{}) *dbus.Call {
+		if method != "org.SONiC.HostService.gcu.replace_db" {
+			t.Errorf("Wrong method: %v", method)
+		}
+		ret := &dbus.Call{}
+		ret.Err = nil
+		ret.Body = make([]interface{}, 2)
+		ret.Body[0] = int32(1)
+		ret.Body[1] = err_msg
+		ch <- ret
+		return &dbus.Call{}
+	})
+	defer mock2.Reset()
+
+	client, err := NewDbusClient()
+	if err != nil {
+		t.Errorf("NewDbusClient failed: %v", err)
+	}
+	err = client.ConfigReplace("abc")
+	if err == nil {
+		t.Errorf("ConfigReplace should fail")
+	}
+	if err.Error() != err_msg {
+		t.Errorf("Wrong error: %v", err)
+	}
+}
+
 func TestConfigSave(t *testing.T) {
 	mock1 := gomonkey.ApplyFunc(dbus.SystemBus, func() (conn *dbus.Conn, err error) {
 		return &dbus.Conn{}, nil


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

By default, gNMI does a version of `config reload` when passed a full config. This is disruptive, since it requires services to be restarted for it to take effect. It's also not intuitive; all of the other SET gnmi commands take place immediately. By enhancing the full config endpoint handling to trigger `config replace` instead of the gnmi-specific version of reload that exists today, we resolve both of those issues.

The existing implementation uses a full config DELETE given alongside a full config UPDATE to represent a reload. We can leave that syntax and behavior intact and instead add logic to handle a full config REPLACE.

fixes [Issue 357](https://github.com/sonic-net/sonic-gnmi/issues/357)

#### How I did it

There is already a D-BUS endpoint implemented for `config replace`, so all this takes is a handler implemented in [gnmi/sonic_service_client/dbus_client.go](https://github.com/sonic-net/sonic-gnmi/blob/master/sonic_service_client/dbus_client.go) which will pass the full config it receives through to HostServices (and from there to GCU).

#### How to verify it

Manually verified by sending full configs using `gnmic` and ensuring that state changes are propagated to ConfigDb.

DBUS message passing verified by using `dbus-monitor` to verify content of messages being passed.

All sonic-gnmi unit tests pass. New test cases were added to verify the SET-REPLACE handler logic. A new unit test was added to `dbus_client_test.go` to test the new D-Bus endpoint.

A sonic-mgmt testcase for this behavior is proposed [here](https://github.com/sonic-net/sonic-mgmt/issues/17885).

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Use ConfigReplace when full config is sent over gNMI

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

   _
 / . . \                        
  \   /.   \__________/ \
    |    \--------------/
    ^

(be kind i drew it myself)
