### PR TITLE
Add support for GNOI File service

### DIFF
--- a/common_utils/context.go
+++ b/common_utils/context.go
@@ -43,6 +43,7 @@ const (
 	GNMI_SET
 	GNMI_SET_FAIL
 	GNOI_REBOOT
+	GNOI_FILE_REMOVE
 	DBUS
 	DBUS_FAIL
 	DBUS_APPLY_PATCH_DB
@@ -77,6 +78,8 @@ func (c CounterType) String() string {
 		return "GNMI set fail"
 	case GNOI_REBOOT:
 		return "GNOI reboot"
+	case GNOI_FILE_REMOVE:
+		return "GNOI File Remove"
 	case DBUS:
 		return "DBUS"
 	case DBUS_FAIL:

--- a/gnmi_server/clear_neighbor_dummy_test.go
+++ b/gnmi_server/clear_neighbor_dummy_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestDummyClearNeighbor(t *testing.T) {
 	// Start server
-	s := createServer(t, 8081)
+	s := createServer(t)
 	go runServer(t, s)
 	defer s.s.Stop()
 
@@ -29,7 +29,7 @@ func TestDummyClearNeighbor(t *testing.T) {
 
 func TestDummyCopyConfig(t *testing.T) {
 	// Start server
-	s := createServer(t, 8081)
+	s := createServer(t)
 	go runServer(t, s)
 	defer s.s.Stop()
 

--- a/gnmi_server/gnoi.go
+++ b/gnmi_server/gnoi.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	jwt "github.com/dgrijalva/jwt-go"
 	log "github.com/golang/glog"
-	gnoi_file_pb "github.com/openconfig/gnoi/file"
 	gnoi_os_pb "github.com/openconfig/gnoi/os"
 	spb "github.com/sonic-net/sonic-gnmi/proto/gnoi"
 	spb_jwt "github.com/sonic-net/sonic-gnmi/proto/gnoi/jwt"
@@ -15,7 +14,6 @@ import (
 	"google.golang.org/grpc/status"
 	"os"
 	"os/user"
-	"strconv"
 	"strings"
 	"time"
 )
@@ -23,78 +21,6 @@ import (
 const (
 	stateDB string = "STATE_DB"
 )
-
-func ReadFileStat(path string) (*gnoi_file_pb.StatInfo, error) {
-	sc, err := ssc.NewDbusClient()
-	if err != nil {
-		return nil, err
-	}
-	defer sc.Close()
-
-	log.V(2).Infof("Reading file stat at path %s...", path)
-	data, err := sc.GetFileStat(path)
-	if err != nil {
-		log.V(2).Infof("Failed to read file stat at path %s: %v. Error ", path, err)
-		return nil, err
-	}
-	// Parse the data and populate StatInfo
-	lastModified, err := strconv.ParseUint(data["last_modified"], 10, 64)
-	if err != nil {
-		return nil, err
-	}
-
-	permissions, err := strconv.ParseUint(data["permissions"], 8, 32)
-	if err != nil {
-		return nil, err
-	}
-
-	size, err := strconv.ParseUint(data["size"], 10, 64)
-	if err != nil {
-		return nil, err
-	}
-
-	umaskStr := data["umask"]
-	if strings.HasPrefix(umaskStr, "o") {
-		umaskStr = umaskStr[1:] // Remove leading "o"
-	}
-	umask, err := strconv.ParseUint(umaskStr, 8, 32)
-	if err != nil {
-		return nil, err
-	}
-
-	statInfo := &gnoi_file_pb.StatInfo{
-		Path:         data["path"],
-		LastModified: lastModified,
-		Permissions:  uint32(permissions),
-		Size:         size,
-		Umask:        uint32(umask),
-	}
-	return statInfo, nil
-}
-
-func (srv *FileServer) Stat(ctx context.Context, req *gnoi_file_pb.StatRequest) (*gnoi_file_pb.StatResponse, error) {
-	_, err := authenticate(srv.config, ctx, "gnoi", false)
-	if err != nil {
-		return nil, err
-	}
-	path := req.GetPath()
-	log.V(1).Info("gNOI: Read File Stat")
-	log.V(1).Info("Request: ", req)
-	statInfo, err := ReadFileStat(path)
-	if err != nil {
-		return nil, err
-	}
-	resp := &gnoi_file_pb.StatResponse{
-		Stats: []*gnoi_file_pb.StatInfo{statInfo},
-	}
-	return resp, nil
-}
-
-// TODO: Support GNOI File Get
-func (srv *FileServer) Get(req *gnoi_file_pb.GetRequest, stream gnoi_file_pb.File_GetServer) error {
-	log.V(1).Info("gNOI: File Get")
-	return status.Errorf(codes.Unimplemented, "")
-}
 
 func (srv *OSServer) Verify(ctx context.Context, req *gnoi_os_pb.VerifyRequest) (*gnoi_os_pb.VerifyResponse, error) {
 	_, err := authenticate(srv.config, ctx, "gnoi", false)
@@ -104,7 +30,7 @@ func (srv *OSServer) Verify(ctx context.Context, req *gnoi_os_pb.VerifyRequest) 
 	}
 
 	log.V(1).Info("gNOI: Verify")
-	dbus, err := ssc.NewDbusClient()
+	dbus, err := ssc.NewDbusClient(dbusCaller)
 	if err != nil {
 		log.V(2).Infof("Failed to create dbus client: %v", err)
 		return nil, err
@@ -149,7 +75,7 @@ func (srv *OSServer) Activate(ctx context.Context, req *gnoi_os_pb.ActivateReque
 	image := req.GetVersion()
 	log.Infof("Requested to activate image %s", image)
 
-	dbus, err := ssc.NewDbusClient()
+	dbus, err := ssc.NewDbusClient(dbusCaller)
 	if err != nil {
 		log.Errorf("Failed to create dbus client: %v", err)
 		return nil, err

--- a/gnmi_server/gnoi_file.go
+++ b/gnmi_server/gnoi_file.go
@@ -1,0 +1,108 @@
+package gnmi
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	log "github.com/golang/glog"
+	gnoi_file_pb "github.com/openconfig/gnoi/file"
+	ssc "github.com/sonic-net/sonic-gnmi/sonic_service_client"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func (srv *FileServer) Stat(ctx context.Context, req *gnoi_file_pb.StatRequest) (*gnoi_file_pb.StatResponse, error) {
+	_, err := authenticate(srv.config, ctx, "gnoi", false)
+	if err != nil {
+		return nil, err
+	}
+	path := req.GetPath()
+	log.V(1).Info("Request: ", req)
+	statInfo, err := ReadFileStat(path)
+	if err != nil {
+		return nil, err
+	}
+	resp := &gnoi_file_pb.StatResponse{
+		Stats: []*gnoi_file_pb.StatInfo{statInfo},
+	}
+	return resp, nil
+}
+
+func ReadFileStat(path string) (*gnoi_file_pb.StatInfo, error) {
+	sc, err := ssc.NewDbusClient(dbusCaller)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := sc.GetFileStat(path)
+	if err != nil {
+		log.V(2).Infof("Failed to read file stat at path %s: %v. Error ", path, err)
+		return nil, err
+	}
+	// Parse the data and populate StatInfo
+	lastModified, err := strconv.ParseUint(data["last_modified"], 10, 64)
+	if err != nil {
+		return nil, err
+	}
+
+	permissions, err := strconv.ParseUint(data["permissions"], 8, 32)
+	if err != nil {
+		return nil, err
+	}
+
+	size, err := strconv.ParseUint(data["size"], 10, 64)
+	if err != nil {
+		return nil, err
+	}
+
+	umaskStr := data["umask"]
+	if strings.HasPrefix(umaskStr, "o") {
+		umaskStr = umaskStr[1:] // Remove leading "o"
+	}
+	umask, err := strconv.ParseUint(umaskStr, 8, 32)
+	if err != nil {
+		return nil, err
+	}
+
+	statInfo := &gnoi_file_pb.StatInfo{
+		Path:         data["path"],
+		LastModified: lastModified,
+		Permissions:  uint32(permissions),
+		Size:         size,
+		Umask:        uint32(umask),
+	}
+	return statInfo, nil
+}
+
+// Get RPC is unimplemented.
+func (srv *FileServer) Get(req *gnoi_file_pb.GetRequest, stream gnoi_file_pb.File_GetServer) error {
+	return status.Errorf(codes.Unimplemented, "Method file.Get is unimplemented.")
+}
+
+// TransferToRemote RPC is unimplemented.
+func (srv *FileServer) TransferToRemote(ctx context.Context, req *gnoi_file_pb.TransferToRemoteRequest) (*gnoi_file_pb.TransferToRemoteResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "Method file.TransferToRemote is unimplemented.")
+}
+
+// Put RPC is unimplemented.
+func (srv *FileServer) Put(stream gnoi_file_pb.File_PutServer) error {
+	return status.Errorf(codes.Unimplemented, "Method file.Put is unimplemented.")
+}
+
+// Remove implements the corresponding RPC.
+func (srv *FileServer) Remove(ctx context.Context, req *gnoi_file_pb.RemoveRequest) (*gnoi_file_pb.RemoveResponse, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "Invalid nil request.")
+	}
+	if req.GetRemoteFile() == "" {
+		return nil, status.Error(codes.InvalidArgument, "Invalid request: remote_file field is empty.")
+	}
+	sc, err := ssc.NewDbusClient(dbusCaller)
+	if err != nil {
+		return nil, err
+	}
+	_, err = sc.FileRemove(req.GetRemoteFile())
+	return &gnoi_file_pb.RemoveResponse{}, err
+}

--- a/gnmi_server/gnoi_file_test.go
+++ b/gnmi_server/gnoi_file_test.go
@@ -1,0 +1,54 @@
+package gnmi
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"github.com/openconfig/gnoi/file"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"testing"
+)
+
+// TestFileServer tests implementation of gnoi.File server.
+func TestFileServer(t *testing.T) {
+	s := createServer(t)
+	go runServer(t, s)
+	targetAddr := fmt.Sprintf("127.0.0.1:%d", s.config.Port)
+	tlsConfig := &tls.Config{InsecureSkipVerify: true}
+	opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
+	conn, err := grpc.Dial(targetAddr, opts...)
+	if err != nil {
+		t.Fatalf("Dialing to %s failed: %v", targetAddr, err)
+	}
+	defer conn.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sc := file.NewFileClient(conn)
+	t.Run("GetFailsAsUnimplemented", func(t *testing.T) {
+		stream, err := sc.Get(ctx, &file.GetRequest{})
+		if err != nil {
+			t.Error(err.Error())
+		}
+		_, err = stream.Recv()
+		testErr(err, codes.Unimplemented, "Method file.Get is unimplemented.", t)
+	})
+	t.Run("TransferToRemoteFailsAsUnimplemented", func(t *testing.T) {
+		_, err := sc.TransferToRemote(ctx, &file.TransferToRemoteRequest{})
+		testErr(err, codes.Unimplemented, "Method file.TransferToRemote is unimplemented.", t)
+	})
+	t.Run("PutFailsAsUnimplemented", func(t *testing.T) {
+		stream, err := sc.Put(ctx)
+		if err != nil {
+			t.Error(err.Error())
+		}
+		_, err = stream.CloseAndRecv()
+		testErr(err, codes.Unimplemented, "Method file.Put is unimplemented.", t)
+	})
+	t.Run("RemoveFailsIfRemoteFileMissing", func(t *testing.T) {
+		req := &file.RemoveRequest{}
+		_, err := sc.Remove(ctx, req)
+		testErr(err, codes.InvalidArgument, "Invalid request: remote_file field is empty.", t)
+	})
+}

--- a/gnmi_server/gnoi_system.go
+++ b/gnmi_server/gnoi_system.go
@@ -47,7 +47,7 @@ func ValidateRebootRequest(req *syspb.RebootRequest) error {
 }
 
 func KillOrRestartProcess(restart bool, serviceName string) error {
-	sc, err := ssc.NewDbusClient()
+	sc, err := ssc.NewDbusClient(dbusCaller)
 	if err != nil {
 		return err
 	}
@@ -309,7 +309,7 @@ func (srv *Server) SetPackage(rs syspb.System_SetPackageServer) error {
 	log.V(1).Info("gNOI: SetPackage request received")
 
 	// Create D-Bus client
-	dbus, err := ssc.NewDbusClient()
+	dbus, err := ssc.NewDbusClient(dbusCaller)
 	if err != nil {
 		log.Errorf("Failed to create D-Bus client: %v", err)
 		return status.Errorf(codes.Internal, "failed to create D-Bus client: %v", err)

--- a/gnmi_server/gnoi_system_test.go
+++ b/gnmi_server/gnoi_system_test.go
@@ -448,7 +448,7 @@ func RebootBackendResponse(t *testing.T, sc *redis.Client, expectedResponse code
 }
 
 func TestSystem(t *testing.T) {
-	s := createServer(t, 8081)
+	s := createServer(t)
 	go runServer(t, s)
 	defer s.Stop()
 

--- a/gnmi_server/poll_mode_test.go
+++ b/gnmi_server/poll_mode_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestPollMissingTableThenTableKey(t *testing.T) {
 	// Test that 1) missing table 2)table + key should just send sync responses and rpc connection should be alive
-	s := createServer(t, 8081)
+	s := createServer(t)
 	go runServer(t, s)
 	defer s.ForceStop()
 
@@ -129,7 +129,7 @@ func TestPollMissingTableThenTableKey(t *testing.T) {
 
 func TestPollMissingTableAndTableKey(t *testing.T) {
 	// Test that missing table and table + key should just send sync responses and rpc connection should be alive
-	s := createServer(t, 8081)
+	s := createServer(t)
 	go runServer(t, s)
 	defer s.ForceStop()
 
@@ -225,7 +225,7 @@ func TestPollMissingTableAndTableKey(t *testing.T) {
 func TestPollMissingTableThenAdded(t *testing.T) {
 	// Test that missing table should just send sync responses and rpc connection should be alive
 	// When we add data for Table, we should receive update notifications
-	s := createServer(t, 8081)
+	s := createServer(t)
 	go runServer(t, s)
 	defer s.ForceStop()
 
@@ -340,7 +340,7 @@ func TestPollMissingTableThenAdded(t *testing.T) {
 func TestPollMissingKeyThenAdded(t *testing.T) {
 	// Test that missing table+key should just send sync responses and rpc connection should be alive
 	// When we add data for table+key, we should receive update notifications
-	s := createServer(t, 8081)
+	s := createServer(t)
 	go runServer(t, s)
 	defer s.ForceStop()
 
@@ -455,7 +455,7 @@ func TestPollMissingKeyThenAdded(t *testing.T) {
 func TestPollMissingTableAndKeyThenAdded(t *testing.T) {
 	// Test that we get not updates from missing table and table key queried but still get sync responses
 	// After adding back, we will get both updates
-	s := createServer(t, 8081)
+	s := createServer(t)
 	go runServer(t, s)
 	defer s.ForceStop()
 
@@ -595,7 +595,7 @@ func TestPollMissingTableAndKeyThenAdded(t *testing.T) {
 func TestPollPresentTableMissingTableKey(t *testing.T) {
 	// Test that we receive update notification for table query and no data for missing key
 	// After 2 polls, we will add back the missing key data to get both data in our notifications
-	s := createServer(t, 8081)
+	s := createServer(t)
 	go runServer(t, s)
 	defer s.ForceStop()
 
@@ -737,7 +737,7 @@ func TestPollPresentTableMissingTableKey(t *testing.T) {
 func TestPollPresentTableKeyMissingTable(t *testing.T) {
 	// Test that we receive update notification for table key query and no data for missing table
 	// After 2 polls, we will add back the missing table data to get both data in our notifications
-	s := createServer(t, 8081)
+	s := createServer(t)
 	go runServer(t, s)
 	defer s.ForceStop()
 
@@ -879,7 +879,7 @@ func TestPollPresentTableKeyMissingTable(t *testing.T) {
 func TestPollTableDeleted(t *testing.T) {
 	// Test that we received update notifications for existing table data, then delete table, we should receive 1 delete notification
 	// After delete notification, we should only see sync responses
-	s := createServer(t, 8081)
+	s := createServer(t)
 	go runServer(t, s)
 	defer s.ForceStop()
 
@@ -1001,7 +1001,7 @@ func TestPollTableDeleted(t *testing.T) {
 func TestPollTableFieldDeleted(t *testing.T) {
 	// Test that we received update notifications for existing table field data, then delete table field, we should receive 1 delete notification
 	// After delete notification, we should only see sync responses
-	s := createServer(t, 8081)
+	s := createServer(t)
 	go runServer(t, s)
 	defer s.ForceStop()
 
@@ -1114,7 +1114,7 @@ func TestPollTableFieldDeleted(t *testing.T) {
 func TestPollTableKeyDeleted(t *testing.T) {
 	// Test that we received update notifications for existing table key data, then delete table key, we should receive 1 delete notification
 	// After delete notification, we should only see sync responses
-	s := createServer(t, 8081)
+	s := createServer(t)
 	go runServer(t, s)
 	defer s.ForceStop()
 
@@ -1237,7 +1237,7 @@ func TestPollTableKeyDeleted(t *testing.T) {
 func TestPollTableAndTableKeyBothDeleted(t *testing.T) {
 	// Test that we received update notifications for existing data, then delete both table and table key, we should receive 2 delete notifications
 	// After delete notifications, we should only see sync responses
-	s := createServer(t, 8081)
+	s := createServer(t)
 	go runServer(t, s)
 	defer s.ForceStop()
 
@@ -1385,7 +1385,7 @@ func TestPollTableAndTableKeyBothDeleted(t *testing.T) {
 func TestPollTableAndTableKeyTableDeleted(t *testing.T) {
 	// Test that we receive update notifications for existing data, and then when we delete table we should receive delete notification
 	// After delete notification, we should see sync responses and continued update for existing data
-	s := createServer(t, 8081)
+	s := createServer(t)
 	go runServer(t, s)
 	defer s.ForceStop()
 
@@ -1535,7 +1535,7 @@ func TestPollTableAndTableKeyTableDeleted(t *testing.T) {
 func TestPollTableAndTableKeyTableKeyDeleted(t *testing.T) {
 	// Test that we receive update notifications for existing data, and then when we delete table key we should receive delete notification
 	// After delete notification, we should see sync responses and continued update for existing data
-	s := createServer(t, 8081)
+	s := createServer(t)
 	go runServer(t, s)
 	defer s.ForceStop()
 

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -65,7 +65,24 @@ import (
 	"github.com/sonic-net/sonic-gnmi/swsscommon"
 )
 
+const (
+	srvTestCertFile = "../testdata/mtls/server_test_cert.pem"
+	srvTestKeyFile  = "../testdata/mtls/server_test_key.pem"
+	srvTestKeyLink  = "../testdata/mtls/server_key.lnk"
+	srvTestCertLink = "../testdata/mtls/server_cert.lnk"
+)
+
 var clientTypes = []string{gclient.Type}
+
+type testServerType int
+
+const (
+	testSrvType testServerType = iota
+	readOnlySrvType
+	rejectSrvType
+	authSrvType
+	keepAliveSrvType
+)
 
 func loadConfig(t *testing.T, key string, in []byte) map[string]interface{} {
 	var fvp map[string]interface{}
@@ -120,26 +137,81 @@ func createClient(t *testing.T, port int) *grpc.ClientConn {
 	return conn
 }
 
-func createServer(t *testing.T, port int64) *Server {
-	t.Helper()
-	certificate, err := testcert.NewCert()
-	if err != nil {
-		t.Fatalf("could not load server key pair: %s", err)
-	}
-	tlsCfg := &tls.Config{
-		ClientAuth:   tls.RequestClientCert,
-		Certificates: []tls.Certificate{certificate},
-	}
+// To avoid problems related to starting a new instance of the server on a port
+// already being used by another instance every time a server is created it is
+// started on a unique TCP port.
+var testSrvPort int64 = 8000
+var testSrvPortMu sync.Mutex
 
-	opts := []grpc.ServerOption{grpc.Creds(credentials.NewTLS(tlsCfg))}
-	cfg := &Config{Port: port, EnableTranslibWrite: true, EnableNativeWrite: true, Threshold: 100}
-	s, err := NewServer(cfg, opts)
+func getNewTestSrvPort() int64 {
+	testSrvPortMu.Lock()
+	defer testSrvPortMu.Unlock()
+	testSrvPort = testSrvPort + 1
+	if testSrvPort > 8888 {
+		testSrvPort = 8000
+	}
+	return testSrvPort
+}
+
+func createServer(t *testing.T) *Server {
+	t.Helper()
+	opts := []grpc.ServerOption{}
+	s, err := NewServer(testServerConfig(testSrvType), opts)
 	if err != nil {
-		t.Errorf("Failed to create gNMI server: %v", err)
+		t.Fatalf("Failed to create gNMI server: %v", err)
 	}
 	return s
 }
 
+func createCustomServer(t *testing.T, cfg *Config) *Server {
+	t.Helper()
+	opts := []grpc.ServerOption{}
+	s, err := NewServer(cfg, opts)
+	if err != nil {
+		t.Fatalf("Failed to create gNMI server: %v", err)
+	}
+	return s
+}
+
+func testServerConfig(srvType testServerType) *Config {
+	oscfg := &OSConfig{
+		ImgDir:          "/tmp",
+		ProcessTrfReady: ProcessFakeTrfReady,
+		ProcessTrfEnd:   ProcessFakeTrfEnd,
+	}
+	cfg := &Config{
+		Port:                getNewTestSrvPort(),
+		EnableTranslibWrite: true,
+		Threshold:           100,
+		LogLevel:            3,
+		CaCertLnk:           "",
+		CaCertFile:          "",
+		SrvCertLnk:          srvTestCertLink,
+		SrvCertFile:         srvTestCertFile,
+		SrvKeyLnk:           srvTestKeyLink,
+		SrvKeyFile:          srvTestKeyFile,
+		OSCfg:               oscfg,
+		GetOptions:          SrvTestConfig,
+	}
+
+	switch srvType {
+	case readOnlySrvType:
+		cfg.EnableTranslibWrite = false
+	case rejectSrvType:
+		cfg.Threshold = 2
+	case authSrvType:
+		cfg.UserAuth = AuthTypes{"password": true, "cert": true, "jwt": true}
+	case keepAliveSrvType:
+		keepaliveMaxIdle = 1 * time.Second
+		cfg.EnableNativeWrite = true
+	case testSrvType:
+		fallthrough
+	default:
+		cfg.EnableNativeWrite = true
+	}
+
+	return cfg
+}
 func createReadServer(t *testing.T, port int64) *Server {
 	certificate, err := testcert.NewCert()
 	if err != nil {
@@ -244,7 +316,7 @@ func createKeepAliveServer(t *testing.T, port int64) *Server {
 }
 
 func TestPFCWDErrors(t *testing.T) {
-	s := createServer(t, 8081)
+	s := createServer(t)
 	go runServer(t, s)
 	defer s.ForceStop()
 
@@ -1074,7 +1146,7 @@ func TestGnmiSet(t *testing.T) {
 	if !ENABLE_TRANSLIB_WRITE {
 		t.Skip("skipping test in read-only mode.")
 	}
-	s := createServer(t, 8081)
+	s := createServer(t)
 	go runServer(t, s)
 
 	prepareDbTranslib(t)
@@ -1083,7 +1155,7 @@ func TestGnmiSet(t *testing.T) {
 	tlsConfig := &tls.Config{InsecureSkipVerify: true}
 	opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
 
-	targetAddr := "127.0.0.1:8081"
+	targetAddr := fmt.Sprintf("127.0.0.1:%d", s.config.Port)
 	conn, err := grpc.Dial(targetAddr, opts...)
 	if err != nil {
 		t.Fatalf("Dialing to %q failed: %v", targetAddr, err)
@@ -1231,14 +1303,14 @@ func TestGnmiSet(t *testing.T) {
 }
 
 func TestGnmiSetReadOnly(t *testing.T) {
-	s := createReadServer(t, 8081)
+	s := createCustomServer(t, testServerConfig(readOnlySrvType))
 	go runServer(t, s)
 	defer s.Stop()
 
 	tlsConfig := &tls.Config{InsecureSkipVerify: true}
 	opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
 
-	targetAddr := "127.0.0.1:8081"
+	targetAddr := fmt.Sprintf("127.0.0.1:%d", s.config.Port)
 	conn, err := grpc.Dial(targetAddr, opts...)
 	if err != nil {
 		t.Fatalf("Dialing to %q failed: %v", targetAddr, err)
@@ -1263,14 +1335,14 @@ func TestGnmiSetReadOnly(t *testing.T) {
 }
 
 func TestGnmiSetAuthFail(t *testing.T) {
-	s := createAuthServer(t, 8081)
+	s := createCustomServer(t, testServerConfig(authSrvType))
 	go runServer(t, s)
 	defer s.Stop()
 
 	tlsConfig := &tls.Config{InsecureSkipVerify: true}
 	opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
 
-	targetAddr := "127.0.0.1:8081"
+	targetAddr := fmt.Sprintf("127.0.0.1:%d", s.config.Port)
 	conn, err := grpc.Dial(targetAddr, opts...)
 	if err != nil {
 		t.Fatalf("Dialing to %q failed: %v", targetAddr, err)
@@ -1295,14 +1367,14 @@ func TestGnmiSetAuthFail(t *testing.T) {
 }
 
 func TestGnmiGetAuthFail(t *testing.T) {
-	s := createAuthServer(t, 8081)
+	s := createCustomServer(t, testServerConfig(authSrvType))
 	go runServer(t, s)
 	defer s.Stop()
 
 	tlsConfig := &tls.Config{InsecureSkipVerify: true}
 	opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
 
-	targetAddr := "127.0.0.1:8081"
+	targetAddr := fmt.Sprintf("127.0.0.1:%d", s.config.Port)
 	conn, err := grpc.Dial(targetAddr, opts...)
 	if err != nil {
 		t.Fatalf("Dialing to %q failed: %v", targetAddr, err)
@@ -1326,12 +1398,12 @@ func TestGnmiGetAuthFail(t *testing.T) {
 	}
 }
 
-func runGnmiTestGet(t *testing.T, namespace string) {
+func runGnmiTestGet(t *testing.T, port int64, namespace string) {
 	//t.Log("Start gNMI client")
 	tlsConfig := &tls.Config{InsecureSkipVerify: true}
 	opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
 
-	targetAddr := "127.0.0.1:8081"
+	targetAddr := fmt.Sprintf("127.0.0.1:%d", s.config.Port)
 	conn, err := grpc.Dial(targetAddr, opts...)
 	if err != nil {
 		t.Fatalf("Dialing to %q failed: %v", targetAddr, err)
@@ -1665,13 +1737,13 @@ func runGnmiTestGet(t *testing.T, namespace string) {
 
 func TestGnmiGet(t *testing.T) {
 	//t.Log("Start server")
-	s := createServer(t, 8081)
+	s := createServer(t)
 	go runServer(t, s)
 
 	ns, _ := sdcfg.GetDbDefaultNamespace()
 	prepareDb(t, ns)
 
-	runGnmiTestGet(t, ns)
+	runGnmiTestGet(t, s.config.Port, ns)
 
 	s.Stop()
 }
@@ -1691,18 +1763,18 @@ func TestGnmiGetMultiNs(t *testing.T) {
 	})
 
 	//t.Log("Start server")
-	s := createServer(t, 8081)
+	s := createServer(t)
 	go runServer(t, s)
 
 	prepareDb(t, test_utils.GetMultiNsNamespace())
 
-	runGnmiTestGet(t, test_utils.GetMultiNsNamespace())
+	runGnmiTestGet(t, s.config.Port, test_utils.GetMultiNsNamespace())
 
 	s.Stop()
 }
 func TestGnmiGetTranslib(t *testing.T) {
 	//t.Log("Start server")
-	s := createServer(t, 8081)
+	s := createServer(t)
 	go runServer(t, s)
 
 	prepareDbTranslib(t)
@@ -1711,7 +1783,7 @@ func TestGnmiGetTranslib(t *testing.T) {
 	tlsConfig := &tls.Config{InsecureSkipVerify: true}
 	opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
 
-	targetAddr := "127.0.0.1:8081"
+	targetAddr := fmt.Sprintf("127.0.0.1:%d", s.config.Port)
 	conn, err := grpc.Dial(targetAddr, opts...)
 	if err != nil {
 		t.Fatalf("Dialing to %q failed: %v", targetAddr, err)
@@ -2857,7 +2929,7 @@ func runTestSubscribe(t *testing.T, namespace string) {
 		time.Sleep(time.Millisecond * 1000)
 		t.Run(tt.desc, func(t *testing.T) {
 			q := tt.q
-			q.Addrs = []string{"127.0.0.1:8081"}
+			q.Addrs = []string{fmt.Sprintf("127.0.0.1:%d", port)}
 			c := client.New()
 			defer c.Close()
 			var gotNoti []client.Notification
@@ -2943,11 +3015,11 @@ func runTestSubscribe(t *testing.T, namespace string) {
 }
 
 func TestGnmiSubscribe(t *testing.T) {
-	s := createServer(t, 8081)
+	s := createServer(t)
 	go runServer(t, s)
 
 	ns, _ := sdcfg.GetDbDefaultNamespace()
-	runTestSubscribe(t, ns)
+	runTestSubscribe(t, s.config.Port, ns)
 
 	s.Stop()
 }
@@ -2966,17 +3038,17 @@ func TestGnmiSubscribeMultiNs(t *testing.T) {
 		}
 	})
 
-	s := createServer(t, 8081)
+	s := createServer(t)
 	go runServer(t, s)
 
-	runTestSubscribe(t, test_utils.GetMultiNsNamespace())
+	runTestSubscribe(t, s.config.Port, test_utils.GetMultiNsNamespace())
 
 	s.Stop()
 }
 
 func TestCapabilities(t *testing.T) {
 	//t.Log("Start server")
-	s := createServer(t, 8085)
+	s := createServer(t)
 	go runServer(t, s)
 
 	// prepareDb(t)
@@ -2986,7 +3058,7 @@ func TestCapabilities(t *testing.T) {
 	opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
 
 	//targetAddr := "30.57.185.38:8080"
-	targetAddr := "127.0.0.1:8085"
+	targetAddr := fmt.Sprintf("127.0.0.1:%d", s.config.Port)
 	conn, err := grpc.Dial(targetAddr, opts...)
 	if err != nil {
 		t.Fatalf("Dialing to %q failed: %v", targetAddr, err)
@@ -3012,7 +3084,7 @@ func TestGNOI(t *testing.T) {
 	if !ENABLE_TRANSLIB_WRITE {
 		t.Skip("skipping test in read-only mode.")
 	}
-	s := createServer(t, 8086)
+	s := createServer(t)
 	go runServer(t, s)
 	defer s.Stop()
 
@@ -3022,8 +3094,7 @@ func TestGNOI(t *testing.T) {
 	tlsConfig := &tls.Config{InsecureSkipVerify: true}
 	opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
 
-	//targetAddr := "30.57.185.38:8080"
-	targetAddr := "127.0.0.1:8086"
+	targetAddr := fmt.Sprintf("127.0.0.1:%d", s.config.Port)
 	conn, err := grpc.Dial(targetAddr, opts...)
 	if err != nil {
 		t.Fatalf("Dialing to %q failed: %v", targetAddr, err)
@@ -3276,7 +3347,7 @@ func TestGNOI(t *testing.T) {
 }
 
 func TestBundleVersion(t *testing.T) {
-	s := createServer(t, 8087)
+	s := createServer(t)
 	go runServer(t, s)
 	defer s.Stop()
 
@@ -3286,8 +3357,7 @@ func TestBundleVersion(t *testing.T) {
 	tlsConfig := &tls.Config{InsecureSkipVerify: true}
 	opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
 
-	//targetAddr := "30.57.185.38:8080"
-	targetAddr := "127.0.0.1:8087"
+	targetAddr := fmt.Sprintf("127.0.0.1:%d", s.config.Port)
 	conn, err := grpc.Dial(targetAddr, opts...)
 	if err != nil {
 		t.Fatalf("Dialing to %q failed: %v", targetAddr, err)
@@ -3336,7 +3406,7 @@ func TestBundleVersion(t *testing.T) {
 }
 
 func TestBulkSet(t *testing.T) {
-	s := createServer(t, 8088)
+	s := createServer(t)
 	go runServer(t, s)
 	defer s.Stop()
 
@@ -3346,8 +3416,7 @@ func TestBulkSet(t *testing.T) {
 	tlsConfig := &tls.Config{InsecureSkipVerify: true}
 	opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
 
-	//targetAddr := "30.57.185.38:8080"
-	targetAddr := "127.0.0.1:8088"
+	targetAddr := fmt.Sprintf("127.0.0.1:%d", s.config.Port)
 	conn, err := grpc.Dial(targetAddr, opts...)
 	if err != nil {
 		t.Fatalf("Dialing to %q failed: %v", targetAddr, err)
@@ -3455,7 +3524,7 @@ func TestAuthCapabilities(t *testing.T) {
 	})
 	defer mock1.Reset()
 
-	s := createAuthServer(t, 8089)
+	s := createCustomServer(t, testServerConfig(authSrvType))
 	go runServer(t, s)
 	defer s.Stop()
 
@@ -3464,7 +3533,7 @@ func TestAuthCapabilities(t *testing.T) {
 	cred := &loginCreds{Username: currentUser.Username, Password: "dummy"}
 	opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)), grpc.WithPerRPCCredentials(cred)}
 
-	targetAddr := "127.0.0.1:8089"
+	targetAddr := fmt.Sprintf("127.0.0.1:%d", s.config.Port)
 	conn, err := grpc.Dial(targetAddr, opts...)
 	if err != nil {
 		t.Fatalf("Dialing to %q failed: %v", targetAddr, err)
@@ -3486,7 +3555,7 @@ func TestAuthCapabilities(t *testing.T) {
 }
 
 func TestTableKeyOnDeletion(t *testing.T) {
-	s := createKeepAliveServer(t, 8081)
+	s := createCustomServer(t, testServerConfig(keepAliveSrvType))
 	go runServer(t, s)
 	defer s.Stop()
 
@@ -3572,7 +3641,7 @@ func TestTableKeyOnDeletion(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			q := tt.q
-			q.Addrs = []string{"127.0.0.1:8081"}
+			q.Addrs = []string{fmt.Sprintf("127.0.0.1:%d", s.config.Port)}
 			c := client.New()
 			defer c.Close()
 			var gotNoti []client.Notification
@@ -3624,7 +3693,7 @@ func TestCPUUtilization(t *testing.T) {
 	})
 
 	defer mock.Reset()
-	s := createServer(t, 8081)
+	s := createServer(t)
 	go runServer(t, s)
 	defer s.Stop()
 
@@ -3653,7 +3722,7 @@ func TestCPUUtilization(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			q := tt.q
-			q.Addrs = []string{"127.0.0.1:8081"}
+			q.Addrs = []string{fmt.Sprintf("127.0.0.1:%d", s.config.Port)}
 			c := client.New()
 			var gotNoti []client.Notification
 			q.NotificationHandler = func(n client.Notification) error {
@@ -3694,7 +3763,7 @@ func TestCPUUtilization(t *testing.T) {
 }
 
 func TestClientConnections(t *testing.T) {
-	s := createRejectServer(t, 8081)
+	s := createCustomServer(t, testServerConfig(rejectSrvType))
 	go runServer(t, s)
 	defer s.Stop()
 
@@ -3753,7 +3822,7 @@ func TestClientConnections(t *testing.T) {
 	for i, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			q := tt.q
-			q.Addrs = []string{"127.0.0.1:8081"}
+			q.Addrs = []string{fmt.Sprintf("127.0.0.1:%d", s.config.Port)}
 			var gotNoti []client.Notification
 			q.NotificationHandler = func(n client.Notification) error {
 				if nn, ok := n.(client.Update); ok {
@@ -3791,7 +3860,7 @@ func TestClientConnections(t *testing.T) {
 }
 
 func TestWildcardTableNoError(t *testing.T) {
-	s := createServer(t, 8081)
+	s := createServer(t)
 	go runServer(t, s)
 	defer s.ForceStop()
 
@@ -3883,7 +3952,7 @@ func TestWildcardTableNoError(t *testing.T) {
 }
 
 func TestNonExistentTableNoError(t *testing.T) {
-	s := createServer(t, 8081)
+	s := createServer(t)
 	go runServer(t, s)
 	defer s.ForceStop()
 
@@ -3976,7 +4045,7 @@ func TestNonExistentTableNoError(t *testing.T) {
 }
 
 func TestConnectionDataSet(t *testing.T) {
-	s := createServer(t, 8081)
+	s := createServer(t)
 	go runServer(t, s)
 	defer s.ForceStop()
 
@@ -4009,7 +4078,7 @@ func TestConnectionDataSet(t *testing.T) {
 		prepareStateDb(t, namespace)
 		t.Run(tt.desc, func(t *testing.T) {
 			q := tt.q
-			q.Addrs = []string{"127.0.0.1:8081"}
+			q.Addrs = []string{fmt.Sprintf("127.0.0.1:%d", s.config.Port)}
 			c := client.New()
 
 			wg := new(sync.WaitGroup)
@@ -4045,7 +4114,7 @@ func TestConnectionDataSet(t *testing.T) {
 }
 
 func TestConnectionsKeepAlive(t *testing.T) {
-	s := createKeepAliveServer(t, 8081)
+	s := createCustomServer(t, testServerConfig(keepAliveSrvType))
 	go runServer(t, s)
 	defer s.Stop()
 
@@ -4075,7 +4144,7 @@ func TestConnectionsKeepAlive(t *testing.T) {
 		for i := 0; i < 5; i++ {
 			t.Run(tt.desc, func(t *testing.T) {
 				q := tt.q
-				q.Addrs = []string{"127.0.0.1:8081"}
+				q.Addrs = []string{fmt.Sprintf("127.0.0.1:%d", s.config.Port)}
 				c := client.New()
 				clients = append(clients, c)
 				wg := new(sync.WaitGroup)
@@ -4174,12 +4243,12 @@ func TestClient(t *testing.T) {
 	})
 	defer mock6.Reset()
 
-	s := createServer(t, 8081)
+	s := createServer(t)
 	go runServer(t, s)
 
 	qstr := fmt.Sprintf("all[heartbeat=%d]", HEARTBEAT_SET)
 	q := createEventsQuery(t, qstr)
-	q.Addrs = []string{"127.0.0.1:8081"}
+	q.Addrs = []string{fmt.Sprintf("127.0.0.1:%d", s.config.Port)}
 
 	tests := []struct {
 		desc     string
@@ -4336,7 +4405,7 @@ print('%s')
 	defer mock1.Reset()
 
 	sdcfg.Init()
-	s := createServer(t, 8090)
+	s := createServer(t)
 	go runServer(t, s)
 
 	prepareDbTranslib(t)
@@ -4345,7 +4414,7 @@ print('%s')
 	tlsConfig := &tls.Config{InsecureSkipVerify: true}
 	opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
 
-	targetAddr := "127.0.0.1:8090"
+	targetAddr := fmt.Sprintf("127.0.0.1:%d", s.config.Port)
 	conn, err := grpc.Dial(targetAddr, opts...)
 	if err != nil {
 		t.Fatalf("Dialing to %q failed: %v", targetAddr, err)
@@ -4417,7 +4486,7 @@ func TestGNMINative(t *testing.T) {
 	defer mock3.Reset()
 
 	sdcfg.Init()
-	s := createServer(t, 8080)
+	s := createServer(t)
 	go runServer(t, s)
 	defer s.Stop()
 	ns, _ := sdcfg.GetDbDefaultNamespace()
@@ -4471,7 +4540,7 @@ func TestGNMINativeMultiDB(t *testing.T) {
 		}
 	})
 
-	s := createServer(t, 8080)
+	s := createServer(t)
 	go runServer(t, s)
 	defer s.Stop()
 
@@ -4518,7 +4587,7 @@ func TestGNMINativeMultiNamespace(t *testing.T) {
 		}
 	})
 
-	s := createServer(t, 8080)
+	s := createServer(t)
 	go runServer(t, s)
 	defer s.Stop()
 	ns, _ := sdcfg.GetDbDefaultNamespace()
@@ -4539,7 +4608,9 @@ func TestGNMINativeMultiNamespace(t *testing.T) {
 }
 
 func TestServerPort(t *testing.T) {
-	s := createServer(t, -8080)
+	cfg := testServerConfig(testSrvType)
+	cfg.Port = -8080
+	s := createCustomServer(t, cfg)
 	port := s.Port()
 	if port != 0 {
 		t.Errorf("Invalid port: %d", port)
@@ -4597,7 +4668,7 @@ func TestParseOrigin(t *testing.T) {
 }
 
 func TestMasterArbitration(t *testing.T) {
-	s := createServer(t, 8088)
+	s := createServer(t)
 	// Turn on Master Arbitration
 	s.ReqFromMaster = ReqFromMasterEnabledMA
 	go runServer(t, s)
@@ -4608,8 +4679,7 @@ func TestMasterArbitration(t *testing.T) {
 	tlsConfig := &tls.Config{InsecureSkipVerify: true}
 	opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
 
-	//targetAddr := "30.57.185.38:8080"
-	targetAddr := "127.0.0.1:8088"
+	targetAddr := fmt.Sprintf("127.0.0.1:%d", s.config.Port)
 	conn, err := grpc.Dial(targetAddr, opts...)
 	if err != nil {
 		t.Fatalf("Dialing to %q failed: %v", targetAddr, err)
@@ -5083,7 +5153,7 @@ func (x *MockSetPackageServer) Recv() (*gnoi_system_pb.SetPackageRequest, error)
 }
 
 func TestGnoiAuthorization(t *testing.T) {
-	s := createServer(t, 8081)
+	s := createServer(t)
 	go runServer(t, s)
 	mockAuthenticate := gomonkey.ApplyFunc(s.Authenticate, func(ctx context.Context, req *spb_jwt.AuthenticateRequest) (*spb_jwt.AuthenticateResponse, error) {
 		return nil, nil

--- a/gnmi_server/transl_sub_test.go
+++ b/gnmi_server/transl_sub_test.go
@@ -38,7 +38,7 @@ const (
 )
 
 func TestTranslSubscribe(t *testing.T) {
-	s := createServer(t, 8081)
+	s := createServer(t)
 	go runServer(t, s)
 	defer s.s.Stop()
 
@@ -936,7 +936,7 @@ func newBundleVersion(t *testing.T, version string) *extnpb.Extension {
 }
 
 func TestDebugSubscribePreferences(t *testing.T) {
-	s := createServer(t, 8081)
+	s := createServer(t)
 	go runServer(t, s)
 	defer s.s.Stop()
 

--- a/gnoi_client/file/file.go
+++ b/gnoi_client/file/file.go
@@ -29,3 +29,116 @@ func Stat(conn *grpc.ClientConn, ctx context.Context) {
 	}
 	fmt.Println(string(respstr))
 }
+
+func Get(conn *grpc.ClientConn, ctx context.Context) {
+	fmt.Println("File Get")
+	ctx = utils.SetUserCreds(ctx)
+	fc := pb.NewFileClient(conn)
+
+	req := &pb.GetRequest{}
+	err := json.Unmarshal([]byte(*config.Args), req)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	stream, err := fc.Get(ctx, req)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	for {
+		resp, err := stream.Recv()
+		if err != nil {
+			panic(err.Error())
+			break
+		}
+
+		switch r := resp.Response.(type) {
+		case *pb.GetResponse_Contents:
+			fmt.Printf("Received file chunk: %v\n", r.Contents)
+		case *pb.GetResponse_Hash:
+			fmt.Printf("Received file hash: %v\n", r.Hash)
+		default:
+			fmt.Println("Unknown GetResponse type")
+		}
+	}
+}
+
+func Put(conn *grpc.ClientConn, ctx context.Context) {
+	fmt.Println("File Put")
+	ctx = utils.SetUserCreds(ctx)
+	fc := pb.NewFileClient(conn)
+
+	req := &pb.PutRequest{}
+	err := json.Unmarshal([]byte(*config.Args), req)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	stream, err := fc.Put(ctx)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	err = stream.Send(req)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	resp, err := stream.CloseAndRecv()
+	if err != nil {
+		panic(err.Error())
+	}
+
+	respstr, err := json.Marshal(resp)
+	if err != nil {
+		panic(err.Error())
+	}
+	fmt.Println(string(respstr))
+}
+
+func Remove(conn *grpc.ClientConn, ctx context.Context) {
+	fmt.Println("File Remove")
+	ctx = utils.SetUserCreds(ctx)
+	fc := pb.NewFileClient(conn)
+
+	req := &pb.RemoveRequest{}
+	err := json.Unmarshal([]byte(*config.Args), req)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	resp, err := fc.Remove(ctx, req)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	respstr, err := json.Marshal(resp)
+	if err != nil {
+		panic(err.Error())
+	}
+	fmt.Println(string(respstr))
+}
+
+func TransferToRemote(conn *grpc.ClientConn, ctx context.Context) {
+	fmt.Println("File TransferToRemote")
+	ctx = utils.SetUserCreds(ctx)
+	fc := pb.NewFileClient(conn)
+
+	req := &pb.TransferToRemoteRequest{}
+	err := json.Unmarshal([]byte(*config.Args), req)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	resp, err := fc.TransferToRemote(ctx, req)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	respstr, err := json.Marshal(resp)
+	if err != nil {
+		panic(err.Error())
+	}
+	fmt.Println(string(respstr))
+}

--- a/gnoi_client/gnoi_client.go
+++ b/gnoi_client/gnoi_client.go
@@ -53,6 +53,14 @@ func main() {
 		switch *config.Rpc {
 		case "Stat":
 			file.Stat(conn, ctx)
+		case "Get":
+			file.Get(conn, ctx)
+		case "Put":
+			file.Put(conn, ctx)
+		case "Remove":
+			file.Remove(conn, ctx)
+		case "TransferToRemote":
+			file.TransferToRemote(conn, ctx)
 		default:
 			panic("Invalid RPC Name")
 		}

--- a/sonic_data_client/mixed_db_client.go
+++ b/sonic_data_client/mixed_db_client.go
@@ -1216,7 +1216,7 @@ func (c *MixedDbClient) SetIncrementalConfig(delete []*gnmipb.Path, replace []*g
 	var err error
 
 	var sc ssc.Service
-	sc, err = ssc.NewDbusClient()
+	sc, err = ssc.NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		return err
 	}
@@ -1414,7 +1414,7 @@ func (c *MixedDbClient) ReplaceFullConfig(delete []*gnmipb.Path, replace []*gnmi
 	content := []byte(ietf_json_val)
 
 	var sc ssc.Service
-	sc, err := ssc.NewDbusClient()
+	sc, err := ssc.NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		return err
 	}

--- a/sonic_data_client/mixed_db_client.go
+++ b/sonic_data_client/mixed_db_client.go
@@ -1220,6 +1220,16 @@ func (c *MixedDbClient) SetIncrementalConfig(delete []*gnmipb.Path, replace []*g
 	if err != nil {
 		return err
 	}
+	err = sc.CreateCheckPoint(CHECK_POINT_PATH + "/config")
+	if err != nil {
+		return err
+	}
+	defer sc.DeleteCheckPoint(CHECK_POINT_PATH + "/config")
+	fileName := CHECK_POINT_PATH + "/config.cp.json"
+	c.jClient, err = NewJsonClient(fileName)
+	if err != nil {
+		return err
+	}
 
 	multiNs, err := sdcfg.CheckDbMultiNamespace()
 	if err != nil {

--- a/sonic_service_client/dbus_client_test.go
+++ b/sonic_service_client/dbus_client_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestNewDbusClient(t *testing.T) {
-	client, err := NewDbusClient()
 	client, err := NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		t.Errorf("NewDbusClient failed: %v", err)
@@ -20,7 +19,6 @@ func TestNewDbusClient(t *testing.T) {
 }
 
 func TestCloseClient(t *testing.T) {
-	client, err := NewDbusClient()
 	client, err := NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		t.Errorf("NewDbusClient failed: %v", err)
@@ -32,7 +30,6 @@ func TestCloseClient(t *testing.T) {
 }
 
 func TestCloseClientWithChannel(t *testing.T) {
-	client, err := NewDbusClient()
 	client, err := NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		t.Errorf("NewDbusClient failed: %v", err)
@@ -52,7 +49,6 @@ func TestCloseClientWithChannel(t *testing.T) {
 }
 
 func TestSystemBusNegative(t *testing.T) {
-	client, err := NewDbusClient()
 	client, err := NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		t.Errorf("NewDbusClient failed: %v", err)
@@ -91,7 +87,6 @@ func TestGetFileStat(t *testing.T) {
 	})
 	defer mock2.Reset()
 
-	client, err := NewDbusClient()
 	client, err := NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		t.Errorf("NewDbusClient failed: %v", err)
@@ -130,7 +125,6 @@ func TestGetFileStatNegative(t *testing.T) {
 	})
 	defer mock2.Reset()
 
-	client, err := NewDbusClient()
 	client, err := NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		t.Errorf("NewDbusClient failed: %v", err)
@@ -163,7 +157,6 @@ func TestConfigReload(t *testing.T) {
 	})
 	defer mock2.Reset()
 
-	client, err := NewDbusClient()
 	client, err := NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		t.Errorf("NewDbusClient failed: %v", err)
@@ -194,7 +187,6 @@ func TestConfigReloadNegative(t *testing.T) {
 	})
 	defer mock2.Reset()
 
-	client, err := NewDbusClient()
 	client, err := NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		t.Errorf("NewDbusClient failed: %v", err)
@@ -221,7 +213,6 @@ func TestConfigReloadTimeout(t *testing.T) {
 	})
 	defer mock2.Reset()
 
-	client, err := NewDbusClient()
 	client, err := NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		t.Errorf("NewDbusClient failed: %v", err)
@@ -250,7 +241,6 @@ func TestConfigReplace(t *testing.T) {
 	})
 	defer mock2.Reset()
 
-	client, err := NewDbusClient()
 	client, err := NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		t.Errorf("NewDbusClient failed: %v", err)
@@ -281,7 +271,6 @@ func TestConfigReplaceNegative(t *testing.T) {
 	})
 	defer mock2.Reset()
 
-	client, err := NewDbusClient()
 	client, err := NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		t.Errorf("NewDbusClient failed: %v", err)
@@ -313,7 +302,6 @@ func TestConfigSave(t *testing.T) {
 	})
 	defer mock2.Reset()
 
-	client, err := NewDbusClient()
 	client, err := NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		t.Errorf("NewDbusClient failed: %v", err)
@@ -344,7 +332,6 @@ func TestConfigSaveNegative(t *testing.T) {
 	})
 	defer mock2.Reset()
 
-	client, err := NewDbusClient()
 	client, err := NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		t.Errorf("NewDbusClient failed: %v", err)
@@ -376,7 +363,6 @@ func TestApplyPatchYang(t *testing.T) {
 	})
 	defer mock2.Reset()
 
-	client, err := NewDbusClient()
 	client, err := NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		t.Errorf("NewDbusClient failed: %v", err)
@@ -407,7 +393,6 @@ func TestApplyPatchYangNegative(t *testing.T) {
 	})
 	defer mock2.Reset()
 
-	client, err := NewDbusClient()
 	client, err := NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		t.Errorf("NewDbusClient failed: %v", err)
@@ -439,7 +424,6 @@ func TestApplyPatchDb(t *testing.T) {
 	})
 	defer mock2.Reset()
 
-	client, err := NewDbusClient()
 	client, err := NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		t.Errorf("NewDbusClient failed: %v", err)
@@ -470,7 +454,6 @@ func TestApplyPatchDbNegative(t *testing.T) {
 	})
 	defer mock2.Reset()
 
-	client, err := NewDbusClient()
 	client, err := NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		t.Errorf("NewDbusClient failed: %v", err)
@@ -502,7 +485,6 @@ func TestCreateCheckPoint(t *testing.T) {
 	})
 	defer mock2.Reset()
 
-	client, err := NewDbusClient()
 	client, err := NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		t.Errorf("NewDbusClient failed: %v", err)
@@ -533,7 +515,6 @@ func TestCreateCheckPointNegative(t *testing.T) {
 	})
 	defer mock2.Reset()
 
-	client, err := NewDbusClient()
 	client, err := NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		t.Errorf("NewDbusClient failed: %v", err)
@@ -565,7 +546,6 @@ func TestDeleteCheckPoint(t *testing.T) {
 	})
 	defer mock2.Reset()
 
-	client, err := NewDbusClient()
 	client, err := NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		t.Errorf("NewDbusClient failed: %v", err)
@@ -596,7 +576,6 @@ func TestDeleteCheckPointNegative(t *testing.T) {
 	})
 	defer mock2.Reset()
 
-	client, err := NewDbusClient()
 	client, err := NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		t.Errorf("NewDbusClient failed: %v", err)
@@ -639,7 +618,6 @@ func TestDownloadImageSuccess(t *testing.T) {
 	})
 	defer mock2.Reset()
 
-	client, err := NewDbusClient()
 	client, err := NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		t.Errorf("NewDbusClient failed: %v", err)
@@ -682,7 +660,6 @@ func TestDownloadImageFail(t *testing.T) {
 	})
 	defer mock2.Reset()
 
-	client, err := NewDbusClient()
 	client, err := NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		t.Errorf("NewDbusClient failed: %v", err)
@@ -721,7 +698,6 @@ func TestInstallImageSuccess(t *testing.T) {
 	})
 	defer mock2.Reset()
 
-	client, err := NewDbusClient()
 	client, err := NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		t.Errorf("NewDbusClient failed: %v", err)
@@ -760,7 +736,6 @@ func TestInstallImageFail(t *testing.T) {
 	})
 	defer mock2.Reset()
 
-	client, err := NewDbusClient()
 	client, err := NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		t.Errorf("NewDbusClient failed: %v", err)
@@ -798,7 +773,6 @@ func TestListImagesSuccess(t *testing.T) {
 	})
 	defer mock2.Reset()
 
-	client, err := NewDbusClient()
 	client, err := NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		t.Errorf("NewDbusClient failed: %v", err)
@@ -829,7 +803,6 @@ func TestListImagesFailDBusError(t *testing.T) {
 	})
 	defer mock2.Reset()
 
-	client, err := NewDbusClient()
 	client, err := NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		t.Errorf("NewDbusClient failed: %v", err)
@@ -859,7 +832,6 @@ func TestListImagesFailWrongType(t *testing.T) {
 	})
 	defer mock2.Reset()
 
-	client, err := NewDbusClient()
 	client, err := NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		t.Errorf("NewDbusClient failed: %v", err)
@@ -895,7 +867,6 @@ func TestActivateImageSuccess(t *testing.T) {
 	})
 	defer mock2.Reset()
 
-	client, err := NewDbusClient()
 	client, err := NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		t.Errorf("NewDbusClient failed: %v", err)
@@ -934,7 +905,6 @@ func TestActivateImageFail(t *testing.T) {
 	})
 	defer mock2.Reset()
 
-	client, err := NewDbusClient()
 	client, err := NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		t.Errorf("NewDbusClient failed: %v", err)

--- a/sonic_service_client/dbus_client_test.go
+++ b/sonic_service_client/dbus_client_test.go
@@ -10,6 +10,7 @@ import (
 
 func TestNewDbusClient(t *testing.T) {
 	client, err := NewDbusClient()
+	client, err := NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		t.Errorf("NewDbusClient failed: %v", err)
 	}
@@ -20,6 +21,7 @@ func TestNewDbusClient(t *testing.T) {
 
 func TestCloseClient(t *testing.T) {
 	client, err := NewDbusClient()
+	client, err := NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		t.Errorf("NewDbusClient failed: %v", err)
 	}
@@ -31,6 +33,7 @@ func TestCloseClient(t *testing.T) {
 
 func TestCloseClientWithChannel(t *testing.T) {
 	client, err := NewDbusClient()
+	client, err := NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		t.Errorf("NewDbusClient failed: %v", err)
 	}
@@ -50,6 +53,7 @@ func TestCloseClientWithChannel(t *testing.T) {
 
 func TestSystemBusNegative(t *testing.T) {
 	client, err := NewDbusClient()
+	client, err := NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		t.Errorf("NewDbusClient failed: %v", err)
 	}
@@ -88,6 +92,7 @@ func TestGetFileStat(t *testing.T) {
 	defer mock2.Reset()
 
 	client, err := NewDbusClient()
+	client, err := NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		t.Errorf("NewDbusClient failed: %v", err)
 	}
@@ -126,6 +131,7 @@ func TestGetFileStatNegative(t *testing.T) {
 	defer mock2.Reset()
 
 	client, err := NewDbusClient()
+	client, err := NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		t.Errorf("NewDbusClient failed: %v", err)
 	}
@@ -133,90 +139,6 @@ func TestGetFileStatNegative(t *testing.T) {
 	_, err = client.GetFileStat("/invalid/path")
 	if err == nil {
 		t.Errorf("GetFileStat should fail")
-	}
-	if err.Error() != errMsg {
-		t.Errorf("Expected error message '%s' but got '%v'", errMsg, err)
-	}
-}
-
-func TestDownloadSuccess(t *testing.T) {
-	hostname := "host"
-	username := "user"
-	password := "pass"
-	remotePath := "/remote/file"
-	localPath := "/local/file"
-	protocol := "SFTP"
-
-	mock1 := gomonkey.ApplyFunc(dbus.SystemBus, func() (conn *dbus.Conn, err error) {
-		return &dbus.Conn{}, nil
-	})
-	defer mock1.Reset()
-
-	mock2 := gomonkey.ApplyMethod(reflect.TypeOf(&dbus.Object{}), "Go", func(obj *dbus.Object, method string, flags dbus.Flags, ch chan *dbus.Call, args ...interface{}) *dbus.Call {
-		if method != "org.SONiC.HostService.file.download" {
-			t.Errorf("Wrong method: %v", method)
-		}
-		if len(args) != 6 {
-			t.Errorf("Wrong number of arguments: %v", len(args))
-		}
-		if args[0] != hostname || args[1] != username || args[2] != password ||
-			args[3] != remotePath || args[4] != localPath || args[5] != protocol {
-			t.Errorf("Wrong arguments: %v", args)
-		}
-		ret := &dbus.Call{}
-		ret.Err = nil
-		ret.Body = make([]interface{}, 2)
-		ret.Body[0] = int32(0)
-		ch <- ret
-		return &dbus.Call{}
-	})
-	defer mock2.Reset()
-
-	client, err := NewDbusClient()
-	if err != nil {
-		t.Errorf("NewDbusClient failed: %v", err)
-	}
-	err = client.DownloadFile(hostname, username, password, remotePath, localPath, protocol)
-	if err != nil {
-		t.Errorf("Download should pass: %v", err)
-	}
-}
-
-func TestDownloadFail(t *testing.T) {
-	hostname := "host"
-	username := "user"
-	password := "pass"
-	remotePath := "/remote/file"
-	localPath := "/local/file"
-	protocol := "SFTP"
-	errMsg := "This is the mock error message"
-
-	mock1 := gomonkey.ApplyFunc(dbus.SystemBus, func() (conn *dbus.Conn, err error) {
-		return &dbus.Conn{}, nil
-	})
-	defer mock1.Reset()
-
-	mock2 := gomonkey.ApplyMethod(reflect.TypeOf(&dbus.Object{}), "Go", func(obj *dbus.Object, method string, flags dbus.Flags, ch chan *dbus.Call, args ...interface{}) *dbus.Call {
-		if method != "org.SONiC.HostService.file.download" {
-			t.Errorf("Wrong method: %v", method)
-		}
-		ret := &dbus.Call{}
-		ret.Err = nil
-		ret.Body = make([]interface{}, 2)
-		ret.Body[0] = int32(1)
-		ret.Body[1] = errMsg
-		ch <- ret
-		return &dbus.Call{}
-	})
-	defer mock2.Reset()
-
-	client, err := NewDbusClient()
-	if err != nil {
-		t.Errorf("NewDbusClient failed: %v", err)
-	}
-	err = client.DownloadFile(hostname, username, password, remotePath, localPath, protocol)
-	if err == nil {
-		t.Errorf("Download should fail")
 	}
 	if err.Error() != errMsg {
 		t.Errorf("Expected error message '%s' but got '%v'", errMsg, err)
@@ -242,6 +164,7 @@ func TestConfigReload(t *testing.T) {
 	defer mock2.Reset()
 
 	client, err := NewDbusClient()
+	client, err := NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		t.Errorf("NewDbusClient failed: %v", err)
 	}
@@ -272,6 +195,7 @@ func TestConfigReloadNegative(t *testing.T) {
 	defer mock2.Reset()
 
 	client, err := NewDbusClient()
+	client, err := NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		t.Errorf("NewDbusClient failed: %v", err)
 	}
@@ -298,6 +222,7 @@ func TestConfigReloadTimeout(t *testing.T) {
 	defer mock2.Reset()
 
 	client, err := NewDbusClient()
+	client, err := NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		t.Errorf("NewDbusClient failed: %v", err)
 	}
@@ -326,6 +251,7 @@ func TestConfigReplace(t *testing.T) {
 	defer mock2.Reset()
 
 	client, err := NewDbusClient()
+	client, err := NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		t.Errorf("NewDbusClient failed: %v", err)
 	}
@@ -356,6 +282,7 @@ func TestConfigReplaceNegative(t *testing.T) {
 	defer mock2.Reset()
 
 	client, err := NewDbusClient()
+	client, err := NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		t.Errorf("NewDbusClient failed: %v", err)
 	}
@@ -387,6 +314,7 @@ func TestConfigSave(t *testing.T) {
 	defer mock2.Reset()
 
 	client, err := NewDbusClient()
+	client, err := NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		t.Errorf("NewDbusClient failed: %v", err)
 	}
@@ -417,6 +345,7 @@ func TestConfigSaveNegative(t *testing.T) {
 	defer mock2.Reset()
 
 	client, err := NewDbusClient()
+	client, err := NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		t.Errorf("NewDbusClient failed: %v", err)
 	}
@@ -448,6 +377,7 @@ func TestApplyPatchYang(t *testing.T) {
 	defer mock2.Reset()
 
 	client, err := NewDbusClient()
+	client, err := NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		t.Errorf("NewDbusClient failed: %v", err)
 	}
@@ -478,6 +408,7 @@ func TestApplyPatchYangNegative(t *testing.T) {
 	defer mock2.Reset()
 
 	client, err := NewDbusClient()
+	client, err := NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		t.Errorf("NewDbusClient failed: %v", err)
 	}
@@ -509,6 +440,7 @@ func TestApplyPatchDb(t *testing.T) {
 	defer mock2.Reset()
 
 	client, err := NewDbusClient()
+	client, err := NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		t.Errorf("NewDbusClient failed: %v", err)
 	}
@@ -539,6 +471,7 @@ func TestApplyPatchDbNegative(t *testing.T) {
 	defer mock2.Reset()
 
 	client, err := NewDbusClient()
+	client, err := NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		t.Errorf("NewDbusClient failed: %v", err)
 	}
@@ -570,6 +503,7 @@ func TestCreateCheckPoint(t *testing.T) {
 	defer mock2.Reset()
 
 	client, err := NewDbusClient()
+	client, err := NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		t.Errorf("NewDbusClient failed: %v", err)
 	}
@@ -600,6 +534,7 @@ func TestCreateCheckPointNegative(t *testing.T) {
 	defer mock2.Reset()
 
 	client, err := NewDbusClient()
+	client, err := NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		t.Errorf("NewDbusClient failed: %v", err)
 	}
@@ -631,6 +566,7 @@ func TestDeleteCheckPoint(t *testing.T) {
 	defer mock2.Reset()
 
 	client, err := NewDbusClient()
+	client, err := NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		t.Errorf("NewDbusClient failed: %v", err)
 	}
@@ -661,6 +597,7 @@ func TestDeleteCheckPointNegative(t *testing.T) {
 	defer mock2.Reset()
 
 	client, err := NewDbusClient()
+	client, err := NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		t.Errorf("NewDbusClient failed: %v", err)
 	}
@@ -703,6 +640,7 @@ func TestDownloadImageSuccess(t *testing.T) {
 	defer mock2.Reset()
 
 	client, err := NewDbusClient()
+	client, err := NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		t.Errorf("NewDbusClient failed: %v", err)
 	}
@@ -745,6 +683,7 @@ func TestDownloadImageFail(t *testing.T) {
 	defer mock2.Reset()
 
 	client, err := NewDbusClient()
+	client, err := NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		t.Errorf("NewDbusClient failed: %v", err)
 	}
@@ -783,6 +722,7 @@ func TestInstallImageSuccess(t *testing.T) {
 	defer mock2.Reset()
 
 	client, err := NewDbusClient()
+	client, err := NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		t.Errorf("NewDbusClient failed: %v", err)
 	}
@@ -821,6 +761,7 @@ func TestInstallImageFail(t *testing.T) {
 	defer mock2.Reset()
 
 	client, err := NewDbusClient()
+	client, err := NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		t.Errorf("NewDbusClient failed: %v", err)
 	}
@@ -858,6 +799,7 @@ func TestListImagesSuccess(t *testing.T) {
 	defer mock2.Reset()
 
 	client, err := NewDbusClient()
+	client, err := NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		t.Errorf("NewDbusClient failed: %v", err)
 	}
@@ -888,6 +830,7 @@ func TestListImagesFailDBusError(t *testing.T) {
 	defer mock2.Reset()
 
 	client, err := NewDbusClient()
+	client, err := NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		t.Errorf("NewDbusClient failed: %v", err)
 	}
@@ -917,6 +860,7 @@ func TestListImagesFailWrongType(t *testing.T) {
 	defer mock2.Reset()
 
 	client, err := NewDbusClient()
+	client, err := NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		t.Errorf("NewDbusClient failed: %v", err)
 	}
@@ -952,6 +896,7 @@ func TestActivateImageSuccess(t *testing.T) {
 	defer mock2.Reset()
 
 	client, err := NewDbusClient()
+	client, err := NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		t.Errorf("NewDbusClient failed: %v", err)
 	}
@@ -990,6 +935,7 @@ func TestActivateImageFail(t *testing.T) {
 	defer mock2.Reset()
 
 	client, err := NewDbusClient()
+	client, err := NewDbusClient(&ssc.DbusCaller{})
 	if err != nil {
 		t.Errorf("NewDbusClient failed: %v", err)
 	}
@@ -1002,29 +948,24 @@ func TestActivateImageFail(t *testing.T) {
 	}
 }
 
-func TestLoadDockerImageSuccess(t *testing.T) {
-	imagePath := "/tmp/docker-image.tar"
+func TestFileRemove(t *testing.T) {
+	expectedResult := "File removed successfully"
 
-	// Mocking the DBus API to simulate a successful image load
+	// Mock the SystemBus
 	mock1 := gomonkey.ApplyFunc(dbus.SystemBus, func() (conn *dbus.Conn, err error) {
 		return &dbus.Conn{}, nil
 	})
 	defer mock1.Reset()
 
+	// Mock the Go method of dbus.Object
 	mock2 := gomonkey.ApplyMethod(reflect.TypeOf(&dbus.Object{}), "Go", func(obj *dbus.Object, method string, flags dbus.Flags, ch chan *dbus.Call, args ...interface{}) *dbus.Call {
-		if method != "org.SONiC.HostService.docker_service.load" {
+		if method != "org.SONiC.HostService.file.remove_file" {
 			t.Errorf("Wrong method: %v", method)
-		}
-		if len(args) != 1 {
-			t.Errorf("Wrong number of arguments: %v", len(args))
-		}
-		if args[0] != imagePath {
-			t.Errorf("Wrong image path: %v", args[0])
 		}
 		ret := &dbus.Call{}
 		ret.Err = nil
-		ret.Body = make([]interface{}, 2)
-		ret.Body[0] = int32(0) // Indicating success
+		ret.Body = make([]interface{}, 1)
+		ret.Body[0] = expectedResult
 		ch <- ret
 		return &dbus.Call{}
 	})
@@ -1035,37 +976,32 @@ func TestLoadDockerImageSuccess(t *testing.T) {
 		t.Errorf("NewDbusClient failed: %v", err)
 	}
 
-	err = client.LoadDockerImage(imagePath)
+	result, err := client.FileRemove("/etc/sonic/tempfile")
 	if err != nil {
-		t.Errorf("LoadDockerImage should pass: %v", err)
+		t.Errorf("FileRemove should pass: %v", err)
+	}
+	if result != expectedResult {
+		t.Errorf("Expected %s but got %s", expectedResult, result)
 	}
 }
 
-func TestLoadDockerImageFail(t *testing.T) {
-	imagePath := "/tmp/docker-image.tar"
-	errMsg := "This is the mock error message"
+func TestFileRemoveNegative(t *testing.T) {
+	errMsg := "mock file removal error"
 
-	// Mocking the DBus API to simulate a failure
+	// Mock the SystemBus
 	mock1 := gomonkey.ApplyFunc(dbus.SystemBus, func() (conn *dbus.Conn, err error) {
 		return &dbus.Conn{}, nil
 	})
 	defer mock1.Reset()
 
+	// Mock the Go method of dbus.Object
 	mock2 := gomonkey.ApplyMethod(reflect.TypeOf(&dbus.Object{}), "Go", func(obj *dbus.Object, method string, flags dbus.Flags, ch chan *dbus.Call, args ...interface{}) *dbus.Call {
-		if method != "org.SONiC.HostService.docker_service.load" {
+		if method != "org.SONiC.HostService.file.remove_file" {
 			t.Errorf("Wrong method: %v", method)
 		}
-		if len(args) != 1 {
-			t.Errorf("Wrong number of arguments: %v", len(args))
-		}
-		if args[0] != imagePath {
-			t.Errorf("Wrong image path: %v", args[0])
-		}
 		ret := &dbus.Call{}
-		ret.Err = nil
-		ret.Body = make([]interface{}, 2)
-		ret.Body[0] = int32(1) // Indicating failure
-		ret.Body[1] = errMsg
+		ret.Err = errors.New(errMsg)
+		ret.Body = nil
 		ch <- ret
 		return &dbus.Call{}
 	})
@@ -1076,80 +1012,11 @@ func TestLoadDockerImageFail(t *testing.T) {
 		t.Errorf("NewDbusClient failed: %v", err)
 	}
 
-	err = client.LoadDockerImage(imagePath)
+	_, err = client.FileRemove("/invalid/path")
 	if err == nil {
-		t.Errorf("LoadDockerImage should fail")
+		t.Errorf("FileRemove should fail")
 	}
 	if err.Error() != errMsg {
-		t.Errorf("Expected error message '%s' but got '%v'", errMsg, err)
-	}
-}
-
-func TestRemoveFileSuccess(t *testing.T) {
-	path := "/tmp/testfile"
-	mock1 := gomonkey.ApplyFunc(dbus.SystemBus, func() (conn *dbus.Conn, err error) {
-		return &dbus.Conn{}, nil
-	})
-	defer mock1.Reset()
-	mock2 := gomonkey.ApplyMethod(reflect.TypeOf(&dbus.Object{}), "Go", func(obj *dbus.Object, method string, flags dbus.Flags, ch chan *dbus.Call, args ...interface{}) *dbus.Call {
-		if method != "org.SONiC.HostService.file.remove" {
-			t.Errorf("Wrong method: %v", method)
-		}
-		if len(args) != 1 {
-			t.Errorf("Wrong number of arguments: %v", len(args))
-		}
-		if args[0] != path {
-			t.Errorf("Wrong path: %v", args[0])
-		}
-		ret := &dbus.Call{}
-		ret.Err = nil
-		ret.Body = make([]interface{}, 2)
-		ret.Body[0] = int32(0)
-		ch <- ret
-		return &dbus.Call{}
-	})
-	defer mock2.Reset()
-
-	client, err := NewDbusClient()
-	if err != nil {
-		t.Errorf("NewDbusClient failed: %v", err)
-	}
-	err = client.RemoveFile(path)
-	if err != nil {
-		t.Errorf("RemoveFile should pass: %v", err)
-	}
-}
-
-func TestRemoveFileFail(t *testing.T) {
-	path := "/tmp/testfile"
-	errMsg := "This is the mock error message"
-	mock1 := gomonkey.ApplyFunc(dbus.SystemBus, func() (conn *dbus.Conn, err error) {
-		return &dbus.Conn{}, nil
-	})
-	defer mock1.Reset()
-	mock2 := gomonkey.ApplyMethod(reflect.TypeOf(&dbus.Object{}), "Go", func(obj *dbus.Object, method string, flags dbus.Flags, ch chan *dbus.Call, args ...interface{}) *dbus.Call {
-		if method != "org.SONiC.HostService.file.remove" {
-			t.Errorf("Wrong method: %v", method)
-		}
-		ret := &dbus.Call{}
-		ret.Err = nil
-		ret.Body = make([]interface{}, 2)
-		ret.Body[0] = int32(1)
-		ret.Body[1] = errMsg
-		ch <- ret
-		return &dbus.Call{}
-	})
-	defer mock2.Reset()
-
-	client, err := NewDbusClient()
-	if err != nil {
-		t.Errorf("NewDbusClient failed: %v", err)
-	}
-	err = client.RemoveFile(path)
-	if err == nil {
-		t.Errorf("RemoveFile should fail")
-	}
-	if err.Error() != errMsg {
-		t.Errorf("Expected error message '%s' but got '%v'", errMsg, err)
+		t.Errorf("Expected error '%s', but got '%v'", errMsg, err)
 	}
 }


### PR DESCRIPTION
Added support for GNOI File service.

**CLI Testing Results on Virtual Switch:**
**Stat RPC:**
```
admin@sonic:~$  docker exec gnmi gnoi_client -target 127.0.0.1:8080 -logtostderr -notls -module File -rpc Stat -jsonin '{ "path": "/etc/hostname" }'
File Stat
{"stats":[{"path":"/etc/hostname","last_modified":1746630200904000000,"permissions":420,"size":6,"umask":18}]}
admin@sonic:~$ 
```

**Get RPC:**
```
admin@sonic:~$ docker exec gnmi gnoi_client -target 127.0.0.1:8080 -logtostderr -notls -module File -rpc Get -jsonin '{ "remote_file": "/etc/sonic/config_db.json" }'
File Get
panic: rpc error: code = Unimplemented desc = Method file.Get is unimplemented.

goroutine 1 [running]:
github.com/sonic-net/sonic-gnmi/gnoi_client/file.Get(0xc000174400, {0xb315b8, 0xc000079bc0?})
	/sonic/src/sonic-gnmi/gnoi_client/file/file.go:52 +0x354
main.main()
	/sonic/src/sonic-gnmi/gnoi_client/gnoi_client.go:56 +0x225
admin@sonic:~$ 
```

**Put RPC:**
```
admin@sonic:~$ docker exec gnmi gnoi_client -target 127.0.0.1:8080 -logtostderr -notls -module File -rpc Put -jsonin '{ "open": { "remote_file": "/etc/config.txt", "permissions": 420 } }'
File Put
panic: rpc error: code = Unimplemented desc = Method file.Put is unimplemented.

goroutine 1 [running]:
github.com/sonic-net/sonic-gnmi/gnoi_client/file.Put(0xc000172400, {0xb315b8, 0xc000079bc0})
	/sonic/src/sonic-gnmi/gnoi_client/file/file.go:90 +0x294
main.main()
	/sonic/src/sonic-gnmi/gnoi_client/gnoi_client.go:58 +0x24e
admin@sonic:~$
```

**TransferToRemote RPC:**
```
admin@sonic:~$ docker exec gnmi gnoi_client -target 127.0.0.1:8080 -logtostderr -notls -module File -rpc TransferToRemote -jsonin '{
>   "local_path": "/etc/config.txt",
>   "remote_download": {
>     "protocol": 1,
>     "remote_url": "scp://user@remotehost:/path/to/destination",
>     "username": "user",
>     "password": "password"
>   }
> }'
File TransferToRemote
panic: rpc error: code = Unimplemented desc = Method file.TransferToRemote is unimplemented.

goroutine 1 [running]:
github.com/sonic-net/sonic-gnmi/gnoi_client/file.TransferToRemote(0xc000174400, {0xb315b8, 0xc000079bc0})
	/sonic/src/sonic-gnmi/gnoi_client/file/file.go:136 +0x254
main.main()
	/sonic/src/sonic-gnmi/gnoi_client/gnoi_client.go:62 +0x2f9
admin@sonic:~$ 
```

**Remove RPC:**
```
admin@sonic:~$ docker exec gnmi gnoi_client -target 127.0.0.1:8080 -logtostderr -notls -module File -rpc Remove -jsonin '{ "remote_file": "/etc/sonic/config_db.json" }'
File Remove
panic: rpc error: code = Unknown desc = Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/dbus/service.py", line 659, in _message_cb
    (candidate_method, parent_method) = _method_lookup(self, method_name, interface_name)
                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/dbus/service.py", line 249, in _method_lookup
    raise UnknownMethodException('%s is not a valid method of interface %s' % (method_name, dbus_interface))
dbus.exceptions.UnknownMethodException: org.freedesktop.DBus.Error.UnknownMethod: Unknown method: remove_file is not a valid method of interface org.SONiC.HostService.file

goroutine 1 [running]:
github.com/sonic-net/sonic-gnmi/gnoi_client/file.Remove(0xc000174400, {0xb315b8, 0xc000081bc0})
	/sonic/src/sonic-gnmi/gnoi_client/file/file.go:113 +0x254
main.main()
	/sonic/src/sonic-gnmi/gnoi_client/gnoi_client.go:60 +0x2ad
admin@sonic:~$
```

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

