### PR TITLE
Support CloseWrite event such that we don't reload on every Write event

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,8 @@ sonic-gnmi: $(GO_DEPS) $(FORMAT_CHECK)
 # advancetls 1.0.0 release need following patch to build by go-1.19
 	patch -d vendor -p0 < patches/0002-Fix-advance-tls-build-with-go-119.patch
 # build service first which depends on advancetls
+# add support for fsnotify closewrite event
+	patch -d vendor -p0 < patches/0004-CloseWrite-event-support.patch
 ifeq ($(CROSS_BUILD_ENVIRON),y)
 	$(GO) build -o ${GOBIN}/telemetry -mod=vendor $(BLD_FLAGS) github.com/sonic-net/sonic-gnmi/telemetry
 ifneq ($(ENABLE_DIALOUT_VALUE),0)

--- a/patches/0004-CloseWrite-event-support.patch
+++ b/patches/0004-CloseWrite-event-support.patch
@@ -1,0 +1,41 @@
+--- ./github.com/fsnotify/fsnotify/fsnotify.go
++++ ./github.com/fsnotify/fsnotify/fsnotify.go
+@@ -29,6 +29,7 @@
+ 	Remove
+ 	Rename
+ 	Chmod
++	CloseWrite
+ )
+ 
+ func (op Op) String() string {
+@@ -50,6 +51,9 @@
+ 	if op&Chmod == Chmod {
+ 		buffer.WriteString("|CHMOD")
+ 	}
++	if op&Chmod == CloseWrite {
++		buffer.WriteString("|CLOSE_WRITE")
++	}
+ 	if buffer.Len() == 0 {
+ 		return ""
+ 	}
+--- ./github.com/fsnotify/fsnotify/inotify.go
++++ ./github.com/fsnotify/fsnotify/inotify.go
+@@ -96,7 +96,8 @@
+ 
+ 	const agnosticEvents = unix.IN_MOVED_TO | unix.IN_MOVED_FROM |
+ 		unix.IN_CREATE | unix.IN_ATTRIB | unix.IN_MODIFY |
+-		unix.IN_MOVE_SELF | unix.IN_DELETE | unix.IN_DELETE_SELF
++		unix.IN_MOVE_SELF | unix.IN_DELETE | unix.IN_DELETE_SELF |
++		unix.IN_CLOSE_WRITE
+ 
+ 	var flags uint32 = agnosticEvents
+ 
+@@ -333,5 +334,8 @@
+ 	if mask&unix.IN_ATTRIB == unix.IN_ATTRIB {
+ 		e.Op |= Chmod
+ 	}
++	if mask&unix.IN_CLOSE_WRITE == unix.IN_CLOSE_WRITE {
++		e.Op |= CloseWrite
++	}
+ 	return e
+ }

--- a/patches/0004-CloseWrite-event-support.patch
+++ b/patches/0004-CloseWrite-event-support.patch
@@ -1,19 +1,23 @@
 --- ./github.com/fsnotify/fsnotify/fsnotify.go
 +++ ./github.com/fsnotify/fsnotify/fsnotify.go
-@@ -29,6 +29,7 @@
+@@ -29,6 +29,8 @@
  	Remove
  	Rename
  	Chmod
 +	CloseWrite
++	MovedTo
  )
  
  func (op Op) String() string {
-@@ -50,6 +51,9 @@
+@@ -50,6 +52,12 @@
  	if op&Chmod == Chmod {
  		buffer.WriteString("|CHMOD")
  	}
 +	if op&CloseWrite == CloseWrite {
 +		buffer.WriteString("|CLOSE_WRITE")
++	}
++	if op&MovedTo == MovedTo {
++		buffer.WriteString("|MOVED_TO")
 +	}
  	if buffer.Len() == 0 {
  		return ""
@@ -30,7 +34,21 @@
  
  	var flags uint32 = agnosticEvents
  
-@@ -333,5 +334,8 @@
+@@ -318,9 +319,12 @@
+ // newEvent returns an platform-independent Event based on an inotify mask.
+ func newEvent(name string, mask uint32) Event {
+ 	e := Event{Name: name}
+-	if mask&unix.IN_CREATE == unix.IN_CREATE || mask&unix.IN_MOVED_TO == unix.IN_MOVED_TO {
++	if mask&unix.IN_CREATE == unix.IN_CREATE {
+ 		e.Op |= Create
+ 	}
++	if mask&unix.IN_MOVED_TO == unix.IN_MOVED_TO {
++		e.Op |= MovedTo
++	}
+ 	if mask&unix.IN_DELETE_SELF == unix.IN_DELETE_SELF || mask&unix.IN_DELETE == unix.IN_DELETE {
+ 		e.Op |= Remove
+ 	}
+@@ -333,5 +337,8 @@
  	if mask&unix.IN_ATTRIB == unix.IN_ATTRIB {
  		e.Op |= Chmod
  	}

--- a/patches/0004-CloseWrite-event-support.patch
+++ b/patches/0004-CloseWrite-event-support.patch
@@ -12,7 +12,7 @@
  	if op&Chmod == Chmod {
  		buffer.WriteString("|CHMOD")
  	}
-+	if op&Chmod == CloseWrite {
++	if op&CloseWrite == CloseWrite {
 +		buffer.WriteString("|CLOSE_WRITE")
 +	}
  	if buffer.Len() == 0 {

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -283,7 +283,7 @@ func iNotifyCertMonitoring(watcher *fsnotify.Watcher, telemetryCfg *TelemetryCon
 					filepath.Ext(event.Name) == ".cer" || filepath.Ext(event.Name) == ".pem" ||
 					filepath.Ext(event.Name) == ".key") {
 					log.V(1).Infof("Inotify watcher has received event: %v", event)
-					if event.Op&fsnotify.Write == fsnotify.Write || event.Op&fsnotify.Create == fsnotify.Create {
+					if event.Op&fsnotify.CloseWrite == fsnotify.CloseWrite || event.Op&fsnotify.Create == fsnotify.Create {
 						log.V(1).Infof("Cert File has been modified: %s", event.Name)
 						serverControlSignal <- ServerStart // let server know that a write/create event occurred
 						done <- true

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -283,7 +283,7 @@ func iNotifyCertMonitoring(watcher *fsnotify.Watcher, telemetryCfg *TelemetryCon
 					filepath.Ext(event.Name) == ".cer" || filepath.Ext(event.Name) == ".pem" ||
 					filepath.Ext(event.Name) == ".key") {
 					log.V(1).Infof("Inotify watcher has received event: %v", event)
-					if event.Op&fsnotify.CloseWrite == fsnotify.CloseWrite || event.Op&fsnotify.Create == fsnotify.Create {
+					if event.Op&fsnotify.CloseWrite == fsnotify.CloseWrite || event.Op&fsnotify.MovedTo == fsnotify.MovedTo {
 						log.V(1).Infof("Cert File has been modified: %s", event.Name)
 						serverControlSignal <- ServerStart // let server know that a write/create event occurred
 						done <- true

--- a/telemetry/telemetry_test.go
+++ b/telemetry/telemetry_test.go
@@ -353,7 +353,10 @@ func copyFile(srcPath string, destPath string) error {
 
 func writeSlowKey(backupKeyPath string, keyPath string) error {
 	// Copy existing key from keyPath to backupKeyPath
-	copyFile(keyPath, backupKeyPath)
+	err := copyFile(keyPath, backupKeyPath)
+	if err != nil {
+		return err
+	}
 
 	// Write from backupKeyPath to keyPath
 	backupKey, err := os.Open(backupKeyPath)
@@ -898,7 +901,7 @@ func TestINotifyCertMonitoringSlowWrites(t *testing.T) {
 
 	// Write slowly to key file such that only get 1 reload after multiple writes
 
-	writeSlowKey(testServerKeyBackup, testServerKey)
+	err = writeSlowKey(testServerKeyBackup, testServerKey)
 	if err != nil {
 		t.Errorf("Expected err to be nil, got err %v", err)
 	}

--- a/telemetry/telemetry_test.go
+++ b/telemetry/telemetry_test.go
@@ -382,6 +382,9 @@ func writeSlowKey(backupKeyPath string, keyPath string) error {
 		if err == io.EOF {
 			break
 		}
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

MS ADO: 33377547

If we have a slow writer to a cert file that is monitored such that they truncate the file, and write bytes at a time, we will see excessive amount of WRITE events such that our server will try to reload on each one. With CloseWrite supported, once a writer has finished writing to the file and closed the file we will then try the reload. We also add logic to distinguish between CREATE and IN_MOVED_TO events such that we will reload on IN_MOVED_TO but not CREATE events.

#### How I did it

1) Added a patch for fsnotify to support CLOSE_WRITE events and distinguish between CREATE and IN_MOVED_TO events
2) Change telemetry server to monitor for CLOSE_WRITE instead of just WRITE events and monitor IN_MOVED_TO instead of CREATE events.

Patched is based off https://github.com/fsnotify/fsnotify/pull/252

#### How to verify it

Manual test, UT

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

