### PR TITLE
Adding Activate & Verify RPC and Use transformer for TransferReady/ TransferEnd

### DIFF
--- a/gnmi_server/gnoi.go
+++ b/gnmi_server/gnoi.go
@@ -6,14 +6,12 @@ import (
 	jwt "github.com/dgrijalva/jwt-go"
 	log "github.com/golang/glog"
 	gnoi_file_pb "github.com/openconfig/gnoi/file"
-	gnoi_os_pb "github.com/openconfig/gnoi/os"
 	spb "github.com/sonic-net/sonic-gnmi/proto/gnoi"
 	spb_jwt "github.com/sonic-net/sonic-gnmi/proto/gnoi/jwt"
 	ssc "github.com/sonic-net/sonic-gnmi/sonic_service_client"
 	transutil "github.com/sonic-net/sonic-gnmi/transl_utils"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"os"
 	"os/user"
 	"strconv"
 	"strings"
@@ -94,98 +92,6 @@ func (srv *FileServer) Stat(ctx context.Context, req *gnoi_file_pb.StatRequest) 
 func (srv *FileServer) Get(req *gnoi_file_pb.GetRequest, stream gnoi_file_pb.File_GetServer) error {
 	log.V(1).Info("gNOI: File Get")
 	return status.Errorf(codes.Unimplemented, "")
-}
-
-func (srv *OSServer) Verify(ctx context.Context, req *gnoi_os_pb.VerifyRequest) (*gnoi_os_pb.VerifyResponse, error) {
-	_, err := authenticate(srv.config, ctx, "gnoi", false)
-	if err != nil {
-		log.V(2).Infof("Failed to authenticate: %v", err)
-		return nil, err
-	}
-
-	log.V(1).Info("gNOI: Verify")
-	dbus, err := ssc.NewDbusClient()
-	if err != nil {
-		log.V(2).Infof("Failed to create dbus client: %v", err)
-		return nil, err
-	}
-	defer dbus.Close()
-
-	image_json, err := dbus.ListImages()
-	if err != nil {
-		log.V(2).Infof("Failed to list images: %v", err)
-		return nil, err
-	}
-
-	images := make(map[string]interface{})
-	err = json.Unmarshal([]byte(image_json), &images)
-	if err != nil {
-		log.V(2).Infof("Failed to unmarshal images: %v", err)
-		return nil, err
-	}
-
-	current, exists := images["current"]
-	if !exists {
-		return nil, status.Errorf(codes.Internal, "Key 'current' not found in images")
-	}
-	current_image, ok := current.(string)
-	if !ok {
-		return nil, status.Errorf(codes.Internal, "Failed to assert current image as string")
-	}
-	resp := &gnoi_os_pb.VerifyResponse{
-		Version: current_image,
-	}
-	return resp, nil
-}
-
-func (srv *OSServer) Activate(ctx context.Context, req *gnoi_os_pb.ActivateRequest) (*gnoi_os_pb.ActivateResponse, error) {
-	_, err := authenticate(srv.config, ctx, "gnoi" /*writeAccess=*/, true)
-	if err != nil {
-		log.Errorf("Failed to authenticate: %v", err)
-		return nil, err
-	}
-
-	log.Infof("gNOI: Activate")
-	image := req.GetVersion()
-	log.Infof("Requested to activate image %s", image)
-
-	dbus, err := ssc.NewDbusClient()
-	if err != nil {
-		log.Errorf("Failed to create dbus client: %v", err)
-		return nil, err
-	}
-	defer dbus.Close()
-
-	var resp gnoi_os_pb.ActivateResponse
-	err = dbus.ActivateImage(image)
-	if err != nil {
-		log.Errorf("Failed to activate image %s: %v", image, err)
-		image_not_exists := os.IsNotExist(err) ||
-			(strings.Contains(strings.ToLower(err.Error()), "not") &&
-				strings.Contains(strings.ToLower(err.Error()), "exist"))
-		if image_not_exists {
-			// Image does not exist.
-			resp.Response = &gnoi_os_pb.ActivateResponse_ActivateError{
-				ActivateError: &gnoi_os_pb.ActivateError{
-					Type:   gnoi_os_pb.ActivateError_NON_EXISTENT_VERSION,
-					Detail: err.Error(),
-				},
-			}
-		} else {
-			// Other error.
-			resp.Response = &gnoi_os_pb.ActivateResponse_ActivateError{
-				ActivateError: &gnoi_os_pb.ActivateError{
-					Type:   gnoi_os_pb.ActivateError_UNSPECIFIED,
-					Detail: err.Error(),
-				},
-			}
-		}
-		return &resp, nil
-	}
-
-	log.Infof("Successfully activated image %s", image)
-	resp.Response = &gnoi_os_pb.ActivateResponse_ActivateOk{}
-	return &resp, nil
 }
 
 func (srv *Server) Authenticate(ctx context.Context, req *spb_jwt.AuthenticateRequest) (*spb_jwt.AuthenticateResponse, error) {

--- a/gnmi_server/gnoi_os.go
+++ b/gnmi_server/gnoi_os.go
@@ -1,0 +1,212 @@
+package gnmi
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sync"
+
+	ospb "github.com/openconfig/gnoi/os"
+
+	log "github.com/golang/glog"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+var (
+	sem             sync.Mutex
+	imgTrfInitiated = false
+)
+
+func (srv *OSServer) processTransferReq(trfReq *ospb.TransferRequest) *ospb.InstallResponse {
+	if trfReq.GetVersion() == "" {
+		log.Errorln("TransferRequest must contain a valid OS version.")
+		return &ospb.InstallResponse{
+			Response: &ospb.InstallResponse_InstallError{
+				InstallError: &ospb.InstallError{
+					Type:   ospb.InstallError_PARSE_FAIL,
+					Detail: "TransferRequest must contain a valid OS version.",
+				},
+			},
+		}
+	}
+
+	return &ospb.InstallResponse{
+		Response: &ospb.InstallResponse_TransferReady{},
+	}
+}
+
+func (srv *OSServer) processTransferEnd(trfReq *ospb.TransferEnd) *ospb.InstallResponse {
+	return &ospb.InstallResponse{
+		Response: &ospb.InstallResponse_Validated{},
+	}
+}
+
+func (srv *OSServer) processTransferContent(trfCnt []byte, imgPath string) *ospb.InstallResponse {
+	// If image exists, target should have sent Validated | InstallError on TransferRequest.
+	if !imgTrfInitiated && srv.imageExists(imgPath) {
+		return &ospb.InstallResponse{
+			Response: &ospb.InstallResponse_InstallError{
+				InstallError: &ospb.InstallError{
+					Detail: fmt.Sprintf("File exists [%s]!", imgPath),
+				},
+			},
+		}
+	}
+	imgTrfInitiated = true
+
+	errResp := &ospb.InstallResponse{
+		Response: &ospb.InstallResponse_InstallError{
+			InstallError: &ospb.InstallError{
+				Detail: fmt.Sprintf("Failed to open file [%s].", imgPath),
+			},
+		},
+	}
+
+	// If the file doesn't exist, create it, or append to the file
+	f, err := os.OpenFile(imgPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		log.Errorln(err)
+		return errResp
+	}
+	if _, err := f.Write(trfCnt); err != nil {
+		f.Close()
+		log.Errorln(err)
+		return errResp
+	}
+	if err := f.Close(); err != nil {
+		log.Errorln(err)
+		return errResp
+	}
+
+	return &ospb.InstallResponse{
+		Response: &ospb.InstallResponse_TransferProgress{},
+	}
+}
+
+func (srv *OSServer) getVersionPath(version string) string {
+	return srv.config.ImgDir + "/" + version
+}
+
+func (srv *OSServer) imageExists(path string) bool {
+	if _, err := os.Lstat(path); err == nil {
+		return true
+	}
+	return false
+}
+
+// Install implements correspondig RPC
+func (srv *OSServer) Install(stream ospb.OS_InstallServer) error {
+	ctx := stream.Context()
+	ctx, err := authenticate(srv.config, ctx, "gnoi", false)
+	if err != nil {
+		return err
+	}
+	log.V(1).Info("gNOI: os.Install")
+
+	defer func() {
+		imgTrfInitiated = false
+	}()
+
+	// Concurrent Install RPCs are not allowed.
+	if !sem.TryLock() {
+		log.Errorln("Concurrent Install RPCs are not allowed.")
+
+		// Send InstallError response.
+		err = stream.Send(&ospb.InstallResponse{
+			Response: &ospb.InstallResponse_InstallError{
+				InstallError: &ospb.InstallError{
+					Type:   ospb.InstallError_INSTALL_IN_PROGRESS,
+					Detail: "Concurrent Install RPCs are not allowed.",
+				},
+			},
+		})
+		if err != nil {
+			log.Errorln("Error while sending InstallError response: ", err)
+			return status.Errorf(codes.Aborted, err.Error())
+		}
+
+		return status.Errorf(codes.Aborted, "Concurrent Install RPCs are not allowed.")
+	}
+	defer sem.Unlock()
+
+	// Receive TransferReq message.
+	req, err := stream.Recv()
+	if err == io.EOF {
+		log.Errorln("Received EOF instead of TransferRequest!")
+		return nil
+	}
+	if err != nil {
+		log.Errorln("Received error: ", err)
+		return status.Errorf(codes.Aborted, err.Error())
+	}
+
+	trfReq := req.GetTransferRequest()
+	if trfReq == nil {
+		log.Errorln("Did not receive a TransferRequest.")
+		return status.Errorf(codes.InvalidArgument, "Expected TransferRequest.")
+	}
+
+	resp := srv.processTransferReq(trfReq)
+	if resp != nil {
+		if err := stream.Send(resp); err != nil {
+			log.Errorln("Error while sending response: ", err)
+			return status.Errorf(codes.Aborted, err.Error())
+		}
+	}
+	if resp == nil || resp.GetInstallError() != nil {
+		return status.Errorf(codes.Aborted, "Failed to process TransferRequest.")
+	}
+
+	imgPath := srv.getVersionPath(trfReq.GetVersion())
+	for {
+		req, err = stream.Recv()
+		if err == io.EOF {
+			log.Errorln("Received EOF instead of TransferContent request!")
+			return nil
+		}
+		if err != nil {
+			log.Errorln("Received error: ", err)
+			return status.Errorf(codes.Aborted, err.Error())
+		}
+		if trfReq := req.GetTransferRequest(); trfReq != nil {
+			log.Errorln("Received a TransferReq out-of-sequence.")
+			return status.Errorf(codes.InvalidArgument, "Expected TransferContent, or TransferEnd.")
+		}
+		// Transferring content is complete.
+		if trfEnd := req.GetTransferEnd(); trfEnd != nil {
+			break
+		}
+		// Process content transfer.
+		resp := srv.processTransferContent(req.GetTransferContent(), imgPath)
+		if resp != nil {
+			if err := stream.Send(resp); err != nil {
+				log.Errorln("Error while sending response: ", err)
+				return status.Errorf(codes.Aborted, err.Error())
+			}
+		}
+		if resp == nil || resp.GetInstallError() != nil {
+			return status.Errorf(codes.Aborted, "Failed to process TransferContent.")
+		}
+	}
+
+	// Receive TransferEnd message.
+	trfEnd := req.GetTransferEnd()
+	if trfEnd == nil {
+		log.Errorln("Did not receive a TransferEnd")
+		return status.Errorf(codes.InvalidArgument, "Expected TransferEnd")
+	}
+
+	resp = srv.processTransferEnd(trfEnd)
+	if resp != nil {
+		if err := stream.Send(resp); err != nil {
+			log.Errorln("Error while sending response: ", err)
+			return status.Errorf(codes.Aborted, err.Error())
+		}
+	}
+	if resp == nil || resp.GetInstallError() != nil {
+		return status.Errorf(codes.Aborted, "Failed to process TransferEnd.")
+	}
+
+	return nil
+}

--- a/gnmi_server/gnoi_os_test.go
+++ b/gnmi_server/gnoi_os_test.go
@@ -1,0 +1,395 @@
+package gnmi
+
+import (
+	"context"
+	"crypto/tls"
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	ospb "github.com/openconfig/gnoi/os"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+)
+
+var testOSCases = []struct {
+	desc string
+	f    func(ctx context.Context, t *testing.T, sc ospb.OSClient, s *OSServer)
+}{
+	{
+		desc: "OSActivateFailsAsBackEndIsUnimplemented",
+		f: func(ctx context.Context, t *testing.T, sc ospb.OSClient, s *OSServer) {
+			_, err := sc.Activate(ctx, &ospb.ActivateRequest{})
+			testErr(err, codes.Internal, "Internal SONiC HostService failure", t)
+		},
+	},
+	{
+		desc: "OSVerifyFailsAsBackEndIsUnimplemented",
+		f: func(ctx context.Context, t *testing.T, sc ospb.OSClient, s *OSServer) {
+			_, err := sc.Verify(ctx, &ospb.VerifyRequest{})
+			testErr(err, codes.Internal, "Internal SONiC HostService failure", t)
+		},
+	},
+	{
+		desc: "OSInstallFailsIfTransferRequestIsMissingVersion",
+		f: func(ctx context.Context, t *testing.T, sc ospb.OSClient, s *OSServer) {
+			stream, err := sc.Install(ctx, grpc.EmptyCallOption{})
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+
+			// Send TransferRequest.
+			err = stream.Send(&ospb.InstallRequest{
+				Request: &ospb.InstallRequest_TransferRequest{},
+			})
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+
+			// Receive InstallError due to missing version.
+			resp, err := stream.Recv()
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			instErr := resp.GetInstallError()
+			if instErr == nil {
+				t.Fatal("Expected InstallError!")
+			}
+			if instErr.GetType() != ospb.InstallError_PARSE_FAIL {
+				t.Fatal("Expected InstallError type: PARSE_FAIL!")
+			}
+			// Receive error reporting.
+			_, err = stream.Recv()
+			if err == nil {
+				t.Fatal("Expected error!")
+			}
+			testErr(err, codes.Aborted, "Failed to process TransferRequest.", t)
+		},
+	},
+	{
+		desc: "OSInstallFailsForConcurrentOperations",
+		f: func(ctx context.Context, t *testing.T, sc ospb.OSClient, s *OSServer) {
+			stream, err := sc.Install(ctx, grpc.EmptyCallOption{})
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+
+			// Send TransferRequest.
+			err = stream.Send(&ospb.InstallRequest{
+				Request: &ospb.InstallRequest_TransferRequest{
+					TransferRequest: &ospb.TransferRequest{
+						Version: "os1.1",
+					},
+				},
+			})
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+
+			// Receive TransferReady response.
+			resp, err := stream.Recv()
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			if resp.GetTransferReady() == nil {
+				t.Fatal("Did not receive expected TransferReady response")
+			}
+
+			// Create a new client.
+			tlsConfig := &tls.Config{InsecureSkipVerify: true}
+			opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
+			conn, err := grpc.Dial(targetAddr, opts...)
+			if err != nil {
+				t.Fatalf("Dialing to %s failed: %v", targetAddr, err)
+			}
+			defer conn.Close()
+
+			newsc := ospb.NewOSClient(conn)
+
+			newctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+			defer cancel()
+
+			newstream, err := newsc.Install(newctx, grpc.EmptyCallOption{})
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+
+			// Receive InstallError due to Install in progress.
+			resp, err = newstream.Recv()
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			instErr := resp.GetInstallError()
+			if instErr == nil {
+				t.Fatal("Expected InstallError!")
+			}
+			if instErr.GetType() != ospb.InstallError_INSTALL_IN_PROGRESS {
+				t.Fatal("Expected InstallError type: INSTALL_IN_PROGRESS!")
+			}
+
+			_, err = newstream.Recv()
+			if err == nil {
+				t.Fatal("Expected error!")
+			}
+			testErr(err, codes.Aborted, "Concurrent Install RPCs", t)
+
+			// Continue with the existing stream.
+			err = stream.Send(&ospb.InstallRequest{
+				Request: &ospb.InstallRequest_TransferEnd{},
+			})
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			// Receive Validated response.
+			resp, err = stream.Recv()
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			if resp.GetValidated() == nil {
+				t.Fatal("Did not receive expected Validated response.")
+			}
+		},
+	},
+	{
+		desc: "OSInstallFailsIfWrongMessageIsSent",
+		f: func(ctx context.Context, t *testing.T, sc ospb.OSClient, s *OSServer) {
+			stream, err := sc.Install(ctx, grpc.EmptyCallOption{})
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+
+			// Send TransferEnd; server expects TransferRequest.
+			err = stream.Send(&ospb.InstallRequest{
+				Request: &ospb.InstallRequest_TransferEnd{},
+			})
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+
+			// Receive error reporting.
+			_, err = stream.Recv()
+			if err == nil {
+				t.Fatal("Expected error!")
+			}
+			testErr(err, codes.InvalidArgument, "Expected TransferRequest", t)
+		},
+	},
+	{
+		desc: "OSInstallAbortedImmediately",
+		f: func(ctx context.Context, t *testing.T, sc ospb.OSClient, s *OSServer) {
+			stream, err := sc.Install(ctx, grpc.EmptyCallOption{})
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+
+			// Close the stream immediately.
+			stream.CloseSend()
+
+			// Receive error reporting premature closure of the stream.
+			_, err = stream.Recv()
+			if err == nil {
+				t.Fatal("Expected an error reporting on premature closure of the stream.")
+			}
+		},
+	},
+	{
+		desc: "OSInstallFailsIfImageExistsWhenTransferBegins",
+		f: func(ctx context.Context, t *testing.T, sc ospb.OSClient, s *OSServer) {
+			stream, err := sc.Install(ctx, grpc.EmptyCallOption{})
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+
+			// Send TransferRequest.
+			version := "os1.1"
+			err = stream.Send(&ospb.InstallRequest{
+				Request: &ospb.InstallRequest_TransferRequest{
+					TransferRequest: &ospb.TransferRequest{
+						Version: version,
+					},
+				},
+			})
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+
+			// Receive TransferReady response.
+			resp, err := stream.Recv()
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			if resp.GetTransferReady() == nil {
+				t.Fatal("Did not receive expected TransferReady response")
+			}
+
+			// TransferReady initiates transferring content. Image must not exist at this point!
+			imgPath := s.getVersionPath(version)
+			f, err := os.OpenFile(imgPath, os.O_CREATE|os.O_WRONLY, 0644)
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			if err := f.Close(); err != nil {
+				t.Fatal(err.Error())
+			}
+			// Cleanup
+			defer func() {
+				if err := os.Remove(imgPath); err != nil {
+					t.Errorf("Error while deleting temporary test file: %v\n", err)
+				}
+			}()
+
+			// Get some file to transfer. Repurpose cert data.
+			data, err := ioutil.ReadFile(GoldSCertV2)
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+
+			// Send TransferContent.
+			err = stream.Send(&ospb.InstallRequest{
+				Request: &ospb.InstallRequest_TransferContent{
+					TransferContent: data,
+				},
+			})
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+
+			// Receive InstallError.
+			resp, err = stream.Recv()
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			instErr := resp.GetInstallError()
+			if instErr == nil {
+				t.Fatal("Expected InstallError!")
+			}
+
+			// Receive error reporting.
+			_, err = stream.Recv()
+			if err == nil {
+				t.Fatal("Expected error!")
+			}
+		},
+	},
+	{
+		desc: "OSInstallSucceeds",
+		f: func(ctx context.Context, t *testing.T, sc ospb.OSClient, s *OSServer) {
+			stream, err := sc.Install(ctx, grpc.EmptyCallOption{})
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+
+			version := "os1.1"
+			// Send TransferRequest.
+			err = stream.Send(&ospb.InstallRequest{
+				Request: &ospb.InstallRequest_TransferRequest{
+					TransferRequest: &ospb.TransferRequest{
+						Version: version,
+					},
+				},
+			})
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+
+			// Receive TransferReady response.
+			resp, err := stream.Recv()
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			if trfReady := resp.GetTransferReady(); trfReady == nil {
+				t.Fatal("Did not receive expected TransferReady response")
+			}
+
+			// Get some file to transfer. Repurpose cert data.
+			data, err := ioutil.ReadFile(GoldSCertV2)
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+
+			// Send TransferContent.
+			err = stream.Send(&ospb.InstallRequest{
+				Request: &ospb.InstallRequest_TransferContent{
+					TransferContent: data,
+				},
+			})
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+
+			// Receive TransferProgress response.
+			resp, err = stream.Recv()
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			if trfProg := resp.GetTransferProgress(); trfProg == nil {
+				t.Fatal("Did not receive expected TransferProgress response")
+			}
+
+			// Send TransferEnd.
+			err = stream.Send(&ospb.InstallRequest{
+				Request: &ospb.InstallRequest_TransferEnd{},
+			})
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+
+			// Receive Validated response.
+			resp, err = stream.Recv()
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			if resp.GetValidated() == nil {
+				t.Fatal("Did not receive expected Validated response.")
+			}
+
+			// Sanity check!
+			imgPath := s.getVersionPath(version)
+			dataRead, err := ioutil.ReadFile(imgPath)
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			if string(data) != string(dataRead) {
+				t.Fatal("Content doesn't match!")
+			}
+
+			// Cleanup
+			if err = os.Remove(imgPath); err != nil {
+				t.Errorf("Error while deleting temporary test file: %v\n", err)
+			}
+		},
+	},
+}
+
+// TestOSServer tests implementation of gnoi.OS server.
+func TestOSServer(t *testing.T) {
+	s := createServer(t, port)
+	go runServer(t, s)
+	defer s.Stop(t)
+
+	tlsConfig := &tls.Config{InsecureSkipVerify: true}
+	opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
+	conn, err := grpc.Dial(targetAddr, opts...)
+	if err != nil {
+		t.Fatalf("Dialing to %s failed: %v", targetAddr, err)
+	}
+	defer conn.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	for _, test := range testOSCases {
+		t.Run(test.desc, func(t *testing.T) {
+			conn, err := grpc.Dial(targetAddr, opts...)
+			if err != nil {
+				t.Fatalf("Dialing to %s failed: %v", targetAddr, err)
+			}
+			defer conn.Close()
+
+			sc := ospb.NewOSClient(conn)
+			test.f(ctx, t, sc, &OSServer{Server: s})
+		})
+	}
+}

--- a/gnmi_server/server.go
+++ b/gnmi_server/server.go
@@ -97,6 +97,7 @@ type Config struct {
 	ConfigTableName     string
 	Vrf                 string
 	EnableCrl           bool
+	ImgDir              string // Path to the directory where image is stored.
 }
 
 var AuthLock sync.Mutex

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -132,7 +132,7 @@ func createServer(t *testing.T, port int64) *Server {
 	}
 
 	opts := []grpc.ServerOption{grpc.Creds(credentials.NewTLS(tlsCfg))}
-	cfg := &Config{Port: port, EnableTranslibWrite: true, EnableNativeWrite: true, Threshold: 100}
+	cfg := &Config{Port: port, EnableTranslibWrite: true, EnableNativeWrite: true, Threshold: 100, ImgDir: "/tmp"}
 	s, err := NewServer(cfg, opts)
 	if err != nil {
 		t.Errorf("Failed to create gNMI server: %v", err)

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -29,6 +29,11 @@ import (
 	"google.golang.org/grpc/keepalive"
 )
 
+var (
+	// Image directory.
+	imgDirPath = flag.String("img_dir", "/tmp", "Directory path where image will be transferred.")
+)
+
 type ServerControlValue int
 
 const (
@@ -229,7 +234,7 @@ func setupFlags(fs *flag.FlagSet) (*TelemetryConfig, *gnmi.Config, error) {
 	gnmi.JwtRefreshInt = time.Duration(*telemetryCfg.JwtRefInt * uint64(time.Second))
 	gnmi.JwtValidInt = time.Duration(*telemetryCfg.JwtValInt * uint64(time.Second))
 
-	cfg := &gnmi.Config{}
+	cfg := &gnmi.Config{ImgDir: *imgDirPath}
 	cfg.Port = int64(*telemetryCfg.Port)
 	cfg.EnableTranslibWrite = bool(*telemetryCfg.GnmiTranslibWrite)
 	cfg.EnableNativeWrite = bool(*telemetryCfg.GnmiNativeWrite)

--- a/testdata/TEST_OS_IMAGE.txt
+++ b/testdata/TEST_OS_IMAGE.txt
@@ -1,0 +1,1 @@
+Version: "os1.1"


### PR DESCRIPTION
Adding Activate & Verify RPC and Use transformer for TransferReady/ TransferEnd

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

