### PR TITLE
[gNOI] Added initial implementation of gNOI.OS Install RPC.

### DIFF
--- a/common_utils/context.go
+++ b/common_utils/context.go
@@ -44,6 +44,7 @@ const (
 	GNMI_SET_FAIL
 	GNOI_REBOOT
 	GNOI_FACTORY_RESET
+	GNOI_OS_INSTALL
 	DBUS
 	DBUS_FAIL
 	DBUS_APPLY_PATCH_DB
@@ -80,6 +81,8 @@ func (c CounterType) String() string {
 		return "GNOI reboot"
 	case GNOI_FACTORY_RESET:
 		return "GNOI Factory Reset"
+	case GNOI_OS_INSTALL:
+		return "GNOI OS Install"
 	case DBUS:
 		return "DBUS"
 	case DBUS_FAIL:

--- a/gnmi_server/gnoi_os.go
+++ b/gnmi_server/gnoi_os.go
@@ -1,0 +1,500 @@
+package gnmi
+
+import (
+	"context"
+	stdjson "encoding/json"
+	"fmt"
+	log "github.com/golang/glog"
+	ospb "github.com/openconfig/gnoi/os"
+	ssc "github.com/sonic-net/sonic-gnmi/sonic_service_client"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	json "google.golang.org/protobuf/encoding/protojson"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+var (
+	sem                sync.Mutex
+	totalBytesReceived = make(map[string]uint64)
+)
+
+// ProcessInstallFromBackEnd makes call via the sonic-host-service.
+func ProcessInstallFromBackEnd(req string) (string, error) {
+	log.Infof("ProcessInstallFromBackEnd: %v", req)
+	sc, err := ssc.NewDbusClient()
+	if err != nil {
+		return "", err
+	}
+	defer sc.Close()
+	return sc.InstallOS(req)
+}
+
+func (srv *OSServer) processTransferReq(req *ospb.InstallRequest) *ospb.InstallResponse {
+	log.Infof("processTransferReq: %v", req)
+	transferReq := req.GetTransferRequest()
+	if transferReq.GetVersion() == "" {
+		log.Errorf("processTransferReq: TransferRequest must contain a valid OS version.")
+		return &ospb.InstallResponse{
+			Response: &ospb.InstallResponse_InstallError{
+				InstallError: &ospb.InstallError{
+					Type:   ospb.InstallError_PARSE_FAIL,
+					Detail: "TransferRequest must contain a valid OS version.",
+				},
+			},
+		}
+	}
+	// Front end marshals the request, and sends to the sonic-host-service.
+	// Back end is expected to return the response in JSON format.
+	reqStr, err := json.Marshal(req)
+	if err != nil {
+		return &ospb.InstallResponse{
+			Response: &ospb.InstallResponse_InstallError{
+				InstallError: &ospb.InstallError{
+					Detail: fmt.Sprintf("Failed to marshal TransferReady JSON: err: %v, req: %v, reqStr: %v", err, req, reqStr),
+				},
+			},
+		}
+
+	}
+	respStr, err := srv.config.OSCfg.ProcessTransferReady(string(reqStr))
+	log.Infof("processTransferReq: Backend response %s", respStr)
+	if err != nil {
+		// Convert the generic error to a gRPC status object
+		st, ok := status.FromError(err)
+		if ok && st.Code() == codes.Unimplemented {
+			log.Errorf("processTransferReq: Backend returned OS unimplemented error.")
+			return nil // signal caller to return codes.Unimplemented
+		}
+		log.Errorf("processTransferReq: Error in processing install from backend")
+		// Fallback to returning a detailed InstallError for other types of errors
+		return &ospb.InstallResponse{
+			Response: &ospb.InstallResponse_InstallError{
+				InstallError: &ospb.InstallError{
+					Detail: fmt.Sprintf("Error in TransferReady response: err: %v, reqStr: %v, respStr: %v", err, reqStr, respStr),
+				},
+			},
+		}
+	}
+
+	resp := &ospb.InstallResponse{}
+	if err := json.Unmarshal([]byte(respStr), resp); err != nil {
+		return &ospb.InstallResponse{
+			Response: &ospb.InstallResponse_InstallError{
+				InstallError: &ospb.InstallError{
+					Detail: fmt.Sprintf("Failed to unmarshal TransferReady JSON: err: %v, respStr: %v", err, respStr),
+				},
+			},
+		}
+
+	}
+	log.Infof("processTransferReq: complete.")
+	return resp
+}
+func (srv *OSServer) processTransferEnd(req *ospb.InstallRequest) *ospb.InstallResponse {
+	// Front end marshals the request, and sends to the sonic-host-service.
+	// Back end is expected to return the response in JSON format.
+
+	log.Infof("processTransferEnd: %v", req)
+	reqStr, err := json.Marshal(req)
+	if err != nil {
+		log.Errorf("Failed to marshal TransferEnd JSON: err: %v, req: %v, reqStr: %v", err, req, reqStr)
+		return &ospb.InstallResponse{
+			Response: &ospb.InstallResponse_InstallError{
+				InstallError: &ospb.InstallError{
+					Detail: fmt.Sprintf("Failed to marshal TransferEnd JSON: err: %v, req: %v, reqStr: %v", err, req, reqStr),
+				},
+			},
+		}
+
+	}
+	respStr, err := srv.config.OSCfg.ProcessTransferEnd(string(reqStr))
+	log.Infof("processTransferEnd: Backend response %s", respStr)
+	if err != nil {
+		log.Errorf("Received error from OSServer.TransferEnd: err: %v, reqStr: %v, respStr: %v", err, reqStr, respStr)
+		return &ospb.InstallResponse{
+			Response: &ospb.InstallResponse_InstallError{
+				InstallError: &ospb.InstallError{
+					Detail: fmt.Sprintf("Error in TransferEnd response: err: %v, reqStr: %v, respStr: %v", err, reqStr, respStr),
+				},
+			},
+		}
+
+	}
+	resp := &ospb.InstallResponse{}
+	if err := json.Unmarshal([]byte(respStr), resp); err != nil {
+		return &ospb.InstallResponse{
+			Response: &ospb.InstallResponse_InstallError{
+				InstallError: &ospb.InstallError{
+					Detail: fmt.Sprintf("Failed to unmarshal TransferEnd JSON: err: %v, respStr: %v", err, respStr),
+				},
+			},
+		}
+
+	}
+	log.Infof("processTransferEnd: complete.")
+	return resp
+}
+
+func (srv *OSServer) processTransferContent(transferContent []byte, imgPath string) *ospb.InstallResponse {
+	log.Infof("processTransferContent: file %v", imgPath)
+
+	// Base directory where the images should reside (e.g., /tmp)
+	baseDir := srv.config.OSCfg.ImgDir
+
+	// Clean the user-provided imgPath to avoid directory traversal
+	cleanPath := filepath.Clean(imgPath) // Clean any ".." or other traversal patterns
+
+	// Ensure baseDir has a trailing slash for the HasPrefix check to work correctly.
+	if baseDir[len(baseDir)-1] != '/' {
+		baseDir += "/"
+	}
+
+	var safePath string
+
+	// If cleanPath is absolute (starts with /), use it directly
+	if filepath.IsAbs(cleanPath) {
+		safePath = cleanPath
+	} else {
+		// If it's not absolute, join it with baseDir
+		safePath = filepath.Join(baseDir, cleanPath)
+	}
+
+	// Validate that the safePath is still within the base directory (to avoid path traversal)
+	if !strings.HasPrefix(safePath, baseDir) {
+		log.Errorf("processTransferContent: Path traversal attempt detected: %s", imgPath)
+		return &ospb.InstallResponse{
+			Response: &ospb.InstallResponse_InstallError{
+				InstallError: &ospb.InstallError{
+					Detail: fmt.Sprintf("Invalid image path: %s", imgPath),
+				},
+			},
+		}
+	}
+
+	// Ensure the directory exists before writing the file
+	dir := filepath.Dir(safePath)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		log.Errorf("processTransferContent: Failed to create directory for file: %s, error: %v", dir, err)
+		return &ospb.InstallResponse{
+			Response: &ospb.InstallResponse_InstallError{
+				InstallError: &ospb.InstallError{
+					Detail: fmt.Sprintf("Failed to create directory for file [%s].", dir),
+				},
+			},
+		}
+	}
+
+	// Open the file for writing (create or append)
+	f, err := os.OpenFile(safePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		log.Errorf("processTransferContent: Failed to open or create file for writing: %s, error: %v", safePath, err)
+		return &ospb.InstallResponse{
+			Response: &ospb.InstallResponse_InstallError{
+				InstallError: &ospb.InstallError{
+					Detail: fmt.Sprintf("Failed to open file [%s].", safePath),
+				},
+			},
+		}
+	}
+
+	if _, err := f.Write(transferContent); err != nil {
+		f.Close()
+		log.Errorf("processTransferContent: Failed to write to file: %s, error: %v", safePath, err)
+		return &ospb.InstallResponse{
+			Response: &ospb.InstallResponse_InstallError{
+				InstallError: &ospb.InstallError{
+					Detail: fmt.Sprintf("Failed to write to file [%s].", safePath),
+				},
+			},
+		}
+	}
+
+	if err := f.Close(); err != nil {
+		log.Errorf("processTransferContent: Failed to close file after writing: %s, error: %v", safePath, err)
+		return &ospb.InstallResponse{
+			Response: &ospb.InstallResponse_InstallError{
+				InstallError: &ospb.InstallError{
+					Detail: fmt.Sprintf("Failed to close file after writing [%s].", safePath),
+				},
+			},
+		}
+	}
+
+	// Update progress (total bytes received)
+	totalBytesReceived[safePath] += uint64(len(transferContent))
+	log.Infof("processTransferContent: complete. Wrote %d bytes to %s", totalBytesReceived[safePath], safePath)
+	return &ospb.InstallResponse{
+		Response: &ospb.InstallResponse_TransferProgress{
+			TransferProgress: &ospb.TransferProgress{
+				BytesReceived: totalBytesReceived[safePath],
+			},
+		},
+	}
+}
+
+func (srv *OSServer) getVersionPath(version string) string {
+	return srv.config.OSCfg.ImgDir + "/" + version
+}
+
+func (srv *OSServer) imageExists(path string) bool {
+	if _, err := os.Lstat(path); err == nil {
+		return true
+	}
+	return false
+}
+
+func (srv *OSServer) removeIncompleteTransfer(imgPath string) {
+	if !srv.imageExists(imgPath) {
+		log.Errorf("Image not exist to removeIncompleteTransfer")
+		return
+	}
+	log.V(1).Infoln("Remove incomplete image: ", imgPath)
+	// Now remove the file.
+	if err := os.Remove(imgPath); err != nil {
+		log.Errorf("Failed to remove incomplete image: %v", err)
+	}
+}
+
+// Install implements correspondig RPC
+func (srv *OSServer) Install(stream ospb.OS_InstallServer) error {
+	ctx := stream.Context()
+	ctx, err := authenticate(srv.config, ctx, "gnoi", false)
+	if err != nil {
+		return err
+	}
+	log.V(1).Info("=== [OS Install Start] ===")
+
+	// Concurrent Install RPCs are not allowed.
+	if !sem.TryLock() {
+		log.V(1).Infoln("Concurrent Install RPCs are not allowed.")
+		// Send InstallError response.
+		err = stream.Send(&ospb.InstallResponse{
+			Response: &ospb.InstallResponse_InstallError{
+				InstallError: &ospb.InstallError{
+					Type:   ospb.InstallError_INSTALL_IN_PROGRESS,
+					Detail: "Concurrent Install RPCs are not allowed.",
+				},
+			},
+		})
+		if err != nil {
+			log.V(1).Infoln("Error while sending InstallError response: ", err)
+			log.Errorf("InstallResponse: %v", err)
+			return status.Errorf(codes.Aborted, err.Error())
+		}
+		return status.Errorf(codes.Aborted, "Concurrent Install RPCs are not allowed.")
+	}
+	defer sem.Unlock()
+
+	// Receive TransferReq message.
+	req, err := stream.Recv()
+	log.Infof("Install: Received TransferRequest version=%v", req.GetTransferRequest().GetVersion())
+	if err == io.EOF {
+		log.Errorf("Install: Received EOF while receiving TransferRequest!")
+		return nil
+	}
+	if err != nil {
+		log.Errorf("Install: Received error %v while receiving TransferRequest!", err)
+		return status.Errorf(codes.Aborted, err.Error())
+	}
+	transferReq := req.GetTransferRequest()
+	if transferReq == nil {
+		log.Errorf("Install: TransferRequest is nil")
+		err = status.Errorf(codes.InvalidArgument, "Expected TransferRequest.")
+		return err
+	}
+	resp := srv.processTransferReq(req)
+	log.Infof("Install: Response received %v", resp)
+
+	if resp == nil {
+		log.Errorf("Install: TransferReady not received. Returning OS Unimplemented (backend not supported)")
+		return status.Errorf(codes.Unimplemented, "OS Install not supported")
+	}
+
+	if resp != nil {
+		if err := stream.Send(resp); err != nil {
+			log.Errorf("Install: Error %v in sending TransferReady response:", err)
+			return status.Errorf(codes.Aborted, err.Error())
+		}
+	}
+
+	if resp == nil || resp.GetInstallError() != nil {
+		log.Infof("Install: Failed to process TransferRequest =%v", resp.GetInstallError())
+		err = status.Errorf(codes.Aborted, "Failed to process TransferRequest.")
+		return err
+	}
+
+	imgPath := srv.getVersionPath(transferReq.GetVersion())
+	imgTransferInitiated := false
+	defer func() {
+		if imgTransferInitiated {
+			srv.removeIncompleteTransfer(imgPath)
+		}
+	}()
+
+	for {
+		req, err = stream.Recv()
+		log.Infof("Install: Received TransferContent stream")
+		if err == io.EOF {
+			log.Errorf("Install: Received EOF instead of TransferContent request!")
+			return status.Errorf(codes.Aborted, "Stream closed prematurely during transfer.")
+		}
+		if err != nil {
+			log.Errorf("Install: Error %v in receiving TransferContent", err)
+			return status.Errorf(codes.Aborted, err.Error())
+		}
+		if transferReq := req.GetTransferRequest(); transferReq != nil {
+			log.Errorf("Install: Received a TransferReq out-of-sequence.")
+			err = status.Errorf(codes.InvalidArgument, "Expected TransferContent, or TransferEnd.")
+			return err
+		}
+		// Transferring content is complete.
+		if transferEnd := req.GetTransferEnd(); transferEnd != nil {
+			log.Infof("Install: TransferContent is complete.")
+			break
+		}
+		// Process content transfer.
+		// If image exists, target should have sent Validated | InstallError on TransferRequest.
+		if !imgTransferInitiated && srv.imageExists(imgPath) {
+			log.Errorf("Install: Image %v already exists. Aborting TransferContent.", imgPath)
+			return status.Errorf(codes.Aborted, "Image already exists: %s", imgPath)
+		}
+		imgTransferInitiated = true
+		resp := srv.processTransferContent(req.GetTransferContent(), imgPath)
+		log.Infof("Install: Response received %v", resp)
+		if resp != nil {
+			if err := stream.Send(resp); err != nil {
+				log.Errorf("Install: Error %v in sending TransferContent response", err)
+				srv.removeIncompleteTransfer(imgPath)
+				return status.Errorf(codes.Aborted, err.Error())
+			}
+		}
+		if resp == nil || resp.GetInstallError() != nil {
+			srv.removeIncompleteTransfer(imgPath)
+			err = status.Errorf(codes.Aborted, "Failed to process TransferContent.")
+			log.Errorf("Install: Failed to process TransferContent=%v", err)
+			return err
+		}
+	}
+	// Receive TransferEnd message.
+	transferEnd := req.GetTransferEnd()
+	if transferEnd == nil {
+		log.V(1).Infoln("Did not receive a TransferEnd")
+		srv.removeIncompleteTransfer(imgPath)
+		err = status.Errorf(codes.InvalidArgument, "Expected TransferEnd")
+		return err
+	}
+	log.Infof("Install: Received TransferEnd")
+	resp = srv.processTransferEnd(req)
+	log.Infof("Install: Response received %v", resp)
+	if resp != nil {
+		if err := stream.Send(resp); err != nil {
+			log.Errorf("Install: Error %v in sending TransferEnd response. Aborting..", err)
+			srv.removeIncompleteTransfer(imgPath)
+			return status.Errorf(codes.Aborted, err.Error())
+		}
+	}
+	if resp == nil || resp.GetInstallError() != nil {
+		srv.removeIncompleteTransfer(imgPath)
+		err = status.Errorf(codes.Aborted, "Failed to process TransferEnd.")
+		log.Errorf("Install: Failed to process TransferEnd=%v", resp.GetInstallError())
+		return err
+	}
+	log.V(1).Info("=== [OS Install Complete] ===")
+	return nil
+}
+
+func (srv *OSServer) Activate(ctx context.Context, req *ospb.ActivateRequest) (*ospb.ActivateResponse, error) {
+	_, err := authenticate(srv.config, ctx, "gnoi" /*writeAccess=*/, true)
+	if err != nil {
+		log.Errorf("Failed to authenticate: %v", err)
+		return nil, err
+	}
+
+	log.Infof("gNOI: Activate")
+	image := req.GetVersion()
+	log.Infof("Requested to activate image %s", image)
+
+	dbus, err := ssc.NewDbusClient()
+	if err != nil {
+		log.Errorf("Failed to create dbus client: %v", err)
+		return nil, err
+	}
+	defer dbus.Close()
+
+	var resp ospb.ActivateResponse
+	err = dbus.ActivateImage(image)
+	if err != nil {
+		log.Errorf("Failed to activate image %s: %v", image, err)
+		image_not_exists := os.IsNotExist(err) ||
+			(strings.Contains(strings.ToLower(err.Error()), "not") &&
+				strings.Contains(strings.ToLower(err.Error()), "exist"))
+		if image_not_exists {
+			// Image does not exist.
+			resp.Response = &ospb.ActivateResponse_ActivateError{
+				ActivateError: &ospb.ActivateError{
+					Type:   ospb.ActivateError_NON_EXISTENT_VERSION,
+					Detail: err.Error(),
+				},
+			}
+		} else {
+			// Other error.
+			resp.Response = &ospb.ActivateResponse_ActivateError{
+				ActivateError: &ospb.ActivateError{
+					Type:   ospb.ActivateError_UNSPECIFIED,
+					Detail: err.Error(),
+				},
+			}
+		}
+		return &resp, nil
+	}
+
+	log.Infof("Successfully activated image %s", image)
+	resp.Response = &ospb.ActivateResponse_ActivateOk{}
+	return &resp, nil
+}
+
+func (srv *OSServer) Verify(ctx context.Context, req *ospb.VerifyRequest) (*ospb.VerifyResponse, error) {
+	_, err := authenticate(srv.config, ctx, "gnoi", false)
+	if err != nil {
+		log.V(2).Infof("Failed to authenticate: %v", err)
+		return nil, err
+	}
+
+	log.V(1).Info("gNOI: Verify")
+	dbus, err := ssc.NewDbusClient()
+	if err != nil {
+		log.V(2).Infof("Failed to create dbus client: %v", err)
+		return nil, err
+	}
+	defer dbus.Close()
+
+	image_json, err := dbus.ListImages()
+	if err != nil {
+		log.V(2).Infof("Failed to list images: %v", err)
+		return nil, err
+	}
+
+	images := make(map[string]interface{})
+	err = stdjson.Unmarshal([]byte(image_json), &images)
+	if err != nil {
+		log.V(2).Infof("Failed to unmarshal images: %v", err)
+		return nil, err
+	}
+
+	current, exists := images["current"]
+	if !exists {
+		return nil, status.Errorf(codes.Internal, "Key 'current' not found in images")
+	}
+	current_image, ok := current.(string)
+	if !ok {
+		return nil, status.Errorf(codes.Internal, "Failed to assert current image as string")
+	}
+	resp := &ospb.VerifyResponse{
+		Version: current_image,
+	}
+	return resp, nil
+}

--- a/gnmi_server/gnoi_os_test.go
+++ b/gnmi_server/gnoi_os_test.go
@@ -1,0 +1,1035 @@
+package gnmi
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"github.com/agiledragon/gomonkey/v2"
+	log "github.com/golang/glog"
+	ospb "github.com/openconfig/gnoi/os"
+	ssc "github.com/sonic-net/sonic-gnmi/sonic_service_client"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/status"
+	json "google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"os"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+	"unsafe"
+)
+
+type fakeInstallServer struct {
+	ospb.OS_InstallServer
+	sendErr error
+	ctx     context.Context
+}
+
+func (f *fakeInstallServer) Send(*ospb.InstallResponse) error {
+	return f.sendErr
+}
+
+func (f *fakeInstallServer) Context() context.Context {
+	return f.ctx
+}
+
+func lockSem() {
+	pkg := reflect.ValueOf(&sem).Elem()
+	semPtr := (*sync.Mutex)(unsafe.Pointer(pkg.UnsafeAddr()))
+	semPtr.Lock()
+}
+
+func unlockSem() {
+	pkg := reflect.ValueOf(&sem).Elem()
+	semPtr := (*sync.Mutex)(unsafe.Pointer(pkg.UnsafeAddr()))
+	semPtr.Unlock()
+}
+
+var testOSCases = []struct {
+	desc string
+	f    func(ctx context.Context, t *testing.T, sc ospb.OSClient, s *OSServer)
+}{
+	{
+		desc: "OSInstallFailsIfTransferRequestIsMissingVersion",
+		f: func(ctx context.Context, t *testing.T, sc ospb.OSClient, s *OSServer) {
+			stream, err := sc.Install(ctx, grpc.EmptyCallOption{})
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			// Send TransferRequest.
+			err = stream.Send(&ospb.InstallRequest{
+				Request: &ospb.InstallRequest_TransferRequest{},
+			})
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			// Receive InstallError due to missing version.
+			resp, err := stream.Recv()
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			instErr := resp.GetInstallError()
+			if instErr == nil {
+				t.Fatal("Expected InstallError!")
+			}
+			if instErr.GetType() != ospb.InstallError_PARSE_FAIL {
+				t.Fatal("Expected InstallError type: PARSE_FAIL!")
+			}
+			// Receive error reporting.
+			_, err = stream.Recv()
+			if err == nil {
+				t.Fatal("Expected error!")
+			}
+			testErr(err, codes.Aborted, "Failed to process TransferRequest.", t)
+		},
+	},
+	{
+		desc: "OSInstallFailsForConcurrentOperations",
+		f: func(ctx context.Context, t *testing.T, sc ospb.OSClient, s *OSServer) {
+			stream, err := sc.Install(ctx, grpc.EmptyCallOption{})
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			// Send TransferRequest.
+			err = stream.Send(&ospb.InstallRequest{
+				Request: &ospb.InstallRequest_TransferRequest{
+					TransferRequest: &ospb.TransferRequest{
+						Version: "os1.1",
+					},
+				},
+			})
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			// Receive TransferReady response.
+			resp, err := stream.Recv()
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			if resp.GetTransferReady() == nil {
+				t.Fatal("Did not receive expected TransferReady response")
+			}
+			targetAddr := fmt.Sprintf("127.0.0.1:%d", s.config.Port)
+			// Create a new client.
+			tlsConfig := &tls.Config{InsecureSkipVerify: true}
+			opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
+			conn, err := grpc.Dial(targetAddr, opts...)
+			if err != nil {
+				t.Fatalf("Dialing to %s failed: %v", targetAddr, err)
+			}
+			defer conn.Close()
+			newsc := ospb.NewOSClient(conn)
+			newctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+			defer cancel()
+			newstream, err := newsc.Install(newctx, grpc.EmptyCallOption{})
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			// Receive InstallError due to Install in progress.
+			resp, err = newstream.Recv()
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			instErr := resp.GetInstallError()
+			if instErr == nil {
+				t.Fatal("Expected InstallError!")
+			}
+			if instErr.GetType() != ospb.InstallError_INSTALL_IN_PROGRESS {
+				t.Fatal("Expected InstallError type: INSTALL_IN_PROGRESS!")
+			}
+			_, err = newstream.Recv()
+			if err == nil {
+				t.Fatal("Expected error!")
+			}
+			t.Logf("InstallError=%v", err)
+			testErr(err, codes.Aborted, "Concurrent Install RPCs", t)
+			// Continue with the existing stream.
+			t.Logf("Client continue with the existing stream")
+			err = stream.Send(&ospb.InstallRequest{
+				Request: &ospb.InstallRequest_TransferEnd{},
+			})
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			// Receive Validated response.
+			resp, err = stream.Recv()
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			if resp.GetValidated() == nil {
+				t.Fatal("Did not receive expected Validated response.")
+			}
+		},
+	},
+	{
+		desc: "OSInstallFailsIfWrongMessageIsSent",
+		f: func(ctx context.Context, t *testing.T, sc ospb.OSClient, s *OSServer) {
+			stream, err := sc.Install(ctx, grpc.EmptyCallOption{})
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			// Send TransferEnd; server expects TransferRequest.
+			err = stream.Send(&ospb.InstallRequest{
+				Request: &ospb.InstallRequest_TransferEnd{},
+			})
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			// Receive error reporting.
+			_, err = stream.Recv()
+			if err == nil {
+				t.Fatal("Expected error!")
+			}
+			testErr(err, codes.InvalidArgument, "Expected TransferRequest", t)
+		},
+	},
+	{
+		desc: "OSInstallAbortedImmediately",
+		f: func(ctx context.Context, t *testing.T, sc ospb.OSClient, s *OSServer) {
+			stream, err := sc.Install(ctx, grpc.EmptyCallOption{})
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			// Close the stream immediately.
+			stream.CloseSend()
+			// Receive error reporting premature closure of the stream.
+			_, err = stream.Recv()
+			if err == nil {
+				t.Fatal("Expected an error reporting on premature closure of the stream.")
+			}
+		},
+	},
+	{
+		desc: "OSInstallFailsIfImageExistsWhenTransferBegins",
+		f: func(ctx context.Context, t *testing.T, sc ospb.OSClient, s *OSServer) {
+			stream, err := sc.Install(ctx, grpc.EmptyCallOption{})
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			// Send TransferRequest.
+			version := "os1.1"
+			err = stream.Send(&ospb.InstallRequest{
+				Request: &ospb.InstallRequest_TransferRequest{
+					TransferRequest: &ospb.TransferRequest{
+						Version: version,
+					},
+				},
+			})
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			// Receive TransferReady response.
+			resp, err := stream.Recv()
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			if resp.GetTransferReady() == nil {
+				t.Fatal("Did not receive expected TransferReady response")
+			}
+			// TransferReady initiates transferring content. Image must not exist at this point!
+			imgPath := s.getVersionPath(version)
+			f, err := os.OpenFile(imgPath, os.O_CREATE|os.O_WRONLY, 0644)
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			if err := f.Close(); err != nil {
+				t.Fatal(err.Error())
+			}
+			// Cleanup
+			defer func() {
+				if err := os.Remove(imgPath); err != nil {
+					t.Errorf("Error while deleting temporary test file: %v\n", err)
+				}
+			}()
+			// Send TransferContent.
+			err = stream.Send(&ospb.InstallRequest{
+				Request: &ospb.InstallRequest_TransferContent{
+					TransferContent: []byte("unimportant string"),
+				},
+			})
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			// Now, read the final error from the stream.
+			// The server will abort the entire RPC, so we expect a gRPC error here, not a message on the stream.
+			_, err = stream.Recv()
+
+			// Assert that the received error is of the expected type and code.
+			if err == nil {
+				t.Fatal("Expected an RPC error after sending TransferContent.")
+			}
+
+			st, ok := status.FromError(err)
+			if !ok || st.Code() != codes.Aborted || !strings.Contains(st.Message(), "already exists") {
+				t.Fatalf("Expected Aborted error with 'already exists' message, got: %v", err)
+			}
+		},
+	},
+	{
+		desc: "OSInstallFailsIfStreamClosesInTheMiddleOfTransfer",
+		f: func(ctx context.Context, t *testing.T, sc ospb.OSClient, s *OSServer) {
+			t.Log("OSInstallFailsIfStreamClosesInTheMiddleOfTransfer starts")
+			stream, err := sc.Install(ctx, grpc.EmptyCallOption{})
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			version := "os1.1"
+			// Send TransferRequest.
+			t.Log("Send TransferRequest")
+			err = stream.Send(&ospb.InstallRequest{
+				Request: &ospb.InstallRequest_TransferRequest{
+					TransferRequest: &ospb.TransferRequest{
+						Version: version,
+					},
+				},
+			})
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			// Receive TransferReady response.
+			resp, err := stream.Recv()
+			t.Log("Received TransferReady")
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			if trfReady := resp.GetTransferReady(); trfReady == nil {
+				t.Fatal("Did not receive expected TransferReady response")
+			}
+			// Send TransferContent.
+			t.Log("Send TransferContent")
+			err = stream.Send(&ospb.InstallRequest{
+				Request: &ospb.InstallRequest_TransferContent{
+					TransferContent: []byte("unimportant string"),
+				},
+			})
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			// Receive TransferProgress response.
+			resp, err = stream.Recv()
+			t.Log("Received TransferProgress")
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			if trfProg := resp.GetTransferProgress(); trfProg == nil {
+				t.Fatal("Did not receive expected TransferProgress response")
+			}
+			// Close the stream immediately.
+			t.Log("Close the stream immediately")
+			stream.CloseSend()
+
+			// Receive error reporting premature closure of the stream.
+			t.Log("Receive error reporting premature closure of the stream")
+			_, err = stream.Recv()
+			if err == nil {
+				t.Fatal("Expected an error reporting on premature closure of the stream.")
+			}
+			t.Logf("Got expected error from server: %v", err)
+
+			// Check incomplete transfer is removed!
+			if s.imageExists(s.getVersionPath(version)) {
+				t.Fatal("Incomplete image should have been deleted!")
+			}
+			t.Log("Incomplete transfer has been removed")
+		},
+	},
+	{
+		desc: "OSInstallFailsIfWrongMsgIsSentInTheMiddleOfTransfer",
+		f: func(ctx context.Context, t *testing.T, sc ospb.OSClient, s *OSServer) {
+			stream, err := sc.Install(ctx, grpc.EmptyCallOption{})
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			version := "os1.1"
+			// Send TransferRequest.
+			err = stream.Send(&ospb.InstallRequest{
+				Request: &ospb.InstallRequest_TransferRequest{
+					TransferRequest: &ospb.TransferRequest{
+						Version: version,
+					},
+				},
+			})
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			// Receive TransferReady response.
+			resp, err := stream.Recv()
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			if trfReady := resp.GetTransferReady(); trfReady == nil {
+				t.Fatal("Did not receive expected TransferReady response")
+			}
+			// Send TransferContent.
+			err = stream.Send(&ospb.InstallRequest{
+				Request: &ospb.InstallRequest_TransferContent{
+					TransferContent: []byte("unimportant string"),
+				},
+			})
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			// Receive TransferProgress response.
+			resp, err = stream.Recv()
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			if trfProg := resp.GetTransferProgress(); trfProg == nil {
+				t.Fatal("Did not receive expected TransferProgress response")
+			}
+			// Send TransferRequest again. This is unexpected!
+			// Server should send error message, clean up incomplete transfer.
+			err = stream.Send(&ospb.InstallRequest{
+				Request: &ospb.InstallRequest_TransferRequest{
+					TransferRequest: &ospb.TransferRequest{
+						Version: version,
+					},
+				},
+			})
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			// Receive error reporting.
+			_, err = stream.Recv()
+			if err == nil {
+				t.Fatal("Expected an error reporting on premature closure of the stream.")
+			}
+			// Check incomplete transfer is removed!
+			if s.imageExists(s.getVersionPath(version)) {
+				t.Fatal("Incomplete image should have been deleted!")
+			}
+		},
+	},
+	{
+		desc: "OSInstallSucceeds",
+		f: func(ctx context.Context, t *testing.T, sc ospb.OSClient, s *OSServer) {
+			stream, err := sc.Install(ctx, grpc.EmptyCallOption{})
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			version := "os1.1"
+			// Send TransferRequest.
+			err = stream.Send(&ospb.InstallRequest{
+				Request: &ospb.InstallRequest_TransferRequest{
+					TransferRequest: &ospb.TransferRequest{
+						Version: version,
+					},
+				},
+			})
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			// Receive TransferReady response.
+			resp, err := stream.Recv()
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			if trfReady := resp.GetTransferReady(); trfReady == nil {
+				t.Fatal("Did not receive expected TransferReady response")
+			}
+			data := []byte("unimportant string")
+			// Send TransferContent.
+			err = stream.Send(&ospb.InstallRequest{
+				Request: &ospb.InstallRequest_TransferContent{
+					TransferContent: data,
+				},
+			})
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			// Receive TransferProgress response.
+			resp, err = stream.Recv()
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			if trfProg := resp.GetTransferProgress(); trfProg == nil {
+				t.Fatal("Did not receive expected TransferProgress response")
+			}
+			// Send TransferEnd.
+			err = stream.Send(&ospb.InstallRequest{
+				Request: &ospb.InstallRequest_TransferEnd{},
+			})
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			// Receive Validated response.
+			resp, err = stream.Recv()
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			if resp.GetValidated() == nil {
+				t.Fatal("Did not receive expected Validated response.")
+			}
+		},
+	},
+	{
+		desc: "OSInstallFailsIfBackendErrorsOnTransferReady",
+		f: func(ctx context.Context, t *testing.T, sc ospb.OSClient, s *OSServer) {
+			// Save the original function to restore it later.
+			originalProcessTransferReady := s.config.OSCfg.ProcessTransferReady
+
+			// Override backend to return an error
+			s.config.OSCfg.ProcessTransferReady = func(_ string) (string, error) {
+				return "", status.Errorf(codes.Unimplemented, "OS Install not supported")
+			}
+
+			// Use a defer statement to ensure the function is reset after the test.
+			defer func() {
+				s.config.OSCfg.ProcessTransferReady = originalProcessTransferReady
+			}()
+
+			stream, err := sc.Install(ctx, grpc.EmptyCallOption{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = stream.Send(&ospb.InstallRequest{
+				Request: &ospb.InstallRequest_TransferRequest{
+					TransferRequest: &ospb.TransferRequest{Version: "os1.2"},
+				},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			// Expect gRPC Unimplemented
+			_, err = stream.Recv()
+			if err == nil || grpc.Code(err) != codes.Unimplemented {
+				t.Fatalf("Expected Unimplemented, got: %v", err)
+			}
+		},
+	},
+	{
+		desc: "OSInstallFailsOnBadTransferReadyJSON",
+		f: func(ctx context.Context, t *testing.T, sc ospb.OSClient, s *OSServer) {
+			s.config.OSCfg.ProcessTransferReady = func(_ string) (string, error) {
+				return "{bad-json", nil
+			}
+			stream, _ := sc.Install(ctx, grpc.EmptyCallOption{})
+			stream.Send(&ospb.InstallRequest{
+				Request: &ospb.InstallRequest_TransferRequest{
+					TransferRequest: &ospb.TransferRequest{Version: "os1.2"},
+				},
+			})
+			resp, _ := stream.Recv()
+			if resp.GetInstallError() == nil {
+				t.Fatal("Expected InstallError due to bad JSON")
+			}
+		},
+	},
+	{
+		desc: "OSInstallFailsWithAuthenticationFailure",
+		f: func(ctx context.Context, t *testing.T, sc ospb.OSClient, s *OSServer) {
+			// Patch authenticate to always fail with Unauthenticated error
+			patch := gomonkey.ApplyFuncReturn(authenticate, ctx, status.Error(codes.Unauthenticated, "unauthenticated"))
+			defer patch.Reset()
+
+			// Attempt to call Install (should fail due to auth)
+			stream, err := sc.Install(ctx)
+			if err == nil {
+				// Try sending a request; should fail on send or receive
+				err = stream.Send(&ospb.InstallRequest{
+					Request: &ospb.InstallRequest_TransferRequest{
+						TransferRequest: &ospb.TransferRequest{Version: "os1.2"},
+					},
+				})
+				if err == nil {
+					// If sending didn't fail, try to receive (should fail here)
+					_, err = stream.Recv()
+				}
+			}
+			if err == nil || status.Code(err) != codes.Unauthenticated {
+				t.Fatalf("Expected Unauthenticated error, got: %v", err)
+			}
+		},
+	},
+	{
+		desc: "OSInstallFailsForConcurrentOperations_SendError",
+		f: func(ctx context.Context, t *testing.T, sc ospb.OSClient, s *OSServer) {
+			lockSem()
+			defer unlockSem()
+			// Prepare fake server stream that simulates Send error
+			fakeStream := &fakeInstallServer{
+				sendErr: errors.New("simulated send error"),
+				ctx:     ctx,
+			}
+
+			// Call Install directly with the fake stream
+			err := s.Install(fakeStream)
+
+			// The error should be codes.Aborted with your simulated message
+			if err == nil || status.Code(err) != codes.Aborted || !strings.Contains(err.Error(), "simulated send error") {
+				t.Fatalf("Expected Aborted error with send error message, got: %v", err)
+			}
+		},
+	},
+}
+
+// TestOSServer tests implementation of gnoi.OS server.
+func TestOSServer(t *testing.T) {
+	s := createServer(t, 8081)
+	go runServer(t, s)
+	defer s.s.Stop()
+	targetAddr := "127.0.0.1:8081"
+	tlsConfig := &tls.Config{InsecureSkipVerify: true}
+	opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
+	conn, err := grpc.Dial(targetAddr, opts...)
+	if err != nil {
+		t.Fatalf("Dialing to %s failed: %v", targetAddr, err)
+	}
+	defer conn.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	for _, test := range testOSCases {
+		t.Run(test.desc, func(t *testing.T) {
+			conn, err := grpc.Dial(targetAddr, opts...)
+			if err != nil {
+				t.Fatalf("Dialing to %s failed: %v", targetAddr, err)
+			}
+			defer conn.Close()
+			sc := ospb.NewOSClient(conn)
+			test.f(ctx, t, sc, &OSServer{Server: s})
+		})
+	}
+}
+
+// ProcessFakeTrfReady responds with the TransferReady response.
+func ProcessFakeTrfReady(req string) (string, error) {
+	// Fake response.
+	resp := &ospb.InstallResponse{
+		Response: &ospb.InstallResponse_TransferReady{},
+	}
+	respStr, err := json.Marshal(resp)
+	if err != nil {
+		log.Errorln("Cannot marshal TransferReady response!")
+		return "", fmt.Errorf("Cannot marshal TransferReady response!")
+	}
+	return string(respStr), nil
+}
+
+// ProcessFakeTrfEnd responds with the Validated response.
+func ProcessFakeTrfEnd(req string) (string, error) {
+	// Fake response.
+	resp := &ospb.InstallResponse{
+		Response: &ospb.InstallResponse_Validated{},
+	}
+	respStr, err := json.Marshal(resp)
+	if err != nil {
+		log.Errorln("Cannot marshal TransferEnd response!")
+		return "", fmt.Errorf("Cannot marshal TransferEnd response!")
+	}
+	return string(respStr), nil
+}
+
+func TestHandleErrorResponse(t *testing.T) {
+	errResp := &ospb.InstallResponse{
+		Response: &ospb.InstallResponse_InstallError{
+			InstallError: &ospb.InstallError{
+				Detail: fmt.Sprintf("something went wrong: %d", 42),
+			},
+		},
+	}
+	if errResp.GetInstallError() == nil {
+		t.Fatal("Expected InstallError")
+	}
+	if !strings.Contains(errResp.GetInstallError().GetDetail(), "something went wrong: 42") {
+		t.Fatal("Unexpected error message")
+	}
+}
+
+func TestHandleErrorResponse_MarshalError(t *testing.T) {
+	patch := gomonkey.ApplyFunc(json.Marshal, func(m proto.Message) ([]byte, error) {
+		return nil, errors.New("mock marshal failure")
+	})
+	defer patch.Reset()
+
+	// Provide a real proto.Message input
+	req := &ospb.TransferRequest{}
+	resp := &ospb.InstallResponse{
+		Response: &ospb.InstallResponse_InstallError{
+			InstallError: &ospb.InstallError{
+				Detail: fmt.Sprintf("test marshal fail: %v", req),
+			},
+		},
+	}
+
+	assert.NotNil(t, resp)
+	t.Logf("Got response: %+v", resp)
+}
+
+func TestProcessTransferContent_OpenFileError(t *testing.T) {
+	// Mock the os.OpenFile function to simulate a failure
+	patch := gomonkey.ApplyFunc(os.OpenFile, func(name string, flag int, perm os.FileMode) (*os.File, error) {
+		return nil, errors.New("simulated OpenFile failure")
+	})
+	defer patch.Reset()
+
+	// Initialize the Server struct with a mock Config
+	srv := &OSServer{
+		Server: &Server{
+			config: &Config{
+				OSCfg: &OSConfig{
+					ImgDir: "/tmp", // Mock directory path
+				},
+			},
+		},
+	}
+
+	// Call the method under test
+	resp := srv.processTransferContent([]byte("test data"), "/tmp/test.img")
+	t.Logf("processTransferContent response=%v", resp)
+
+	// Check if the response is not nil and has the expected error
+	if resp == nil || resp.GetInstallError() == nil {
+		t.Fatalf("Expected install_error in InstallResponse, got: %+v", resp)
+	}
+
+	// Check if the error detail matches the expected error message
+	expectedDetail := "Failed to open file [/tmp/test.img]."
+	if resp.GetInstallError().GetDetail() != expectedDetail {
+		t.Errorf("Expected error detail %q, got: %q", expectedDetail, resp.GetInstallError().GetDetail())
+	}
+}
+
+func TestProcessTransferContent_WriteError(t *testing.T) {
+	// Create a dummy *os.File
+	f := &os.File{}
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	// Patch os.OpenFile to return our dummy file and no error
+	patches.ApplyFunc(os.OpenFile, func(name string, flag int, perm os.FileMode) (*os.File, error) {
+		return f, nil
+	})
+
+	// Patch (*os.File).Write to return an error (simulating write failure)
+	patches.ApplyMethod(reflect.TypeOf(f), "Write", func(_ *os.File, b []byte) (int, error) {
+		return 0, errors.New("simulated Write failure")
+	})
+
+	// Patch (*os.File).Close to simulate a clean close (no error)
+	patches.ApplyMethod(reflect.TypeOf(f), "Close", func(_ *os.File) error {
+		return nil
+	})
+
+	// Initialize the Server struct with a mock Config
+	srv := &OSServer{
+		Server: &Server{
+			config: &Config{
+				OSCfg: &OSConfig{
+					ImgDir: "/tmp", // Mock directory path
+				},
+			},
+		},
+	}
+
+	// Call the method being tested
+	resp := srv.processTransferContent([]byte("test data"), "/tmp/test.img")
+	t.Logf("processTransferContent response=%v", resp)
+
+	// Validate that the response contains the expected error
+	t.Logf("processTransferContent response=%v", resp.GetInstallError())
+
+	if resp == nil || resp.GetInstallError() == nil {
+		t.Fatalf("Expected error response due to Write failure, got: %+v", resp)
+	}
+
+	// Check the error detail
+	t.Logf("Error Detail: %v", resp.GetInstallError().GetDetail())
+
+	expectedDetail := "Failed to write to file [/tmp/test.img]."
+	if resp.GetInstallError().GetDetail() != expectedDetail {
+		t.Errorf("Expected error detail %q, got: %q", expectedDetail, resp.GetInstallError().GetDetail())
+	}
+}
+
+func TestProcessTransferContent_CloseError(t *testing.T) {
+	f := &os.File{}
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	// Patch os.OpenFile to return dummy file
+	patches.ApplyFunc(os.OpenFile, func(name string, flag int, perm os.FileMode) (*os.File, error) {
+		return f, nil
+	})
+
+	// Patch (*os.File).Write to simulate successful write
+	patches.ApplyMethod(reflect.TypeOf(f), "Write", func(_ *os.File, b []byte) (int, error) {
+		return len(b), nil
+	})
+
+	// Patch (*os.File).Close to simulate error on final close
+	patches.ApplyMethod(reflect.TypeOf(f), "Close", func(_ *os.File) error {
+		return errors.New("simulated Close failure")
+	})
+
+	// Initialize the Server struct with a mock Config
+	srv := &OSServer{
+		Server: &Server{
+			config: &Config{
+				OSCfg: &OSConfig{
+					ImgDir: "/tmp", // Mock directory path
+				},
+			},
+		},
+	}
+
+	resp := srv.processTransferContent([]byte("test data"), "/tmp/test.img")
+	t.Logf("processTransferContent response=%v", resp)
+
+	if resp == nil || resp.GetInstallError() == nil {
+		t.Errorf("Expected error response due to Close failure, got: %+v", resp)
+	}
+}
+
+func TestProcessInstallFromBackEnd_Success(t *testing.T) {
+	// Patch ssc.NewDbusClient to return our fake client
+	patch := gomonkey.ApplyFunc(ssc.NewDbusClient, func() (ssc.Service, error) {
+		return &ssc.FakeClient{}, nil
+	})
+	defer patch.Reset()
+
+	result, err := ProcessInstallFromBackEnd("stable")
+	t.Logf("ProcessInstallFromBackEnd result=%v", result)
+	assert.NoError(t, err)
+	assert.Equal(t, "stable", result)
+}
+
+func TestProcessInstallFromBackEnd_NewDbusClientFails(t *testing.T) {
+	patch := gomonkey.ApplyFunc(ssc.NewDbusClient, func() (ssc.Service, error) {
+		return nil, errors.New("dbus error")
+	})
+	defer patch.Reset()
+
+	result, err := ProcessInstallFromBackEnd("stable")
+	t.Logf("ProcessInstallFromBackEnd err=%v", err)
+	assert.Error(t, err)
+	assert.Empty(t, result)
+}
+
+func TestRemoveIncompleteTrf_RemoveFails(t *testing.T) {
+	srv := &OSServer{}
+
+	// Create a temp file and don't delete it
+	tmpFile, err := os.CreateTemp("", "testimage-*.img")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	imgPath := tmpFile.Name()
+	tmpFile.Close()
+
+	// Patch os.Remove to return error, triggering the "failed to remove" path
+	patch := gomonkey.ApplyFunc(os.Remove, func(string) error {
+		return errors.New("mock remove failure")
+	})
+	defer patch.Reset()
+
+	// Ensure file still exists so imageExists returns true
+	_, statErr := os.Stat(imgPath)
+	if statErr != nil {
+		t.Fatalf("Temp file unexpectedly missing: %v", statErr)
+	}
+
+	srv.removeIncompleteTransfer(imgPath)
+
+	// Cleanup: remove file manually since our patched Remove does nothing
+	_ = os.Remove(imgPath)
+}
+
+func TestProcessTransferReq_MarshalError(t *testing.T) {
+	mockReq := &ospb.InstallRequest{
+		Request: &ospb.InstallRequest_TransferRequest{
+			TransferRequest: &ospb.TransferRequest{
+				Version: "1.0.0",
+			},
+		},
+	}
+
+	// Define the mock return values.
+	// The first nil is for the []byte, the second value is the error.
+	outputs := []gomonkey.OutputCell{
+		{Values: gomonkey.Params{nil, fmt.Errorf("mock marshal error")}},
+	}
+
+	// Patch the json.Marshal function.
+	patches := gomonkey.ApplyFuncSeq(json.Marshal, outputs)
+	defer patches.Reset() // Un-patch the function after the test.
+
+	srv := &OSServer{}
+	resp := srv.processTransferReq(mockReq)
+
+	installError := resp.GetInstallError()
+	if installError == nil {
+		t.Fatalf("Expected an InstallError, but got nil")
+	}
+
+	expectedDetail := "Failed to marshal TransferReady JSON: err: mock marshal error"
+	if !strings.Contains(installError.GetDetail(), expectedDetail) {
+		t.Errorf("Expected detail to contain '%s', but got '%s'", expectedDetail, installError.GetDetail())
+	}
+}
+
+func TestProcessTransferReq_GenericError(t *testing.T) {
+	// 1. Create a valid request to pass initial checks
+	req := &ospb.InstallRequest{
+		Request: &ospb.InstallRequest_TransferRequest{
+			TransferRequest: &ospb.TransferRequest{
+				Version: "1.0.0",
+			},
+		},
+	}
+
+	// 2. Create the mock OSServer and its dependencies
+	// The key is to create the OSConfig and assign a mock function to its field.
+	mockOSCfg := &OSConfig{
+		// Assign your mock function directly to the field
+		ProcessTransferReady: func(req string) (string, error) {
+			return "", fmt.Errorf("this is a generic backend error")
+		},
+	}
+
+	mockSrv := &OSServer{
+		Server: &Server{
+			config: &Config{
+				OSCfg: mockOSCfg,
+			},
+		},
+	}
+
+	// 3. Call the function under test
+	resp := mockSrv.processTransferReq(req)
+
+	// 4. Assert that the response contains the expected error detail.
+	installError := resp.GetInstallError()
+	if installError == nil {
+		t.Fatalf("Expected an InstallError response, but got nil")
+	}
+
+	expectedDetail := "Error in TransferReady response: err: this is a generic backend error"
+	if !strings.Contains(installError.GetDetail(), expectedDetail) {
+		t.Errorf("Expected response detail to contain '%s', but got '%s'", expectedDetail, installError.GetDetail())
+	}
+}
+
+// MockOSCfg is a mock implementation of the OSCfg interface.
+type MockOSCfg struct {
+	ProcessTransferEndFunc func(reqStr string) (respStr string, err error)
+}
+
+func (m *MockOSCfg) ProcessTransferEnd(reqStr string) (string, error) {
+	return m.ProcessTransferEndFunc(reqStr)
+}
+
+func TestProcessTransferEnd_UnmarshalError(t *testing.T) {
+	// Create a mock function for ProcessTransferEnd.
+	// This function returns a JSON string that is valid but
+	// does not match the ospb.InstallResponse struct.
+	mockProcessTransferEnd := func(req string) (string, error) {
+		return `{"status": "this is not a valid InstallResponse proto"}`, nil
+	}
+
+	// Create the necessary structs to run the test.
+	osConfig := &OSConfig{
+		ProcessTransferEnd: mockProcessTransferEnd,
+	}
+
+	config := &Config{
+		OSCfg: osConfig,
+	}
+
+	srv := &OSServer{
+		Server: &Server{
+			config: config,
+		},
+	}
+
+	// Call the function under test.
+	req := &ospb.InstallRequest{}
+	resp := srv.processTransferEnd(req)
+
+	// Assert the result.
+	if resp == nil {
+		t.Fatal("Expected a non-nil response, but got nil")
+	}
+
+	// Assert that the response is an InstallError.
+	installError := resp.GetInstallError()
+	if installError == nil {
+		t.Errorf("Expected response to be an InstallError, but got a different response type: %T", resp.Response)
+	}
+
+	// Assert that the error detail contains the expected substring.
+	expectedErrMsg := "Failed to unmarshal TransferEnd JSON"
+	if !strings.Contains(resp.GetInstallError().GetDetail(), expectedErrMsg) {
+		t.Errorf("Expected error message to contain '%s', but got '%s'", expectedErrMsg, resp.GetInstallError().GetDetail())
+	}
+}
+
+func TestProcessTransferEnd_MarshalError(t *testing.T) {
+	// 1. Create a valid request to pass to the function under test.
+	mockReq := &ospb.InstallRequest{}
+
+	// Define the mock return values.
+	// The first nil is for the []byte, the second value is the error.
+	outputs := []gomonkey.OutputCell{
+		{Values: gomonkey.Params{nil, fmt.Errorf("mock marshal error")}},
+	}
+
+	// Patch the json.Marshal function.
+	patches := gomonkey.ApplyFuncSeq(json.Marshal, outputs)
+	defer patches.Reset() // Un-patch the function after the test.
+
+	// 3. Create a mock server and call the function under test.
+	srv := &OSServer{}
+	resp := srv.processTransferEnd(mockReq)
+
+	// 4. Assert the result to verify the error path was taken.
+	installError := resp.GetInstallError()
+	if installError == nil {
+		t.Fatalf("Expected an InstallError, but got nil")
+	}
+
+	expectedDetail := "Failed to marshal TransferEnd JSON: err: mock marshal error"
+	if !strings.Contains(installError.GetDetail(), expectedDetail) {
+		t.Errorf("Expected detail to contain '%s', but got '%s'", expectedDetail, installError.GetDetail())
+	}
+}
+
+func TestProcessTransferEnd_BackendError(t *testing.T) {
+	// Create a mock OSConfig that returns an error.
+	mockOSCfg := &OSConfig{
+		ProcessTransferEnd: func(req string) (string, error) {
+			return "", fmt.Errorf("this is a backend error")
+		},
+	}
+
+	// Create a mock server with the mock OSConfig.
+	srv := &OSServer{
+		Server: &Server{
+			config: &Config{
+				OSCfg: mockOSCfg,
+			},
+		},
+	}
+
+	// Call the function under test with a valid request.
+	req := &ospb.InstallRequest{}
+	resp := srv.processTransferEnd(req)
+
+	// Assert that the function returned the correct error response.
+	installError := resp.GetInstallError()
+	if installError == nil {
+		t.Fatalf("Expected an InstallError, but got nil")
+	}
+
+	expectedDetail := "Error in TransferEnd response: err: this is a backend error"
+	if !strings.Contains(installError.GetDetail(), expectedDetail) {
+		t.Errorf("Expected detail to contain '%s', but got '%s'", expectedDetail, installError.GetDetail())
+	}
+}

--- a/gnmi_server/server.go
+++ b/gnmi_server/server.go
@@ -73,6 +73,8 @@ type FileServer struct {
 // for forward compatibility
 type OSServer struct {
 	*Server
+	ProcessTransferReady func(req string) (string, error)
+	ProcessTransferEnd   func(req string) (string, error)
 	gnoi_os_pb.UnimplementedOSServer
 }
 
@@ -84,6 +86,13 @@ type ContainerzServer struct {
 
 type AuthTypes map[string]bool
 
+// OSConfig is a collection of values for OSServer.
+type OSConfig struct {
+	ImgDir               string                       // Path to the directory where image is stored.
+	ProcessTransferReady func(string) (string, error) // Function that handles TransferReady request.
+	ProcessTransferEnd   func(string) (string, error) // Function that handles TransferEnd request.
+}
+
 // Config is a collection of values for Server
 type Config struct {
 	// Port for the Server to listen on. If 0 or unset the Server will pick a port
@@ -94,11 +103,14 @@ type Config struct {
 	UserAuth            AuthTypes
 	EnableTranslibWrite bool
 	EnableNativeWrite   bool
+	EnableTranslation   bool
 	ZmqPort             string
 	IdleConnDuration    int
 	ConfigTableName     string
 	Vrf                 string
 	EnableCrl           bool
+	// gnoi
+	OSCfg *OSConfig
 }
 
 var AuthLock sync.Mutex
@@ -194,7 +206,11 @@ func NewServer(config *Config, opts []grpc.ServerOption) (*Server, error) {
 	}
 
 	fileSrv := &FileServer{Server: srv}
-	osSrv := &OSServer{Server: srv}
+	osSrv := &OSServer{
+		Server:               srv,
+		ProcessTransferReady: srv.config.OSCfg.ProcessTransferReady,
+		ProcessTransferEnd:   srv.config.OSCfg.ProcessTransferEnd,
+	}
 	containerzSrv := &ContainerzServer{server: srv}
 
 	var err error

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -120,7 +120,16 @@ func createClient(t *testing.T, port int) *grpc.ClientConn {
 	return conn
 }
 
+func createCommonOSCfg() *OSConfig {
+	return &OSConfig{
+		ImgDir:               "/tmp",
+		ProcessTransferReady: ProcessFakeTrfReady,
+		ProcessTransferEnd:   ProcessFakeTrfEnd,
+	}
+}
+
 func createServer(t *testing.T, port int64) *Server {
+	oscfg := createCommonOSCfg()
 	t.Helper()
 	certificate, err := testcert.NewCert()
 	if err != nil {
@@ -132,7 +141,7 @@ func createServer(t *testing.T, port int64) *Server {
 	}
 
 	opts := []grpc.ServerOption{grpc.Creds(credentials.NewTLS(tlsCfg))}
-	cfg := &Config{Port: port, EnableTranslibWrite: true, EnableNativeWrite: true, Threshold: 100}
+	cfg := &Config{Port: port, EnableTranslibWrite: true, EnableNativeWrite: true, Threshold: 100, OSCfg: oscfg}
 	s, err := NewServer(cfg, opts)
 	if err != nil {
 		t.Errorf("Failed to create gNMI server: %v", err)
@@ -141,6 +150,7 @@ func createServer(t *testing.T, port int64) *Server {
 }
 
 func createReadServer(t *testing.T, port int64) *Server {
+	oscfg := createCommonOSCfg()
 	certificate, err := testcert.NewCert()
 	if err != nil {
 		t.Errorf("could not load server key pair: %s", err)
@@ -151,7 +161,7 @@ func createReadServer(t *testing.T, port int64) *Server {
 	}
 
 	opts := []grpc.ServerOption{grpc.Creds(credentials.NewTLS(tlsCfg))}
-	cfg := &Config{Port: port, EnableTranslibWrite: false}
+	cfg := &Config{Port: port, EnableTranslibWrite: false, OSCfg: oscfg}
 	s, err := NewServer(cfg, opts)
 	if err != nil {
 		t.Fatalf("Failed to create gNMI server: %v", err)
@@ -160,6 +170,7 @@ func createReadServer(t *testing.T, port int64) *Server {
 }
 
 func createRejectServer(t *testing.T, port int64) *Server {
+	oscfg := createCommonOSCfg()
 	certificate, err := testcert.NewCert()
 	if err != nil {
 		t.Errorf("could not load server key pair: %s", err)
@@ -170,7 +181,7 @@ func createRejectServer(t *testing.T, port int64) *Server {
 	}
 
 	opts := []grpc.ServerOption{grpc.Creds(credentials.NewTLS(tlsCfg))}
-	cfg := &Config{Port: port, EnableTranslibWrite: true, Threshold: 2}
+	cfg := &Config{Port: port, EnableTranslibWrite: true, Threshold: 2, OSCfg: oscfg}
 	s, err := NewServer(cfg, opts)
 	if err != nil {
 		t.Fatalf("Failed to create gNMI server: %v", err)
@@ -179,6 +190,7 @@ func createRejectServer(t *testing.T, port int64) *Server {
 }
 
 func createAuthServer(t *testing.T, port int64) *Server {
+	oscfg := createCommonOSCfg()
 	t.Helper()
 	certificate, err := testcert.NewCert()
 	if err != nil {
@@ -190,7 +202,7 @@ func createAuthServer(t *testing.T, port int64) *Server {
 	}
 
 	opts := []grpc.ServerOption{grpc.Creds(credentials.NewTLS(tlsCfg))}
-	cfg := &Config{Port: port, EnableTranslibWrite: true, UserAuth: AuthTypes{"password": true, "cert": true, "jwt": true}}
+	cfg := &Config{Port: port, EnableTranslibWrite: true, UserAuth: AuthTypes{"password": true, "cert": true, "jwt": true}, OSCfg: oscfg}
 	s, err := NewServer(cfg, opts)
 	if err != nil {
 		t.Fatalf("Failed to create gNMI server: %v", err)
@@ -217,6 +229,7 @@ func createInvalidServer(t *testing.T, port int64) *Server {
 }
 
 func createKeepAliveServer(t *testing.T, port int64) *Server {
+	oscfg := createCommonOSCfg()
 	t.Helper()
 	certificate, err := testcert.NewCert()
 	if err != nil {
@@ -235,7 +248,7 @@ func createKeepAliveServer(t *testing.T, port int64) *Server {
 		grpc.KeepaliveParams(keep_alive_params),
 	}
 	server_opts = append(server_opts, opts[0])
-	cfg := &Config{Port: port, EnableTranslibWrite: true, EnableNativeWrite: true, Threshold: 100}
+	cfg := &Config{Port: port, EnableTranslibWrite: true, EnableNativeWrite: true, Threshold: 100, OSCfg: oscfg}
 	s, err := NewServer(cfg, server_opts)
 	if err != nil {
 		t.Errorf("Failed to create gNMI server: %v", err)

--- a/sonic_service_client/dbus_client.go
+++ b/sonic_service_client/dbus_client.go
@@ -3,11 +3,19 @@ package host_service
 import (
 	"fmt"
 	"reflect"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/godbus/dbus/v5"
 	log "github.com/golang/glog"
 	"github.com/sonic-net/sonic-gnmi/common_utils"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+var (
+	osMu sync.Mutex
 )
 
 type Service interface {
@@ -36,6 +44,7 @@ type Service interface {
 	FactoryReset(cmd string) (string, error)
 	// Docker services APIs
 	LoadDockerImage(image string) error
+	InstallOS(req string) (string, error)
 }
 
 type DbusClient struct {
@@ -71,7 +80,7 @@ func DbusApi(busName string, busPath string, intName string, timeout int, args .
 	common_utils.IncCounter(common_utils.DBUS)
 	conn, err := dbus.SystemBus()
 	if err != nil {
-		log.V(2).Infof("Failed to connect to system bus: %v", err)
+		log.Infof("Failed to connect to system bus: %v", err)
 		common_utils.IncCounter(common_utils.DBUS_FAIL)
 		return nil, err
 	}
@@ -84,42 +93,51 @@ func DbusApi(busName string, busPath string, intName string, timeout int, args .
 	case call := <-ch:
 		if call.Err != nil {
 			common_utils.IncCounter(common_utils.DBUS_FAIL)
+			log.Infof("call.Err %v", call.Err)
 			return nil, call.Err
 		}
 		result := call.Body
 		if len(result) == 0 {
 			common_utils.IncCounter(common_utils.DBUS_FAIL)
+			log.Infof("Dbus result is empty %v", result)
 			return nil, fmt.Errorf("Dbus result is empty %v", result)
 		}
 		if ret, ok := result[0].(int32); ok {
 			if ret == 0 {
 				if len(result) != 2 {
 					common_utils.IncCounter(common_utils.DBUS_FAIL)
+					log.Infof("Dbus result is invalid %v", result)
 					return nil, fmt.Errorf("Dbus result is invalid %v", result)
 				}
+				log.Infof("result[1] %v", result[1])
 				return result[1], nil
 			} else {
 				if len(result) != 2 {
 					common_utils.IncCounter(common_utils.DBUS_FAIL)
+					log.Infof("Dbus result is invalid %v", result)
 					return nil, fmt.Errorf("Dbus result is invalid %v", result)
 				}
 				if msg, check := result[1].(string); check {
 					common_utils.IncCounter(common_utils.DBUS_FAIL)
+					log.Infof("msg %v", msg)
 					return nil, fmt.Errorf(msg)
 				} else if msg, check := result[1].(map[string]string); check {
 					common_utils.IncCounter(common_utils.DBUS_FAIL)
+					log.Infof("msg[error] %v", msg["error"])
 					return nil, fmt.Errorf(msg["error"])
 				} else {
 					common_utils.IncCounter(common_utils.DBUS_FAIL)
+					log.Infof("Invalid result message type %v %v", result[1], reflect.TypeOf(result[1]))
 					return nil, fmt.Errorf("Invalid result message type %v %v", result[1], reflect.TypeOf(result[1]))
 				}
 			}
 		} else {
 			common_utils.IncCounter(common_utils.DBUS_FAIL)
+			log.Infof("Invalid result type %v %v", result[0], reflect.TypeOf(result[0]))
 			return nil, fmt.Errorf("Invalid result type %v %v", result[0], reflect.TypeOf(result[0]))
 		}
 	case <-time.After(time.Duration(timeout) * time.Second):
-		log.V(2).Infof("DbusApi: timeout")
+		log.Infof("DbusApi: timeout %v", timeout)
 		common_utils.IncCounter(common_utils.DBUS_FAIL)
 		return nil, fmt.Errorf("Timeout %v", timeout)
 	}
@@ -323,6 +341,37 @@ func (c *DbusClient) FactoryReset(cmd string) (string, error) {
 	if !ok {
 		return "", fmt.Errorf("Invalid result type %v: expected string, got %T", reflect.TypeOf(result), result)
 	}
+	return strResult, nil
+}
 
+func (c *DbusClient) InstallOS(req string) (string, error) {
+	common_utils.IncCounter(common_utils.GNOI_OS_INSTALL)
+	modName := "image_service"
+	busName := c.busNamePrefix + modName
+	busPath := c.busPathPrefix + modName
+	intName := c.intNamePrefix + modName + ".gnoi_install_os"
+
+	log.Infof("InstallOS: DbusClient called")
+	osMu.Lock()
+	defer osMu.Unlock()
+	result, err := DbusApi(busName, busPath, intName /*timeout=*/, 60, req)
+	if err != nil {
+		if strings.Contains(err.Error(), "ERROR_UNIMPLEMENTED") {
+			log.Infof("InstallOS: Error %v", err)
+			return "", status.Errorf(codes.Unimplemented, "%s", err)
+		}
+		log.Infof("InstallOS: Error %v", err)
+		return "", err
+	}
+	strResult, ok := result.(string)
+	if !ok {
+		log.Infof("InstallOS: Invalid result type %v %v", result, reflect.TypeOf(result))
+		return "", fmt.Errorf("Invalid result type %v %v", result, reflect.TypeOf(result))
+	}
+	if strings.Contains(strResult, "ERROR_UNIMPLEMENTED") {
+		log.Infof("InstallOS: Result %v", strResult)
+		return "", status.Errorf(codes.Unimplemented, "%s", strResult)
+	}
+	log.Infof("InstallOS: Result %v", strResult)
 	return strResult, nil
 }

--- a/sonic_service_client/dbus_fake_client.go
+++ b/sonic_service_client/dbus_fake_client.go
@@ -39,6 +39,14 @@ func (f *FakeClient) FactoryReset(cmd string) (string, error) {
 	}
 	return cmd, nil
 }
+func (f *FakeClient) InstallOS(req string) (string, error) {
+	if req == "" {
+		return "", errors.New("invalid OS install request")
+	}
+	return req, nil
+}
+
+var _ Service = &FakeClient{}
 
 // FakeClientWithError simulates failure in specific methods.
 type FakeClientWithError struct {

--- a/sonic_service_client/dbus_fake_client_test.go
+++ b/sonic_service_client/dbus_fake_client_test.go
@@ -42,4 +42,13 @@ func TestFakeClientMethods(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, "", output)
 	assert.Equal(t, "Previous reset is ongoing", err.Error())
+
+	output, err = client.InstallOS("stable")
+	assert.NoError(t, err)
+	assert.Equal(t, "stable", output)
+
+	output, err = client.InstallOS("")
+	assert.Error(t, err)
+	assert.Equal(t, "", output)
+	assert.Equal(t, "invalid OS install request", err.Error())
 }

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -61,6 +61,7 @@ type TelemetryConfig struct {
 	Vrf                   *string
 	EnableCrl             *bool
 	CrlExpireDuration     *int
+	ImgDirPath            *string
 }
 
 func main() {
@@ -175,6 +176,7 @@ func setupFlags(fs *flag.FlagSet) (*TelemetryConfig, *gnmi.Config, error) {
 		Vrf:                   fs.String("vrf", "", "VRF name, when zmq_address belong on a VRF, need VRF name to bind ZMQ."),
 		EnableCrl:             fs.Bool("enable_crl", false, "Enable certificate revocation list"),
 		CrlExpireDuration:     fs.Int("crl_expire_duration", 86400, "Certificate revocation list cache expire duration"),
+		ImgDirPath:            fs.String("img_dir", "/tmp/host_tmp", "Directory path where image will be transferred."),
 	}
 
 	fs.Var(&telemetryCfg.UserAuth, "client_auth", "Client auth mode(s) - none,cert,password")
@@ -229,6 +231,11 @@ func setupFlags(fs *flag.FlagSet) (*TelemetryConfig, *gnmi.Config, error) {
 	gnmi.JwtRefreshInt = time.Duration(*telemetryCfg.JwtRefInt * uint64(time.Second))
 	gnmi.JwtValidInt = time.Duration(*telemetryCfg.JwtValInt * uint64(time.Second))
 
+	oscfg := &gnmi.OSConfig{
+		ImgDir:               *telemetryCfg.ImgDirPath,
+		ProcessTransferReady: gnmi.ProcessInstallFromBackEnd,
+		ProcessTransferEnd:   gnmi.ProcessInstallFromBackEnd,
+	}
 	cfg := &gnmi.Config{}
 	cfg.Port = int64(*telemetryCfg.Port)
 	cfg.EnableTranslibWrite = bool(*telemetryCfg.GnmiTranslibWrite)
@@ -254,6 +261,7 @@ func setupFlags(fs *flag.FlagSet) (*TelemetryConfig, *gnmi.Config, error) {
 
 	cfg.ZmqPort = zmqPort
 
+	cfg.OSCfg = oscfg
 	return telemetryCfg, cfg, nil
 }
 


### PR DESCRIPTION
**Client Implementation** [https://github.com/kanchanavelusamy/sonic-gnmi/pull/3]
**Dependent Backend PR:** [https://github.com/sonic-net/sonic-host-services/pull/270]

**[UMF] gNOI OS Service - Test Results**
**Manual CLI Testing**

**Verify RPC**
```
admin@sonic:~$ docker exec -it gnmi gnoi_client -target 127.0.0.1:8080 -logtostderr -notls -module OS -rpc Verify 
OS Verify
{"version":"SONiC-OS-master.0-4b447731e"}
admin@sonic:~$ 
```

**Activate RPC**
```
admin@sonic:~$ docker exec -it gnmi gnoi_client -target 127.0.0.1:8080 -logtostderr -notls -module OS -rpc Activate -jsonin '{ "version": "SONiC-OS-master.0-4b447731e", "no_reboot": true }'
OS Activate
{"Response":{"ActivateOk":{}}}
admin@sonic:~$ 
```

**Install RPC**
```
admin@sonic:~$ docker exec gnmi gnoi_client -target 127.0.0.1:8080 -notls -module OS -rpc Install -jsonin '{"transferRequest": {"version": "SONiC-OS-master.0-4b447731e", "standby_supervisor": false}}' --input_file=SONiC-OS.tar.gz
OS Install
Error receiving stream: rpc error: code = Unimplemented desc = OS Install not supported
admin@sonic:~$
```
[gnmi.log](https://github.com/user-attachments/files/21832896/gnmi.log) for reference.

**UT Results:**
```
2025-09-05T13:22:09.2630939Z === RUN   TestOSServer
2025-09-05T13:22:10.7093953Z === RUN   TestOSServer/OSInstallFailsIfTransferRequestIsMissingVersion
2025-09-05T13:22:10.7303078Z E0905 13:22:10.729785   20907 gnoi_os.go:40] processTransferReq: TransferRequest must contain a valid OS version.
2025-09-05T13:22:10.7323018Z === RUN   TestOSServer/OSInstallFailsForConcurrentOperations
2025-09-05T13:22:10.7773188Z     gnoi_os_test.go:150: InstallError=rpc error: code = Aborted desc = Concurrent Install RPCs are not allowed.
2025-09-05T13:22:10.7774886Z     gnoi_os_test.go:153: Client continue with the existing stream
2025-09-05T13:22:10.7794301Z === RUN   TestOSServer/OSInstallFailsIfWrongMessageIsSent
2025-09-05T13:22:10.8028866Z E0905 13:22:10.801652   20907 gnoi_os.go:305] Install: TransferRequest is nil
2025-09-05T13:22:10.8032866Z === RUN   TestOSServer/OSInstallAbortedImmediately
2025-09-05T13:22:10.8249228Z E0905 13:22:10.824370   20907 gnoi_os.go:296] Install: Received EOF while receiving TransferRequest!
2025-09-05T13:22:10.8258844Z === RUN   TestOSServer/OSInstallFailsIfImageExistsWhenTransferBegins
2025-09-05T13:22:10.8489830Z E0905 13:22:10.848333   20907 gnoi_os.go:362] Install: Image /tmp/os1.1 already exists. Aborting TransferContent.
2025-09-05T13:22:10.8502198Z === RUN   TestOSServer/OSInstallFailsIfStreamClosesInTheMiddleOfTransfer
2025-09-05T13:22:10.8511079Z     gnoi_os_test.go:277: OSInstallFailsIfStreamClosesInTheMiddleOfTransfer starts
2025-09-05T13:22:10.8720829Z     gnoi_os_test.go:284: Send TransferRequest
2025-09-05T13:22:10.8734553Z     gnoi_os_test.go:297: Received TransferReady
2025-09-05T13:22:10.8739985Z     gnoi_os_test.go:305: Send TransferContent
2025-09-05T13:22:10.8747920Z     gnoi_os_test.go:316: Received TransferProgress
2025-09-05T13:22:10.8754585Z     gnoi_os_test.go:324: Close the stream immediately
2025-09-05T13:22:10.8755062Z     gnoi_os_test.go:328: Receive error reporting premature closure of the stream
2025-09-05T13:22:10.8764264Z E0905 13:22:10.875062   20907 gnoi_os.go:342] Install: Received EOF instead of TransferContent request!
2025-09-05T13:22:10.8767015Z     gnoi_os_test.go:333: Got expected error from server: rpc error: code = Aborted desc = Stream closed prematurely during transfer.
2025-09-05T13:22:10.8767714Z     gnoi_os_test.go:339: Incomplete transfer has been removed
2025-09-05T13:22:10.8768420Z === RUN   TestOSServer/OSInstallFailsIfWrongMsgIsSentInTheMiddleOfTransfer
2025-09-05T13:22:10.8999676Z E0905 13:22:10.899169   20907 gnoi_os.go:350] Install: Received a TransferReq out-of-sequence.
2025-09-05T13:22:10.9016380Z === RUN   TestOSServer/OSInstallSucceeds
2025-09-05T13:22:10.9250649Z === RUN   TestOSServer/OSInstallFailsIfBackendErrorsOnTransferReady
2025-09-05T13:22:10.9474486Z E0905 13:22:10.946413   20907 gnoi_os.go:69] processTransferReq: Backend returned OS unimplemented error.
2025-09-05T13:22:10.9475315Z E0905 13:22:10.946463   20907 gnoi_os.go:313] Install: TransferReady not received. Returning OS Unimplemented (backend not supported)
2025-09-05T13:22:10.9485552Z === RUN   TestOSServer/OSInstallFailsOnBadTransferReadyJSON
2025-09-05T13:22:10.9707788Z === RUN   TestOSServer/OSInstallFailsWithAuthenticationFailure
2025-09-05T13:22:10.9937234Z === RUN   TestOSServer/OSInstallFailsForConcurrentOperations_SendError
2025-09-05T13:22:10.9956278Z E0905 13:22:10.994077   20907 gnoi_os.go:285] InstallResponse: simulated send error
2025-09-05T13:22:10.9956650Z --- PASS: TestOSServer (1.73s)
2025-09-05T13:22:10.9956898Z     --- PASS: TestOSServer/OSInstallFailsIfTransferRequestIsMissingVersion (0.03s)
2025-09-05T13:22:10.9957161Z     --- PASS: TestOSServer/OSInstallFailsForConcurrentOperations (0.05s)
2025-09-05T13:22:10.9957410Z     --- PASS: TestOSServer/OSInstallFailsIfWrongMessageIsSent (0.02s)
2025-09-05T13:22:10.9957645Z     --- PASS: TestOSServer/OSInstallAbortedImmediately (0.02s)
2025-09-05T13:22:10.9957897Z     --- PASS: TestOSServer/OSInstallFailsIfImageExistsWhenTransferBegins (0.02s)
2025-09-05T13:22:10.9958168Z     --- PASS: TestOSServer/OSInstallFailsIfStreamClosesInTheMiddleOfTransfer (0.03s)
2025-09-05T13:22:10.9958438Z     --- PASS: TestOSServer/OSInstallFailsIfWrongMsgIsSentInTheMiddleOfTransfer (0.02s)
2025-09-05T13:22:10.9958986Z     --- PASS: TestOSServer/OSInstallSucceeds (0.02s)
2025-09-05T13:22:10.9959417Z     --- PASS: TestOSServer/OSInstallFailsIfBackendErrorsOnTransferReady (0.02s)
2025-09-05T13:22:10.9959670Z     --- PASS: TestOSServer/OSInstallFailsOnBadTransferReadyJSON (0.02s)
2025-09-05T13:22:10.9960179Z     --- PASS: TestOSServer/OSInstallFailsWithAuthenticationFailure (0.02s)
2025-09-05T13:22:10.9960445Z     --- PASS: TestOSServer/OSInstallFailsForConcurrentOperations_SendError (0.00s)
2025-09-05T13:22:10.9960805Z === RUN   TestHandleErrorResponse
2025-09-05T13:22:10.9961027Z --- PASS: TestHandleErrorResponse (0.00s)
2025-09-05T13:22:10.9961236Z === RUN   TestHandleErrorResponse_MarshalError
2025-09-05T13:22:10.9965487Z     gnoi_os_test.go:661: Got response: install_error:{detail:"test marshal fail: "}
2025-09-05T13:22:10.9970771Z --- PASS: TestHandleErrorResponse_MarshalError (0.00s)
2025-09-05T13:22:10.9971494Z === RUN   TestProcessTransferContent_OpenFileError
2025-09-05T13:22:10.9973696Z E0905 13:22:10.996611   20907 gnoi_os.go:194] processTransferContent: Failed to open or create file for writing: /tmp/test.img, error: simulated OpenFile failure
2025-09-05T13:22:10.9975019Z     gnoi_os_test.go:684: processTransferContent response=install_error:{detail:"Failed to open file [/tmp/test.img]."}
2025-09-05T13:22:10.9976839Z --- PASS: TestProcessTransferContent_OpenFileError (0.00s)
2025-09-05T13:22:10.9981222Z === RUN   TestProcessTransferContent_WriteError
2025-09-05T13:22:10.9981494Z --- PASS: TestProcessTransferContent_WriteError (0.00s)
2025-09-05T13:22:10.9985007Z === RUN   TestProcessTransferContent_CloseError
2025-09-05T13:22:10.9986375Z --- PASS: TestProcessTransferContent_CloseError (0.00s)
2025-09-05T13:22:10.9987331Z === RUN   TestProcessInstallFromBackEnd_Success
2025-09-05T13:22:10.9988240Z     gnoi_os_test.go:799: ProcessInstallFromBackEnd result=stable
2025-09-05T13:22:10.9988760Z --- PASS: TestProcessInstallFromBackEnd_Success (0.00s)
2025-09-05T13:22:10.9989628Z === RUN   TestProcessInstallFromBackEnd_NewDbusClientFails
2025-09-05T13:22:10.9989872Z     gnoi_os_test.go:811: ProcessInstallFromBackEnd err=dbus error
2025-09-05T13:22:10.9990118Z --- PASS: TestProcessInstallFromBackEnd_NewDbusClientFails (0.00s)
2025-09-05T13:22:10.9990345Z === RUN   TestRemoveIncompleteTrf_RemoveFails
2025-09-05T13:22:10.9990606Z E0905 13:22:10.998335   20907 gnoi_os.go:258] Failed to remove incomplete image: mock remove failure
2025-09-05T13:22:10.9996664Z --- PASS: TestRemoveIncompleteTrf_RemoveFails (0.00s)
2025-09-05T13:22:10.9998988Z === RUN   TestProcessTransferReq_MarshalError
2025-09-05T13:22:11.0001096Z --- PASS: TestProcessTransferReq_MarshalError (0.00s)
2025-09-05T13:22:11.0001381Z === RUN   TestProcessTransferReq_GenericError
2025-09-05T13:22:11.0003620Z E0905 13:22:10.999116   20907 gnoi_os.go:72] processTransferReq: Error in processing install from backend
2025-09-05T13:22:11.0005404Z --- PASS: TestProcessTransferReq_GenericError (0.00s)
2025-09-05T13:22:11.0005927Z === RUN   TestProcessTransferEnd_UnmarshalError
2025-09-05T13:22:11.0006494Z --- PASS: TestProcessTransferEnd_UnmarshalError (0.00s)
2025-09-05T13:22:11.0006881Z === RUN   TestProcessTransferEnd_MarshalError
2025-09-05T13:22:11.0007336Z E0905 13:22:10.999575   20907 gnoi_os.go:104] Failed to marshal TransferEnd JSON: err: mock marshal error, req: , reqStr: []
2025-09-05T13:22:11.0007745Z --- PASS: TestProcessTransferEnd_MarshalError (0.00s)
2025-09-05T13:22:11.0008513Z === RUN   TestProcessTransferEnd_BackendError
2025-09-05T13:22:11.0008810Z E0905 13:22:10.999833   20907 gnoi_os.go:117] Received error from OSServer.TransferEnd: err: this is a backend error, reqStr: [123 125], respStr: 
2025-09-05T13:22:11.0009110Z --- PASS: TestProcessTransferEnd_BackendError (0.00s)
```


<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

