### PR TITLE
[gNOI] Add support for gNOI Factory Reset

### DIFF
--- a/common_utils/context.go
+++ b/common_utils/context.go
@@ -43,6 +43,7 @@ const (
 	GNMI_SET
 	GNMI_SET_FAIL
 	GNOI_REBOOT
+	GNOI_FACTORY_RESET
 	DBUS
 	DBUS_FAIL
 	DBUS_APPLY_PATCH_DB
@@ -77,6 +78,8 @@ func (c CounterType) String() string {
 		return "GNMI set fail"
 	case GNOI_REBOOT:
 		return "GNOI reboot"
+	case GNOI_FACTORY_RESET:
+		return "GNOI Factory Reset"
 	case DBUS:
 		return "DBUS"
 	case DBUS_FAIL:

--- a/gnmi_server/gnoi_reset.go
+++ b/gnmi_server/gnoi_reset.go
@@ -1,0 +1,46 @@
+package gnmi
+
+import (
+	"context"
+	"fmt"
+
+	log "github.com/golang/glog"
+	"github.com/openconfig/gnoi/factory_reset"
+	ssc "github.com/sonic-net/sonic-gnmi/sonic_service_client"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	json "google.golang.org/protobuf/encoding/protojson"
+)
+
+// Start implements the corresponding RPC.
+func (srv *Server) Start(ctx context.Context, req *factory_reset.StartRequest) (*factory_reset.StartResponse, error) {
+	ctx, err := authenticate(srv.config, ctx, "gnoi", false)
+	if err != nil {
+		return nil, err
+	}
+	log.V(1).Info("gNOI: factory_reset.Start")
+
+	// Front end marshals the request, and sends to the sonic-host-service.
+	// Back end is expected to return the response in JSON format.
+	reqStr, err := json.Marshal(req)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, fmt.Sprintf("Cannot marshal the StartRequest: [%s], err %v", req.String(), err))
+	}
+
+	sc, err := ssc.NewDbusClient()
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, fmt.Sprintf("Error creating dbus client: [%s]", err.Error()))
+	}
+
+	respStr, err := sc.FactoryReset(string(reqStr))
+	log.V(1).Infof("gNOI: factory_reset.Start Response %s", respStr)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, fmt.Sprintf("Backend error: %v", err))
+	}
+
+	resp := &factory_reset.StartResponse{}
+	if err := json.Unmarshal([]byte(respStr), resp); err != nil {
+		return nil, status.Errorf(codes.Internal, fmt.Sprintf("Cannot unmarshal backend response: [%s], error: %v", respStr, err))
+	}
+	return resp, nil
+}

--- a/gnmi_server/gnoi_reset_test.go
+++ b/gnmi_server/gnoi_reset_test.go
@@ -1,0 +1,82 @@
+package gnmi
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+	reset_pb "github.com/openconfig/gnoi/factory_reset"
+	ssc "github.com/sonic-net/sonic-gnmi/sonic_service_client"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	factoryResetSuccess string = `{"reset_success": {}}`
+	factoryResetFail    string = `{"reset_error": {"other": true, "detail": "Previous reset is ongoing."}}`
+)
+
+func TestGnoiResetServer(t *testing.T) {
+	s := createServer(t, 8081)
+	go runServer(t, s)
+	defer s.Stop()
+
+	tlsConfig := &tls.Config{InsecureSkipVerify: true}
+	opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
+	targetAddr := "127.0.0.1:8081"
+	conn, err := grpc.Dial(targetAddr, opts...)
+	if err != nil {
+		t.Fatalf("Dialing to %s failed: %v", targetAddr, err)
+	}
+	defer conn.Close()
+	c := reset_pb.NewFactoryResetClient(conn)
+
+	t.Run("Successful Reset", func(t *testing.T) {
+		patch1 := gomonkey.ApplyFuncReturn(ssc.NewDbusClient, &ssc.DbusClient{}, nil)
+		patch2 := gomonkey.ApplyFuncReturn(ssc.DbusApi, factoryResetSuccess, nil)
+		defer patch1.Reset()
+		defer patch2.Reset()
+
+		resp, err := c.Start(context.Background(), &reset_pb.StartRequest{})
+		if err != nil {
+			t.Fatalf("Unexpected error %v", err)
+		}
+		if _, ok := resp.GetResponse().(*reset_pb.StartResponse_ResetSuccess); !ok {
+			t.Fatalf("Expected ResetSuccess but got %#v", resp.Response)
+		}
+	})
+
+	t.Run("Unsuccessful Reset, DBUS Client Error", func(t *testing.T) {
+		patch := gomonkey.ApplyFuncReturn(ssc.NewDbusClient, nil, fmt.Errorf("client error"))
+		defer patch.Reset()
+
+		_, err := c.Start(context.Background(), &reset_pb.StartRequest{})
+		if err == nil {
+			t.Fatalf("Expected error but got success")
+		}
+		if status.Code(err) != codes.Internal {
+			t.Fatalf("Expected Internal error but got %#v (%#v)", status.Code(err), err)
+		}
+	})
+
+	t.Run("Unsuccessful Reset, DBUS Error", func(t *testing.T) {
+		patch1 := gomonkey.ApplyFuncReturn(ssc.NewDbusClient, &ssc.DbusClient{}, nil)
+		patch2 := gomonkey.ApplyFuncReturn(ssc.DbusApi, factoryResetFail, nil)
+		defer patch1.Reset()
+		defer patch2.Reset()
+
+		resp, err := c.Start(context.Background(), &reset_pb.StartRequest{})
+		if err != nil {
+			t.Fatalf("Unexpected error %v", err)
+		}
+		if _, ok := resp.GetResponse().(*reset_pb.StartResponse_ResetError); !ok {
+			t.Fatalf("Expected ResetError but got %#v", resp.Response)
+		}
+	})
+
+}

--- a/gnmi_server/server.go
+++ b/gnmi_server/server.go
@@ -22,9 +22,9 @@ import (
 	gnmipb "github.com/openconfig/gnmi/proto/gnmi"
 	gnmi_extpb "github.com/openconfig/gnmi/proto/gnmi_ext"
 	gnoi_containerz_pb "github.com/openconfig/gnoi/containerz"
+	"github.com/openconfig/gnoi/factory_reset"
 	gnoi_system_pb "github.com/openconfig/gnoi/system"
 
-	//gnoi_yang "github.com/sonic-net/sonic-gnmi/build/gnoi_yang/server"
 	gnoi_file_pb "github.com/openconfig/gnoi/file"
 	gnoi_os_pb "github.com/openconfig/gnoi/os"
 	"golang.org/x/net/context"
@@ -57,6 +57,7 @@ type Server struct {
 	ReqFromMaster func(req *gnmipb.SetRequest, masterEID *uint128) error
 	masterEID     uint128
 	gnoi_system_pb.UnimplementedSystemServer
+	factory_reset.UnimplementedFactoryResetServer
 }
 
 // FileServer is the server API for File service.
@@ -205,6 +206,7 @@ func NewServer(config *Config, opts []grpc.ServerOption) (*Server, error) {
 		return nil, fmt.Errorf("failed to open listener port %d: %v", srv.config.Port, err)
 	}
 	gnmipb.RegisterGNMIServer(srv.s, srv)
+	factory_reset.RegisterFactoryResetServer(srv.s, srv)
 	spb_jwt_gnoi.RegisterSonicJwtServiceServer(srv.s, srv)
 	if srv.config.EnableTranslibWrite || srv.config.EnableNativeWrite {
 		gnoi_system_pb.RegisterSystemServer(srv.s, srv)

--- a/gnoi_client/factory_reset/factory_reset.go
+++ b/gnoi_client/factory_reset/factory_reset.go
@@ -1,0 +1,36 @@
+package factory_reset
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	syspb "github.com/openconfig/gnoi/factory_reset"
+	"github.com/sonic-net/sonic-gnmi/gnoi_client/config"
+	"github.com/sonic-net/sonic-gnmi/gnoi_client/utils"
+)
+
+func StartFactoryReset(sc syspb.FactoryResetClient, ctx context.Context) {
+	fmt.Println("Start Factory Reset.")
+	ctx = utils.SetUserCreds(ctx)
+	if *config.Args == "" {
+		panic("--jsonin must be set.")
+	}
+
+	req := &syspb.StartRequest{}
+	if err := json.Unmarshal([]byte(*config.Args), req); err != nil {
+		fmt.Println("Unable to parse JSON input: ", err)
+		panic("Unable to parse JSON input.")
+	}
+
+	resp, err := sc.Start(ctx, req)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	respstr, err := json.Marshal(resp)
+	if err != nil {
+		panic(err.Error())
+	}
+	fmt.Println(string(respstr))
+}

--- a/gnoi_client/gnoi_client.go
+++ b/gnoi_client/gnoi_client.go
@@ -6,8 +6,10 @@ import (
 	"os/signal"
 
 	"github.com/google/gnxi/utils/credentials"
+	factory_reset_pb "github.com/openconfig/gnoi/factory_reset"
 	"github.com/sonic-net/sonic-gnmi/gnoi_client/config"
 	"github.com/sonic-net/sonic-gnmi/gnoi_client/containerz"
+	"github.com/sonic-net/sonic-gnmi/gnoi_client/factory_reset"
 	"github.com/sonic-net/sonic-gnmi/gnoi_client/file"
 	gnoi_os "github.com/sonic-net/sonic-gnmi/gnoi_client/os" // So it does not collide with os.
 	"github.com/sonic-net/sonic-gnmi/gnoi_client/sonic"
@@ -70,6 +72,14 @@ func main() {
 			gnoi_os.Verify(conn, ctx)
 		case "Activate":
 			gnoi_os.Activate(conn, ctx)
+		default:
+			panic("Invalid RPC Name")
+		}
+	case "FactoryReset":
+		frc := factory_reset_pb.NewFactoryResetClient(conn)
+		switch *config.Rpc {
+		case "Start":
+			factory_reset.StartFactoryReset(frc, ctx)
 		default:
 			panic("Invalid RPC Name")
 		}

--- a/sonic_service_client/dbus_client.go
+++ b/sonic_service_client/dbus_client.go
@@ -33,6 +33,7 @@ type Service interface {
 	InstallImage(where string) error
 	ListImages() (string, error)
 	ActivateImage(image string) error
+	FactoryReset(cmd string) (string, error)
 	// Docker services APIs
 	LoadDockerImage(image string) error
 }
@@ -304,4 +305,24 @@ func (c *DbusClient) LoadDockerImage(image string) error {
 	intName := c.intNamePrefix + modName + ".load"
 	_, err := DbusApi(busName, busPath, intName /*timeout=*/, 180, image)
 	return err
+}
+
+func (c *DbusClient) FactoryReset(cmd string) (string, error) {
+	modName := "gnoi_reset"
+	busName := c.busNamePrefix + modName
+	busPath := c.busPathPrefix + modName
+	intName := c.intNamePrefix + modName + ".issue_reset"
+
+	common_utils.IncCounter(common_utils.GNOI_FACTORY_RESET)
+	result, err := DbusApi(busName, busPath, intName, 10, cmd)
+	if err != nil {
+		return "", err
+	}
+
+	strResult, ok := result.(string)
+	if !ok {
+		return "", fmt.Errorf("Invalid result type %v: expected string, got %T", reflect.TypeOf(result), result)
+	}
+
+	return strResult, nil
 }

--- a/sonic_service_client/dbus_fake_client.go
+++ b/sonic_service_client/dbus_fake_client.go
@@ -33,6 +33,12 @@ func (f *FakeClient) InstallImage(where string) error                { return ni
 func (f *FakeClient) ListImages() (string, error)                    { return "image1", nil }
 func (f *FakeClient) ActivateImage(image string) error               { return nil }
 func (f *FakeClient) LoadDockerImage(image string) error             { return nil }
+func (f *FakeClient) FactoryReset(cmd string) (string, error) {
+	if cmd == "" {
+		return "", errors.New("Previous reset is ongoing")
+	}
+	return cmd, nil
+}
 
 // FakeClientWithError simulates failure in specific methods.
 type FakeClientWithError struct {

--- a/sonic_service_client/dbus_fake_client_test.go
+++ b/sonic_service_client/dbus_fake_client_test.go
@@ -33,4 +33,13 @@ func TestFakeClientMethods(t *testing.T) {
 	assert.Equal(t, "image1", img)
 	assert.NoError(t, client.ActivateImage("image1"))
 	assert.NoError(t, client.LoadDockerImage("docker-image"))
+
+	output, err := client.FactoryReset("REBOOT")
+	assert.NoError(t, err)
+	assert.Equal(t, "REBOOT", output)
+
+	output, err = client.FactoryReset("")
+	assert.Error(t, err)
+	assert.Equal(t, "", output)
+	assert.Equal(t, "Previous reset is ongoing", err.Error())
 }


### PR DESCRIPTION
#### Dependent sonic-host-services PR: https://github.com/sonic-net/sonic-host-services/pull/254



#### Manual CLI Testing Results for Factory Reset's Start RPC

#### factory_os:
``` 
"admin@sonic:~$ docker exec gnmi gnoi_client -target 127.0.0.1:8080 -notls -module FactoryReset -rpc Start -jsonin '{""factoryOs"": true}'
Start Factory Reset.
{"Response":{"ResetError":{"detail":"Method FactoryReset.Start is unimplemented."}}}
```
```
"admin@sonic:~$ docker exec gnmi gnoi_client -target 127.0.0.1:8080 -notls -module FactoryReset -rpc Start -jsonin '{""factoryOs"": false}'
Start Factory Reset.
{"Response":{"ResetError":{"detail":"Method FactoryReset.Start is unimplemented."}}}
```

#### zero_fill:
```
"admin@sonic:~$ docker exec gnmi gnoi_client -target 127.0.0.1:8080 -notls -module FactoryReset -rpc Start -jsonin '{""factory_os"": true, ""zero_fill"": true}'
Start Factory Reset.
{""Response"":{""ResetError"":{"detail":"zero_fill operation is currently unsupported."}}}"
```
```
"admin@sonic:~$ docker exec gnmi gnoi_client -target 127.0.0.1:8080 -notls -module FactoryReset -rpc Start -jsonin '{""factory_os"": true, ""zero_fill"": false}'
Start Factory Reset.
{"Response":{"ResetError":{"detail":"Method FactoryReset.Start is unimplemented."}}}
```
#### retainCerts:
```
"admin@sonic:~$ docker exec gnmi gnoi_client -target 127.0.0.1:8080 -notls -module FactoryReset -rpc Start -jsonin '{""factoryOs"": true, ""retainCerts"": true}'
Start Factory Reset.
{"Response":{"ResetError":{"detail":"Method FactoryReset.Start is unimplemented."}}}
```
```
"admin@sonic:~$ docker exec gnmi gnoi_client -target 127.0.0.1:8080 -notls -module FactoryReset -rpc Start -jsonin '{""factoryOs"": true, ""retainCerts"": false}'
Start Factory Reset.
{"Response":{"ResetError":{"detail":"Method FactoryReset.Start is unimplemented."}}}
```



<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

