### PR TITLE
Manually revert delete field logic

### DIFF
--- a/proto/sonic_internal.pb.go
+++ b/proto/sonic_internal.pb.go
@@ -99,7 +99,6 @@ type Value struct {
 	Fatal string `protobuf:"bytes,6,opt,name=fatal,proto3" json:"fatal,omitempty"`
 	// Notification to be used in place of 1-4 if present
 	Notification *gnmi.Notification `protobuf:"bytes,7,opt,name=notification,proto3" json:"notification,omitempty"`
-	Delete []*gnmi.Path `protobuf:"bytes,8,opt,name=delete,proto3" json:"delete,omitempty"`
 }
 
 func (x *Value) Reset() {
@@ -181,13 +180,6 @@ func (x *Value) GetNotification() *gnmi.Notification {
 		return x.Notification
 	}
 	return nil
-}
-
-func (x *Value) GetDelete() []*gnmi.Path {
-	if x != nil {
-		return x.Delete
-	}
-	return []*gnmi.Path{}
 }
 
 var File_sonic_internal_proto protoreflect.FileDescriptor

--- a/proto/sonic_internal.proto
+++ b/proto/sonic_internal.proto
@@ -36,7 +36,4 @@ message Value {
 
   // Notification to be used in place of 1-4 if present
   gnmi.Notification notification = 7;
-
-  // Delete to be used to indicate that node was deleted
-  repeated gnmi.Path delete = 8;
 }

--- a/sonic_data_client/mixed_db_client.go
+++ b/sonic_data_client/mixed_db_client.go
@@ -1922,11 +1922,6 @@ func (c *MixedDbClient) dbTableKeySubscribe(gnmiPath *gnmipb.Path, interval time
 
 	// Helper to send hash data over the stream
 	sendMsiData := func(msiData map[string]interface{}) error {
-		sendDeleteField := false
-		if _, isDelete := msiData["delete"]; isDelete {
-			sendDeleteField = true
-		}
-		delete(msiData, "delete")
 		val, err := c.msi2TypedValue(msiData)
 		if err != nil {
 			return err
@@ -1938,9 +1933,6 @@ func (c *MixedDbClient) dbTableKeySubscribe(gnmiPath *gnmipb.Path, interval time
 			Path:      gnmiPath,
 			Timestamp: time.Now().UnixNano(),
 			Val:       val,
-		}
-		if sendDeleteField {
-			(*spbv).Delete = []*gnmipb.Path{gnmiPath}
 		}
 		if err = c.q.Put(Value{spbv}); err != nil {
 			return fmt.Errorf("Queue error:  %v", err)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#31673482

Race condition with deleting field from map while another thread reads from the same map. Causes fatal error concurrent map read and write. Reverting this logic for now and will reimplement with better synchronization logic.

#### How I did it

Manually revert since auto revert doesn't work.

#### How to verify it

Manual test.

#### Which release branch to backport (provide reason below if selected)

202411

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

