### PR TITLE
Issue #22362: Call ConfigReload on full config gnmi update

### DIFF
--- a/sonic_data_client/mixed_db_client.go
+++ b/sonic_data_client/mixed_db_client.go
@@ -1397,7 +1397,15 @@ func (c *MixedDbClient) SetFullConfig(delete []*gnmipb.Path, replace []*gnmipb.U
 		return fmt.Errorf("Yang validation failed!")
 	}
 
-	return nil
+	if err == nil {
+		var sc ssc.Service
+		sc, err = ssc.NewDbusClient()
+		if err != nil {
+			return err
+		}
+		err = sc.ConfigReload(fileName)
+	}
+	return err
 }
 
 func (c *MixedDbClient) SetDB(delete []*gnmipb.Path, replace []*gnmipb.Update, update []*gnmipb.Update) error {

--- a/test/test_gnmi_configdb.py
+++ b/test/test_gnmi_configdb.py
@@ -270,6 +270,9 @@ class TestGNMIConfigDb:
         assert new_cnt == old_cnt+1, 'DBUS API is not invoked'
 
     def test_gnmi_full(self):
+        ret, old_cnt = gnmi_dump("DBUS config reload")
+        assert ret == 0, 'Failed to read counter'
+
         test_data = {
             'field_01': '20001',
             'field_02': '20002',
@@ -291,13 +294,24 @@ class TestGNMIConfigDb:
             config_json = json.load(cf)
         assert test_data == config_json, "Wrong config file"
 
+        ret, new_cnt = gnmi_dump("DBUS config reload")
+        assert ret == 0, 'Failed to read counter'
+        assert new_cnt == old_cnt + 1, 'DBUS API is not invoked'
+
     def test_gnmi_full_negative(self):
+        ret, old_cnt = gnmi_dump("DBUS config reload")
+        assert ret == 0, 'Failed to read counter'
+
         delete_list = ['/sonic-db:CONFIG_DB/localhost/']
         update_list = ['/sonic-db:CONFIG_DB/localhost/' + ':abc']
 
         ret, msg = gnmi_set(delete_list, update_list, [])
         assert ret != 0, 'Invalid ietf_json_val'
         assert 'IETF JSON' in msg
+
+        ret, new_cnt = gnmi_dump("DBUS config reload")
+        assert ret == 0, 'Failed to read counter'
+        assert new_cnt == old_cnt, 'DBUS API should not have been invoked'
 
     @pytest.mark.parametrize("test_data", test_data_checkpoint)
     def test_gnmi_get_checkpoint(self, test_data):


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

The full config update handler already saves the config to a file and does yang validation on it. The previous implementation relied on the Reboot command to trigger a ConfigReload, but that command has been implemented on the system level and no longer performs a reload, leaving this operation non-functional.

#### How I did it

 Call ConfigReload directly from the handler and bypass the Reboot, restoring this operation.

#### How to verify it

Unit tests pass successfully.

TBD:
- working on updating sonic-mgmt test

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Call ConfigReload on full config gnmi update

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)
```
       _____     ____
     /      \  |  o | 
    |        |/ ___\| 
    |_________/     
    |_|_| |_|_|
```
