### PR TITLE
Update agent-pool to use ubuntu 22.04

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,7 +47,7 @@ stages:
     timeoutInMinutes: 60
 
     pool:
-      vmImage: ubuntu-20.04
+      vmImage: ubuntu-22.04
 
     variables:
       DIFF_COVER_CHECK_THRESHOLD: 80


### PR DESCRIPTION
Update agent-pool to 22.04 since 20.04 is no longer available.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Ubuntu 20.04 agent is no longer available.

#### How I did it
Update agent-pool to use ubuntu 22.04

#### How to verify it
See azure-pipeline runs.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

