### PR TITLE
Manually revert delete field logic 202411

### DIFF
--- a/proto/sonic_internal.pb.go
+++ b/proto/sonic_internal.pb.go
@@ -99,7 +99,6 @@ type Value struct {
 	Fatal string `protobuf:"bytes,6,opt,name=fatal,proto3" json:"fatal,omitempty"`
 	// Notification to be used in place of 1-4 if present
 	Notification *gnmi.Notification `protobuf:"bytes,7,opt,name=notification,proto3" json:"notification,omitempty"`
-	Delete []*gnmi.Path `protobuf:"bytes,8,opt,name=delete,proto3" json:"delete,omitempty"`
 }
 
 func (x *Value) Reset() {
@@ -181,13 +180,6 @@ func (x *Value) GetNotification() *gnmi.Notification {
 		return x.Notification
 	}
 	return nil
-}
-
-func (x *Value) GetDelete() []*gnmi.Path {
-	if x != nil {
-		return x.Delete
-	}
-	return []*gnmi.Path{}
 }
 
 var File_sonic_internal_proto protoreflect.FileDescriptor

--- a/proto/sonic_internal.proto
+++ b/proto/sonic_internal.proto
@@ -36,7 +36,4 @@ message Value {
 
   // Notification to be used in place of 1-4 if present
   gnmi.Notification notification = 7;
-
-  // Delete to be used to indicate that node was deleted
-  repeated gnmi.Path delete = 8;
 }

--- a/sonic_data_client/db_client.go
+++ b/sonic_data_client/db_client.go
@@ -389,25 +389,6 @@ func ValToResp(val Value) (*gnmipb.SubscribeResponse, error) {
 				Response: &gnmipb.SubscribeResponse_Update{Update: n}}, nil
 		}
 
-		// In case of path deletion
-		if deleted := val.GetDelete(); deleted != nil {
-			return &gnmipb.SubscribeResponse{
-				Response: &gnmipb.SubscribeResponse_Update{
-					Update: &gnmipb.Notification{
-						Timestamp: val.GetTimestamp(),
-						Prefix:    val.GetPrefix(),
-						Delete:    deleted,
-						Update: []*gnmipb.Update{
-							{
-								Path: val.GetPath(),
-								Val:  val.GetVal(),
-							},
-						},
-					},
-				},
-			}, nil
-		}
-
 		return &gnmipb.SubscribeResponse{
 			Response: &gnmipb.SubscribeResponse_Update{
 				Update: &gnmipb.Notification{
@@ -1151,7 +1132,6 @@ func dbSingleTableKeySubscribe(c *DbClient, rsd redisSubData, updateChannel chan
 					}
 					key := subscr.Channel[prefixLen:]
 					newMsi[key] = fp
-					newMsi["delete"] = "null_value"
 				}
 			} else if subscr.Payload == "hset" {
 				//op := "SET"
@@ -1223,11 +1203,6 @@ func dbTableKeySubscribe(c *DbClient, gnmiPath *gnmipb.Path, interval time.Durat
 
 	// Helper to send hash data over the stream
 	sendMsiData := func(msiData map[string]interface{}) error {
-		sendDeleteField := false
-		if _, isDelete := msiData["delete"]; isDelete {
-			sendDeleteField = true
-		}
-		delete(msiData, "delete")
 		val, err := Msi2TypedValue(msiData)
 		if err != nil {
 			return err
@@ -1239,9 +1214,6 @@ func dbTableKeySubscribe(c *DbClient, gnmiPath *gnmipb.Path, interval time.Durat
 			Path:      gnmiPath,
 			Timestamp: time.Now().UnixNano(),
 			Val:       val,
-		}
-		if sendDeleteField {
-			(*spbv).Delete = []*gnmipb.Path{gnmiPath}
 		}
 		if err = c.q.Put(Value{spbv}); err != nil {
 			return fmt.Errorf("Queue error:  %v", err)

--- a/sonic_data_client/mixed_db_client.go
+++ b/sonic_data_client/mixed_db_client.go
@@ -1900,11 +1900,6 @@ func (c *MixedDbClient) dbTableKeySubscribe(gnmiPath *gnmipb.Path, interval time
 
 	// Helper to send hash data over the stream
 	sendMsiData := func(msiData map[string]interface{}) error {
-		sendDeleteField := false
-		if _, isDelete := msiData["delete"]; isDelete {
-			sendDeleteField = true
-		}
-		delete(msiData, "delete")
 		val, err := c.msi2TypedValue(msiData)
 		if err != nil {
 			return err
@@ -1916,9 +1911,6 @@ func (c *MixedDbClient) dbTableKeySubscribe(gnmiPath *gnmipb.Path, interval time
 			Path:      gnmiPath,
 			Timestamp: time.Now().UnixNano(),
 			Val:       val,
-		}
-		if sendDeleteField {
-			(*spbv).Delete = []*gnmipb.Path{gnmiPath}
 		}
 		if err = c.q.Put(Value{spbv}); err != nil {
 			return fmt.Errorf("Queue error:  %v", err)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Backport PR of #371 

#### How I did it

#### How to verify it

Tested on latest 202411 branch with and without this revert

Without this revert, telemetry crashed within 5-10 minutes, and have not seen it crash with this revert for 20+ mins

Tested this revert on latest 202411 for the SKUs

Arista 7260, Cisco 8102, Mellanox SN 2700, Arista 7060 (slim)

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

