### PR TITLE
Add support for GNOI File service

### DIFF
--- a/gnmi_server/gnoi_file.go
+++ b/gnmi_server/gnoi_file.go
@@ -1,0 +1,56 @@
+package gnmi
+
+import (
+	"context"
+
+	"github.com/Azure/sonic-mgmt-common/translib/transformer"
+	"github.com/openconfig/gnoi/file"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// GNOIFileServer implements the gnoi.file.File service.
+type GNOIFileServer struct {
+	*Server
+}
+
+// NewGNOIFileServer returns initialized GNOIFileServer structure.
+func NewGNOIFileServer(srv *Server) *GNOIFileServer {
+	return &GNOIFileServer{
+		Server: srv,
+	}
+}
+
+// Get RPC is unimplemented.
+func (srv *GNOIFileServer) Get(req *file.GetRequest, stream file.File_GetServer) error {
+	return status.Errorf(codes.Unimplemented, "Method file.Get is unimplemented.")
+}
+
+// TransferToRemote RPC is unimplemented.
+func (srv *GNOIFileServer) TransferToRemote(ctx context.Context, req *file.TransferToRemoteRequest) (*file.TransferToRemoteResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "Method file.TransferToRemote is unimplemented.")
+}
+
+// Put RPC is unimplemented.
+func (srv *GNOIFileServer) Put(stream file.File_PutServer) error {
+	return status.Errorf(codes.Unimplemented, "Method file.Put is unimplemented.")
+}
+
+// Stat RPC is unimplemented.
+func (srv *GNOIFileServer) Stat(ctx context.Context, req *file.StatRequest) (*file.StatResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "Method file.Stat is unimplemented.")
+}
+
+// Remove implements the corresponding RPC.
+func (srv *GNOIFileServer) Remove(ctx context.Context, req *file.RemoveRequest) (*file.RemoveResponse, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "Invalid nil request.")
+	}
+	if req.GetRemoteFile() == "" {
+		return nil, status.Error(codes.InvalidArgument, "Invalid request: remote_file field is empty.")
+	}
+	if _, err := transformer.FileRemove(req.GetRemoteFile()); err != nil {
+		return nil, status.Errorf(codes.Internal, err.Error())
+	}
+	return &file.RemoveResponse{}, nil
+}

--- a/gnmi_server/gnoi_file_test.go
+++ b/gnmi_server/gnoi_file_test.go
@@ -1,0 +1,65 @@
+package gnmi
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"testing"
+
+	"github.com/openconfig/gnoi/file"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+)
+
+// TestFileServer tests implementation of gnoi.File server.
+func TestFileServer(t *testing.T) {
+	s := createServer(t)
+	go runServer(t, s)
+	defer s.Stop(t)
+
+	targetAddr := fmt.Sprintf("127.0.0.1:%d", s.config.Port)
+
+	tlsConfig := &tls.Config{InsecureSkipVerify: true}
+	opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
+	conn, err := grpc.Dial(targetAddr, opts...)
+	if err != nil {
+		t.Fatalf("Dialing to %s failed: %v", targetAddr, err)
+	}
+	defer conn.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sc := file.NewFileClient(conn)
+	t.Run("GetFailsAsUnimplemented", func(t *testing.T) {
+		stream, err := sc.Get(ctx, &file.GetRequest{})
+		if err != nil {
+			t.Error(err.Error())
+		}
+		_, err = stream.Recv()
+		testErr(err, codes.Unimplemented, "Method file.Get is unimplemented.", t)
+	})
+	t.Run("TransferToRemoteFailsAsUnimplemented", func(t *testing.T) {
+		_, err := sc.TransferToRemote(ctx, &file.TransferToRemoteRequest{})
+		testErr(err, codes.Unimplemented, "Method file.TransferToRemote is unimplemented.", t)
+	})
+	t.Run("PutFailsAsUnimplemented", func(t *testing.T) {
+		stream, err := sc.Put(ctx)
+		if err != nil {
+			t.Error(err.Error())
+		}
+		_, err = stream.CloseAndRecv()
+		testErr(err, codes.Unimplemented, "Method file.Put is unimplemented.", t)
+	})
+	t.Run("StatFailsAsUnimplemented", func(t *testing.T) {
+		_, err := sc.Stat(ctx, &file.StatRequest{})
+		testErr(err, codes.Unimplemented, "Method file.Stat is unimplemented.", t)
+	})
+	t.Run("RemoveFailsIfRemoteFileMissing", func(t *testing.T) {
+		req := &file.RemoveRequest{}
+
+		_, err := sc.Remove(ctx, req)
+		testErr(err, codes.InvalidArgument, "Invalid request: remote_file field is empty.", t)
+	})
+}

--- a/gnoi_client/file/file.go
+++ b/gnoi_client/file/file.go
@@ -29,3 +29,116 @@ func Stat(conn *grpc.ClientConn, ctx context.Context) {
 	}
 	fmt.Println(string(respstr))
 }
+
+func Get(conn *grpc.ClientConn, ctx context.Context) {
+	fmt.Println("File Get")
+	ctx = utils.SetUserCreds(ctx)
+	fc := pb.NewFileClient(conn)
+
+	req := &pb.GetRequest{}
+	err := json.Unmarshal([]byte(*config.Args), req)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	stream, err := fc.Get(ctx, req)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	for {
+		resp, err := stream.Recv()
+		if err != nil {
+			panic(err.Error())
+			break
+		}
+
+		switch r := resp.Response.(type) {
+		case *pb.GetResponse_Contents:
+			fmt.Printf("Received file chunk: %v\n", r.Contents)
+		case *pb.GetResponse_Hash:
+			fmt.Printf("Received file hash: %v\n", r.Hash)
+		default:
+			fmt.Println("Unknown GetResponse type")
+		}
+	}
+}
+
+func Put(conn *grpc.ClientConn, ctx context.Context) {
+	fmt.Println("File Put")
+	ctx = utils.SetUserCreds(ctx)
+	fc := pb.NewFileClient(conn)
+
+	req := &pb.PutRequest{}
+	err := json.Unmarshal([]byte(*config.Args), req)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	stream, err := fc.Put(ctx)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	err = stream.Send(req)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	resp, err := stream.CloseAndRecv()
+	if err != nil {
+		panic(err.Error())
+	}
+
+	respstr, err := json.Marshal(resp)
+	if err != nil {
+		panic(err.Error())
+	}
+	fmt.Println(string(respstr))
+}
+
+func Remove(conn *grpc.ClientConn, ctx context.Context) {
+	fmt.Println("File Remove")
+	ctx = utils.SetUserCreds(ctx)
+	fc := pb.NewFileClient(conn)
+
+	req := &pb.RemoveRequest{}
+	err := json.Unmarshal([]byte(*config.Args), req)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	resp, err := fc.Remove(ctx, req)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	respstr, err := json.Marshal(resp)
+	if err != nil {
+		panic(err.Error())
+	}
+	fmt.Println(string(respstr))
+}
+
+func TransferToRemote(conn *grpc.ClientConn, ctx context.Context) {
+	fmt.Println("File TransferToRemote")
+	ctx = utils.SetUserCreds(ctx)
+	fc := pb.NewFileClient(conn)
+
+	req := &pb.TransferToRemoteRequest{}
+	err := json.Unmarshal([]byte(*config.Args), req)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	resp, err := fc.TransferToRemote(ctx, req)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	respstr, err := json.Marshal(resp)
+	if err != nil {
+		panic(err.Error())
+	}
+	fmt.Println(string(respstr))
+}

--- a/gnoi_client/gnoi_client.go
+++ b/gnoi_client/gnoi_client.go
@@ -52,6 +52,14 @@ func main() {
 		switch *config.Rpc {
 		case "Stat":
 			file.Stat(conn, ctx)
+		case "Get":
+			file.Get(conn, ctx)
+		case "Put":
+			file.Put(conn, ctx)
+		case "Remove":
+			file.Remove(conn, ctx)
+		case "TransferToRemote":
+			file.TransferToRemote(conn, ctx)
 		default:
 			panic("Invalid RPC Name")
 		}

--- a/patches/github.com-openconfig-gnoi.patch
+++ b/patches/github.com-openconfig-gnoi.patch
@@ -1,0 +1,37 @@
+diff --git a/file/BUILD.bazel b/file/BUILD.bazel
+index e01b831..a87edc3 100644
+--- a/file/BUILD.bazel
++++ b/file/BUILD.bazel
+@@ -15,6 +15,8 @@
+ # Supporting infrastructure for implementing and testing PINS.
+ #
+ load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+ 
+ package(
+     default_visibility = ["//visibility:public"],
+@@ -41,3 +43,23 @@ cc_grpc_library(
+     grpc_only = True,
+     deps = [":file_cc_proto"],
+ )
++
++go_proto_library(
++    name = "file_go_proto",
++    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
++    importpath = "github.com/openconfig/gnoi/file",
++    protos = [
++        ":file_proto",
++    ],
++)
++
++go_library(
++    name = "file",
++    embed = [":file_go_proto"],
++    importpath = "github.com/openconfig/gnoi/file",
++    deps = [
++        "//common:common",
++        "//types:types",
++    ],
++)
++


### PR DESCRIPTION
 *Add GNOI File service, with support for Remove operation.
 *Now all component tests start server on unique port.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

