### PR TITLE
Update authenticate to support gnmi role and gnoi role

### DIFF
--- a/gnmi_server/client_subscribe.go
+++ b/gnmi_server/client_subscribe.go
@@ -95,7 +95,7 @@ func (c *Client) populateDbPathSubscrition(sublist *gnmipb.SubscriptionList) ([]
 // SubscriptionList. Once the client is started, it will run until the stream
 // is closed or the schedule completes. For Poll queries the Run will block
 // internally after sync until a Poll request is made to the server.
-func (c *Client) Run(stream gnmipb.GNMI_SubscribeServer) (err error) {
+func (c *Client) Run(stream gnmipb.GNMI_SubscribeServer, config *Config) (err error) {
 	defer log.V(1).Infof("Client %s shutdown", c)
 	ctx := stream.Context()
 	var connectionKey string
@@ -158,10 +158,13 @@ func (c *Client) Run(stream gnmipb.GNMI_SubscribeServer) (err error) {
 
 	log.V(3).Infof("mode=%v, origin=%q, target=%q", mode, origin, target)
 
+	authTarget := "gnmi"
 	if origin == "openconfig" {
 		dc, err = sdc.NewTranslClient(prefix, paths, ctx, extensions, sdc.TranslWildcardOption{})
 	} else if IsNativeOrigin(origin) {
-		dc, err = sdc.NewMixedDbClient(paths, prefix, origin, gnmipb.Encoding_JSON_IETF, "", "")
+		var targetDbName string
+		dc, err = sdc.NewMixedDbClient(paths, prefix, origin, gnmipb.Encoding_JSON_IETF, "", "", &targetDbName)
+		authTarget = "gnmi_" + targetDbName
 	} else if len(origin) != 0 {
 		return grpc.Errorf(codes.Unimplemented, "Unsupported origin: %s", origin)
 	} else if target == "" {
@@ -171,10 +174,13 @@ func (c *Client) Run(stream gnmipb.GNMI_SubscribeServer) (err error) {
 		return grpc.Errorf(codes.Unimplemented, "Empty target data not supported")
 	} else if target == "OTHERS" {
 		dc, err = sdc.NewNonDbClient(paths, prefix)
+		authTarget = "gnmi_others"
 	} else if (target == "EVENTS") && (mode == gnmipb.SubscriptionList_STREAM) {
 		dc, err = sdc.NewEventClient(paths, prefix, c.logLevel)
-	} else if _, ok, _, _ := sdc.IsTargetDb(target); ok {
+		authTarget = "gnmi_events"
+	} else if targetDbName, ok, _, _ := sdc.IsTargetDb(target); ok {
 		dc, err = sdc.NewDbClient(paths, prefix)
+		authTarget = "gnmi_" + targetDbName
 	} else {
 		/* For any other target or no target create new Transl Client. */
 		dc, err = sdc.NewTranslClient(prefix, paths, ctx, extensions, sdc.TranslWildcardOption{})
@@ -185,6 +191,11 @@ func (c *Client) Run(stream gnmipb.GNMI_SubscribeServer) (err error) {
 	}
 
 	defer dc.Close()
+	ctx = stream.Context()
+	ctx, err = authenticate(config, ctx, authTarget, false)
+	if err != nil {
+		return err
+	}
 
 	switch mode {
 	case gnmipb.SubscriptionList_STREAM:

--- a/gnmi_server/debug.go
+++ b/gnmi_server/debug.go
@@ -35,7 +35,7 @@ import (
 
 func (srv *Server) GetSubscribePreferences(req *spb_gnoi.SubscribePreferencesReq, stream spb_gnoi.Debug_GetSubscribePreferencesServer) error {
 	ctx := stream.Context()
-	ctx, err := authenticate(srv.config, ctx, false)
+	ctx, err := authenticate(srv.config, ctx, "gnmi", false)
 	if err != nil {
 		return err
 	}

--- a/gnmi_server/gnoi.go
+++ b/gnmi_server/gnoi.go
@@ -73,7 +73,7 @@ func ReadFileStat(path string) (*gnoi_file_pb.StatInfo, error) {
 }
 
 func (srv *FileServer) Stat(ctx context.Context, req *gnoi_file_pb.StatRequest) (*gnoi_file_pb.StatResponse, error) {
-	_, err := authenticate(srv.config, ctx, false)
+	_, err := authenticate(srv.config, ctx, "gnoi", false)
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +97,7 @@ func (srv *FileServer) Get(req *gnoi_file_pb.GetRequest, stream gnoi_file_pb.Fil
 }
 
 func (srv *OSServer) Verify(ctx context.Context, req *gnoi_os_pb.VerifyRequest) (*gnoi_os_pb.VerifyResponse, error) {
-	_, err := authenticate(srv.config, ctx, false)
+	_, err := authenticate(srv.config, ctx, "gnoi", false)
 	if err != nil {
 		log.V(2).Infof("Failed to authenticate: %v", err)
 		return nil, err
@@ -139,7 +139,7 @@ func (srv *OSServer) Verify(ctx context.Context, req *gnoi_os_pb.VerifyRequest) 
 }
 
 func (srv *OSServer) Activate(ctx context.Context, req *gnoi_os_pb.ActivateRequest) (*gnoi_os_pb.ActivateResponse, error) {
-	_, err := authenticate(srv.config, ctx /*writeAccess=*/, true)
+	_, err := authenticate(srv.config, ctx, "gnoi" /*writeAccess=*/, true)
 	if err != nil {
 		log.Errorf("Failed to authenticate: %v", err)
 		return nil, err
@@ -214,7 +214,7 @@ func (srv *Server) Authenticate(ctx context.Context, req *spb_jwt.AuthenticateRe
 
 }
 func (srv *Server) Refresh(ctx context.Context, req *spb_jwt.RefreshRequest) (*spb_jwt.RefreshResponse, error) {
-	ctx, err := authenticate(srv.config, ctx, true)
+	ctx, err := authenticate(srv.config, ctx, "gnoi", true)
 	if err != nil {
 		return nil, err
 	}
@@ -242,7 +242,7 @@ func (srv *Server) Refresh(ctx context.Context, req *spb_jwt.RefreshRequest) (*s
 }
 
 func (srv *Server) ClearNeighbors(ctx context.Context, req *spb.ClearNeighborsRequest) (*spb.ClearNeighborsResponse, error) {
-	ctx, err := authenticate(srv.config, ctx, true)
+	ctx, err := authenticate(srv.config, ctx, "gnoi", true)
 	if err != nil {
 		return nil, err
 	}
@@ -273,7 +273,7 @@ func (srv *Server) ClearNeighbors(ctx context.Context, req *spb.ClearNeighborsRe
 }
 
 func (srv *Server) CopyConfig(ctx context.Context, req *spb.CopyConfigRequest) (*spb.CopyConfigResponse, error) {
-	ctx, err := authenticate(srv.config, ctx, true)
+	ctx, err := authenticate(srv.config, ctx, "gnoi", true)
 	if err != nil {
 		return nil, err
 	}
@@ -302,7 +302,7 @@ func (srv *Server) CopyConfig(ctx context.Context, req *spb.CopyConfigRequest) (
 }
 
 func (srv *Server) ShowTechsupport(ctx context.Context, req *spb.TechsupportRequest) (*spb.TechsupportResponse, error) {
-	ctx, err := authenticate(srv.config, ctx, false)
+	ctx, err := authenticate(srv.config, ctx, "gnoi", false)
 	if err != nil {
 		return nil, err
 	}
@@ -331,7 +331,7 @@ func (srv *Server) ShowTechsupport(ctx context.Context, req *spb.TechsupportRequ
 }
 
 func (srv *Server) ImageInstall(ctx context.Context, req *spb.ImageInstallRequest) (*spb.ImageInstallResponse, error) {
-	ctx, err := authenticate(srv.config, ctx, true)
+	ctx, err := authenticate(srv.config, ctx, "gnoi", true)
 	if err != nil {
 		return nil, err
 	}
@@ -360,7 +360,7 @@ func (srv *Server) ImageInstall(ctx context.Context, req *spb.ImageInstallReques
 }
 
 func (srv *Server) ImageRemove(ctx context.Context, req *spb.ImageRemoveRequest) (*spb.ImageRemoveResponse, error) {
-	ctx, err := authenticate(srv.config, ctx, true)
+	ctx, err := authenticate(srv.config, ctx, "gnoi", true)
 	if err != nil {
 		return nil, err
 	}
@@ -388,7 +388,7 @@ func (srv *Server) ImageRemove(ctx context.Context, req *spb.ImageRemoveRequest)
 }
 
 func (srv *Server) ImageDefault(ctx context.Context, req *spb.ImageDefaultRequest) (*spb.ImageDefaultResponse, error) {
-	ctx, err := authenticate(srv.config, ctx, true)
+	ctx, err := authenticate(srv.config, ctx, "gnoi", true)
 	if err != nil {
 		return nil, err
 	}

--- a/gnmi_server/gnoi_system.go
+++ b/gnmi_server/gnoi_system.go
@@ -68,7 +68,7 @@ func KillOrRestartProcess(restart bool, serviceName string) error {
 }
 
 func (srv *Server) KillProcess(ctx context.Context, req *syspb.KillProcessRequest) (*syspb.KillProcessResponse, error) {
-	_, err := authenticate(srv.config, ctx, true)
+	_, err := authenticate(srv.config, ctx, "gnoi", true)
 	if err != nil {
 		return nil, err
 	}
@@ -189,7 +189,7 @@ func sendRebootReqOnNotifCh(ctx context.Context, req proto.Message, sc *redis.Cl
 
 // Reboot implements the corresponding RPC.
 func (srv *Server) Reboot(ctx context.Context, req *syspb.RebootRequest) (*syspb.RebootResponse, error) {
-	_, err := authenticate(srv.config, ctx, true)
+	_, err := authenticate(srv.config, ctx, "gnoi", true)
 	if err != nil {
 		return nil, err
 	}
@@ -224,7 +224,7 @@ func (srv *Server) Reboot(ctx context.Context, req *syspb.RebootRequest) (*syspb
 
 // RebootStatus implements the corresponding RPC.
 func (srv *Server) RebootStatus(ctx context.Context, req *syspb.RebootStatusRequest) (*syspb.RebootStatusResponse, error) {
-	_, err := authenticate(srv.config, ctx, true)
+	_, err := authenticate(srv.config, ctx, "gnoi", true)
 	if err != nil {
 		return nil, err
 	}
@@ -253,7 +253,7 @@ func (srv *Server) RebootStatus(ctx context.Context, req *syspb.RebootStatusRequ
 
 // CancelReboot RPC implements the corresponding RPC.
 func (srv *Server) CancelReboot(ctx context.Context, req *syspb.CancelRebootRequest) (*syspb.CancelRebootResponse, error) {
-	_, err := authenticate(srv.config, ctx, true)
+	_, err := authenticate(srv.config, ctx, "gnoi", true)
 	if err != nil {
 		return nil, err
 	}
@@ -279,7 +279,7 @@ func (srv *Server) CancelReboot(ctx context.Context, req *syspb.CancelRebootRequ
 // Ping is unimplemented.
 func (srv *Server) Ping(req *syspb.PingRequest, stream syspb.System_PingServer) error {
 	ctx := stream.Context()
-	_, err := authenticate(srv.config, ctx, true)
+	_, err := authenticate(srv.config, ctx, "gnoi", true)
 	if err != nil {
 		return err
 	}
@@ -290,7 +290,7 @@ func (srv *Server) Ping(req *syspb.PingRequest, stream syspb.System_PingServer) 
 // Traceroute is unimplemented.
 func (srv *Server) Traceroute(req *syspb.TracerouteRequest, stream syspb.System_TracerouteServer) error {
 	ctx := stream.Context()
-	_, err := authenticate(srv.config, ctx, true)
+	_, err := authenticate(srv.config, ctx, "gnoi", true)
 	if err != nil {
 		return err
 	}
@@ -301,7 +301,7 @@ func (srv *Server) Traceroute(req *syspb.TracerouteRequest, stream syspb.System_
 func (srv *Server) SetPackage(rs syspb.System_SetPackageServer) error {
 	ctx := rs.Context()
 
-	_, err := authenticate(srv.config, ctx, true)
+	_, err := authenticate(srv.config, ctx, "gnoi", true)
 	if err != nil {
 		log.Errorf("Authentication failed: %v", err)
 		return status.Errorf(codes.PermissionDenied, "authentication failed: %v", err)
@@ -389,7 +389,7 @@ func (srv *Server) SetPackage(rs syspb.System_SetPackageServer) error {
 
 // SwitchControlProcessor implements the corresponding RPC.
 func (srv *Server) SwitchControlProcessor(ctx context.Context, req *syspb.SwitchControlProcessorRequest) (*syspb.SwitchControlProcessorResponse, error) {
-	_, err := authenticate(srv.config, ctx, true)
+	_, err := authenticate(srv.config, ctx, "gnoi", true)
 	if err != nil {
 		return nil, err
 	}
@@ -399,7 +399,7 @@ func (srv *Server) SwitchControlProcessor(ctx context.Context, req *syspb.Switch
 
 // Time implements the corresponding RPC.
 func (srv *Server) Time(ctx context.Context, req *syspb.TimeRequest) (*syspb.TimeResponse, error) {
-	_, err := authenticate(srv.config, ctx, false)
+	_, err := authenticate(srv.config, ctx, "gnoi", false)
 	if err != nil {
 		return nil, err
 	}

--- a/gnmi_server/server.go
+++ b/gnmi_server/server.go
@@ -96,6 +96,8 @@ var AuthLock sync.Mutex
 var maMu sync.Mutex
 
 const WriteAccessMode = "readwrite"
+const ReadOnlyMode = "readonly"
+const NoAccessMode = "noaccess"
 
 func (i AuthTypes) String() string {
 	if i["none"] {
@@ -249,10 +251,10 @@ func (srv *Server) Port() int64 {
 
 // Auth - Authenticate
 func (srv *Server) Auth(ctx context.Context) (context.Context, error) {
-	return authenticate(srv.config, ctx, true)
+	return authenticate(srv.config, ctx, "gnmi", false)
 }
 
-func authenticate(config *Config, ctx context.Context, writeAccess bool) (context.Context, error) {
+func authenticate(config *Config, ctx context.Context, target string, writeAccess bool) (context.Context, error) {
 	var err error
 	success := false
 	rc, ctx := common_utils.GetContext(ctx)
@@ -281,10 +283,31 @@ func authenticate(config *Config, ctx context.Context, writeAccess bool) (contex
 			success = true
 		}
 		// role must be readwrite to support write access
-		if success && writeAccess && config.ConfigTableName != "" {
-			role := rc.Auth.Roles[0]
-			if role != WriteAccessMode {
-				return ctx, fmt.Errorf("%s does not have write access, %s", rc.Auth.User, role)
+		if success && config.ConfigTableName != "" {
+			match := false
+			for _, role := range rc.Auth.Roles {
+				if strings.HasPrefix(role, strings.ToLower(target)) {
+					// Extract the postfix from the role
+					// e.g. role=gnmi_config_db_readwrite
+					// e.g. role=gnoi_readonly
+					postfix := strings.TrimPrefix(role, strings.ToLower(target))
+					postfix = strings.TrimPrefix(postfix, "_")
+					// Check if the role postfix indicates no access, and deny access if true.
+					if postfix == NoAccessMode {
+						return ctx, fmt.Errorf("%s does not have access, %s", rc.Auth.User, role)
+					} else if postfix == ReadOnlyMode && !writeAccess {
+						// ReadOnlyMode is allowed for read access
+						match = true
+						break
+					} else if postfix == WriteAccessMode {
+						// WriteAccessMode is allowed for read/write access
+						match = true
+						break
+					}
+				}
+			}
+			if !match && writeAccess {
+				return ctx, fmt.Errorf("%s does not have write access", rc.Auth.User)
 			}
 		}
 	}
@@ -302,11 +325,6 @@ func authenticate(config *Config, ctx context.Context, writeAccess bool) (contex
 // Subscribe implements the gNMI Subscribe RPC.
 func (s *Server) Subscribe(stream gnmipb.GNMI_SubscribeServer) error {
 	ctx := stream.Context()
-	ctx, err := authenticate(s.config, ctx, false)
-	if err != nil {
-		return err
-	}
-
 	pr, ok := peer.FromContext(ctx)
 	if !ok {
 		return grpc.Errorf(codes.InvalidArgument, "failed to get peer from ctx")
@@ -338,7 +356,7 @@ func (s *Server) Subscribe(stream gnmipb.GNMI_SubscribeServer) error {
 	s.clients[c.String()] = c
 	s.cMu.Unlock()
 
-	err = c.Run(stream)
+	err := c.Run(stream, s.config)
 	s.cMu.Lock()
 	delete(s.clients, c.String())
 	s.cMu.Unlock()
@@ -387,18 +405,13 @@ func IsNativeOrigin(origin string) bool {
 // Get implements the Get RPC in gNMI spec.
 func (s *Server) Get(ctx context.Context, req *gnmipb.GetRequest) (*gnmipb.GetResponse, error) {
 	common_utils.IncCounter(common_utils.GNMI_GET)
-	ctx, err := authenticate(s.config, ctx, false)
-	if err != nil {
-		common_utils.IncCounter(common_utils.GNMI_GET_FAIL)
-		return nil, err
-	}
 
 	if req.GetType() != gnmipb.GetRequest_ALL {
 		common_utils.IncCounter(common_utils.GNMI_GET_FAIL)
 		return nil, status.Errorf(codes.Unimplemented, "unsupported request type: %s", gnmipb.GetRequest_DataType_name[int32(req.GetType())])
 	}
 
-	if err = s.checkEncodingAndModel(req.GetEncoding(), req.GetUseModels()); err != nil {
+	if err := s.checkEncodingAndModel(req.GetEncoding(), req.GetUseModels()); err != nil {
 		common_utils.IncCounter(common_utils.GNMI_GET_FAIL)
 		return nil, status.Error(codes.Unimplemented, err.Error())
 	}
@@ -417,11 +430,14 @@ func (s *Server) Get(ctx context.Context, req *gnmipb.GetRequest) (*gnmipb.GetRe
 	log.V(2).Infof("GetRequest paths: %v", paths)
 
 	var dc sdc.Client
-
+	var err error
+	authTarget := "gnmi"
 	if target == "OTHERS" {
 		dc, err = sdc.NewNonDbClient(paths, prefix)
-	} else if _, ok, _, _ := sdc.IsTargetDb(target); ok {
+		authTarget = "gnmi_other"
+	} else if targetDbName, ok, _, _ := sdc.IsTargetDb(target); ok {
 		dc, err = sdc.NewDbClient(paths, prefix)
+		authTarget = "gnmi_" + targetDbName
 	} else {
 		if origin == "" {
 			origin, err = ParseOrigin(paths)
@@ -430,7 +446,9 @@ func (s *Server) Get(ctx context.Context, req *gnmipb.GetRequest) (*gnmipb.GetRe
 			}
 		}
 		if check := IsNativeOrigin(origin); check {
-			dc, err = sdc.NewMixedDbClient(paths, prefix, origin, encoding, s.config.ZmqPort, s.config.Vrf)
+			var targetDbName string
+			dc, err = sdc.NewMixedDbClient(paths, prefix, origin, encoding, s.config.ZmqPort, s.config.Vrf, &targetDbName)
+			authTarget = "gnmi_" + targetDbName
 		} else {
 			dc, err = sdc.NewTranslClient(prefix, paths, ctx, extensions)
 		}
@@ -441,6 +459,12 @@ func (s *Server) Get(ctx context.Context, req *gnmipb.GetRequest) (*gnmipb.GetRe
 		return nil, status.Error(codes.NotFound, err.Error())
 	}
 	defer dc.Close()
+
+	ctx, err = authenticate(s.config, ctx, authTarget, false)
+	if err != nil {
+		common_utils.IncCounter(common_utils.GNMI_GET_FAIL)
+		return nil, err
+	}
 	notifications := make([]*gnmipb.Notification, len(paths))
 	spbValues, err := dc.Get(nil)
 	if err != nil {
@@ -493,11 +517,6 @@ func (s *Server) Set(ctx context.Context, req *gnmipb.SetRequest) (*gnmipb.SetRe
 		common_utils.IncCounter(common_utils.GNMI_SET_FAIL)
 		return nil, grpc.Errorf(codes.Unimplemented, "GNMI is in read-only mode")
 	}
-	ctx, err := authenticate(s.config, ctx, true)
-	if err != nil {
-		common_utils.IncCounter(common_utils.GNMI_SET_FAIL)
-		return nil, err
-	}
 	var results []*gnmipb.UpdateResult
 
 	/* Fetch the prefix. */
@@ -510,6 +529,7 @@ func (s *Server) Set(ctx context.Context, req *gnmipb.SetRequest) (*gnmipb.SetRe
 	encoding := gnmipb.Encoding_JSON_IETF
 
 	var dc sdc.Client
+	var err error
 	paths := req.GetDelete()
 	for _, path := range req.GetReplace() {
 		paths = append(paths, path.GetPath())
@@ -523,12 +543,15 @@ func (s *Server) Set(ctx context.Context, req *gnmipb.SetRequest) (*gnmipb.SetRe
 			return nil, err
 		}
 	}
+	authTarget := "gnmi"
 	if check := IsNativeOrigin(origin); check {
 		if s.config.EnableNativeWrite == false {
 			common_utils.IncCounter(common_utils.GNMI_SET_FAIL)
 			return nil, grpc.Errorf(codes.Unimplemented, "GNMI native write is disabled")
 		}
-		dc, err = sdc.NewMixedDbClient(paths, prefix, origin, encoding, s.config.ZmqPort, s.config.Vrf)
+		var targetDbName string
+		dc, err = sdc.NewMixedDbClient(paths, prefix, origin, encoding, s.config.ZmqPort, s.config.Vrf, &targetDbName)
+		authTarget = "gnmi_" + targetDbName
 	} else {
 		if s.config.EnableTranslibWrite == false {
 			common_utils.IncCounter(common_utils.GNMI_SET_FAIL)
@@ -544,6 +567,11 @@ func (s *Server) Set(ctx context.Context, req *gnmipb.SetRequest) (*gnmipb.SetRe
 	}
 	defer dc.Close()
 
+	ctx, err = authenticate(s.config, ctx, authTarget, true)
+	if err != nil {
+		common_utils.IncCounter(common_utils.GNMI_SET_FAIL)
+		return nil, err
+	}
 	/* DELETE */
 	for _, path := range req.GetDelete() {
 		log.V(2).Infof("Delete path: %v", path)
@@ -595,7 +623,7 @@ func (s *Server) Set(ctx context.Context, req *gnmipb.SetRequest) (*gnmipb.SetRe
 }
 
 func (s *Server) Capabilities(ctx context.Context, req *gnmipb.CapabilityRequest) (*gnmipb.CapabilityResponse, error) {
-	ctx, err := authenticate(s.config, ctx, false)
+	ctx, err := authenticate(s.config, ctx, "gnmi", false)
 	if err != nil {
 		return nil, err
 	}
@@ -605,7 +633,8 @@ func (s *Server) Capabilities(ctx context.Context, req *gnmipb.CapabilityRequest
 	var supportedModels []gnmipb.ModelData
 	dc, _ := sdc.NewTranslClient(nil, nil, ctx, extensions)
 	supportedModels = append(supportedModels, dc.Capabilities()...)
-	dc, _ = sdc.NewMixedDbClient(nil, nil, "", gnmipb.Encoding_JSON_IETF, s.config.ZmqPort, s.config.Vrf)
+	var targetDbName string
+	dc, _ = sdc.NewMixedDbClient(nil, nil, "", gnmipb.Encoding_JSON_IETF, s.config.ZmqPort, s.config.Vrf, &targetDbName)
 	supportedModels = append(supportedModels, dc.Capabilities()...)
 
 	suppModels := make([]*gnmipb.ModelData, len(supportedModels))

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -4871,7 +4871,7 @@ func TestClientCertAuthenAndAuthor(t *testing.T) {
 	// check get 1 cert name
 	ctx, cancel = CreateAuthorizationCtx()
 	configDb.Flushdb()
-	gnmiTable.Hset("certname1", "role", "readwrite")
+	gnmiTable.Hset("certname1", "role", "gnmi_readwrite")
 	ctx, err = ClientCertAuthenAndAuthor(ctx, "GNMI_CLIENT_CERT", false)
 	if err != nil {
 		t.Errorf("CommonNameMatch with correct cert name should success: %v", err)
@@ -4882,8 +4882,8 @@ func TestClientCertAuthenAndAuthor(t *testing.T) {
 	// check get multiple cert names
 	ctx, cancel = CreateAuthorizationCtx()
 	configDb.Flushdb()
-	gnmiTable.Hset("certname1", "role", "readwrite")
-	gnmiTable.Hset("certname2", "role", "readonly")
+	gnmiTable.Hset("certname1", "role", "gnmi_readwrite")
+	gnmiTable.Hset("certname2", "role", "gnmi_readonly")
 	ctx, err = ClientCertAuthenAndAuthor(ctx, "GNMI_CLIENT_CERT", false)
 	if err != nil {
 		t.Errorf("CommonNameMatch with correct cert name should success: %v", err)
@@ -4894,7 +4894,7 @@ func TestClientCertAuthenAndAuthor(t *testing.T) {
 	// check a invalid cert cname
 	ctx, cancel = CreateAuthorizationCtx()
 	configDb.Flushdb()
-	gnmiTable.Hset("certname2", "role", "readonly")
+	gnmiTable.Hset("certname2", "role", "gnmi_readonly")
 	ctx, err = ClientCertAuthenAndAuthor(ctx, "GNMI_CLIENT_CERT", false)
 	if err == nil {
 		t.Errorf("CommonNameMatch with invalid cert name should fail: %v", err)
@@ -4936,7 +4936,7 @@ func TestClientCertAuthenAndAuthorMultiRole(t *testing.T) {
 	// check get 1 cert name
 	ctx, cancel = CreateAuthorizationCtx()
 	configDb.Flushdb()
-	gnmiTable.Hset("certname1", "role@", "readwrite")
+	gnmiTable.Hset("certname1", "role@", "gnmi_readwrite")
 	ctx, err = ClientCertAuthenAndAuthor(ctx, "GNMI_CLIENT_CERT", false)
 	if err != nil {
 		t.Errorf("CommonNameMatch with correct cert name should success: %v", err)
@@ -4947,8 +4947,8 @@ func TestClientCertAuthenAndAuthorMultiRole(t *testing.T) {
 	// check get multiple cert names
 	ctx, cancel = CreateAuthorizationCtx()
 	configDb.Flushdb()
-	gnmiTable.Hset("certname1", "role@", "readwrite")
-	gnmiTable.Hset("certname2", "role@", "readonly")
+	gnmiTable.Hset("certname1", "role@", "gnmi_readwrite")
+	gnmiTable.Hset("certname2", "role@", "gnmi_readonly")
 	ctx, err = ClientCertAuthenAndAuthor(ctx, "GNMI_CLIENT_CERT", false)
 	if err != nil {
 		t.Errorf("CommonNameMatch with correct cert name should success: %v", err)
@@ -4959,7 +4959,7 @@ func TestClientCertAuthenAndAuthorMultiRole(t *testing.T) {
 	// check a invalid cert cname
 	ctx, cancel = CreateAuthorizationCtx()
 	configDb.Flushdb()
-	gnmiTable.Hset("certname2", "role@", "readonly")
+	gnmiTable.Hset("certname2", "role@", "gnmi_readonly")
 	ctx, err = ClientCertAuthenAndAuthor(ctx, "GNMI_CLIENT_CERT", false)
 	if err == nil {
 		t.Errorf("CommonNameMatch with invalid cert name should fail: %v", err)
@@ -4990,9 +4990,9 @@ func TestAuthenticate(t *testing.T) {
 	cfg := &Config{ConfigTableName: tableName, UserAuth: AuthTypes{"password": false, "cert": true, "jwt": false}}
 	ctx, cancel := CreateAuthorizationCtx()
 	configDb.Flushdb()
-	gnmiTable.Hset("certname1", "role@", "readonly")
-	// Call authenticate to verify the user's role. This should fail if the role is "readonly".
-	_, err = authenticate(cfg, ctx, true)
+	gnmiTable.Hset("certname1", "role@", "gnmi_readonly")
+	// Call authenticate to verify the user's role. This should fail if the role is "gnmi_readonly".
+	_, err = authenticate(cfg, ctx, "gnmi", true)
 	if err == nil {
 		t.Errorf("authenticate with readonly role should fail: %v", err)
 	}

--- a/sonic_data_client/mixed_db_client.go
+++ b/sonic_data_client/mixed_db_client.go
@@ -497,7 +497,7 @@ func init() {
 	initRedisDbMap()
 }
 
-func NewMixedDbClient(paths []*gnmipb.Path, prefix *gnmipb.Path, origin string, encoding gnmipb.Encoding, zmqPort string, vrf string) (Client, error) {
+func NewMixedDbClient(paths []*gnmipb.Path, prefix *gnmipb.Path, origin string, encoding gnmipb.Encoding, zmqPort string, vrf string, targetDbName *string) (Client, error) {
 	var err error
 
 	// Initialize RedisDbMap for test
@@ -553,6 +553,7 @@ func NewMixedDbClient(paths []*gnmipb.Path, prefix *gnmipb.Path, origin string, 
 		client.applDB = swsscommon.NewDBConnector(target, SWSS_TIMEOUT, false, dbkey)
 	}
 	client.target = target
+	*targetDbName = target
 	ns := dbkey.GetNetns()
 	container := dbkey.GetContainerName()
 	client.mapkey = ns + ":" + container


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Support new role for GNMI: gnmi_noaccess, gnmi_readonly, gnmi_readwrite, gnmi_config_db_noaccess, gnmi_config_db_readonly, gnmi_config_db_readwrite, ...

Microsoft ADO: 30073317

#### How I did it
Update authentication logic:
1. if role is noaccess, reject read and write operation
2. if role is readonly, reject write operation, accept write operation
3. if role is readwrite, accept read and write operation
4. if role is empty, reject write operation, accept write operation

telemetry, gnmi and gnoi support this new authentication logic.

#### How to verify it
Run unit test and end to end test

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

