### PR TITLE
[202405] Add cert multiple roles support (#366)

### DIFF
--- a/gnmi_server/clientCertAuth.go
+++ b/gnmi_server/clientCertAuth.go
@@ -1,6 +1,9 @@
 package gnmi
 
 import (
+	"strings"
+
+	"github.com/golang/glog"
 	"github.com/sonic-net/sonic-gnmi/common_utils"
 	"github.com/sonic-net/sonic-gnmi/swsscommon"
 	"github.com/golang/glog"
@@ -58,7 +61,11 @@ func PopulateAuthStructByCommonName(certCommonName string, auth *common_utils.Au
 
 	var fieldValuePairs = configDbConnector.Get_entry(serviceConfigTableName, certCommonName)
 	if fieldValuePairs.Size() > 0 {
-		if fieldValuePairs.Has_key("role") {
+		if fieldValuePairs.Has_key("role@") {
+			var role = fieldValuePairs.Get("role@")
+			auth.Roles = strings.Split(role, ",")
+		} else if fieldValuePairs.Has_key("role") {
+			// Backward compatibility for single role DB schema
 			var role = fieldValuePairs.Get("role")
 			auth.Roles = []string{role}
 		}

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -4484,6 +4484,100 @@ func CreateAuthorizationCtx() (context.Context, context.CancelFunc) {
 	swsscommon.DeleteDBConnector(configDb)
 }
 
+func TestClientCertAuthenAndAuthorMultiRole(t *testing.T) {
+	if !swsscommon.SonicDBConfigIsInit() {
+		swsscommon.SonicDBConfigInitialize()
+	}
+
+	var configDb = swsscommon.NewDBConnector("CONFIG_DB", uint(0), true)
+	var gnmiTable = swsscommon.NewTable(configDb, "GNMI_CLIENT_CERT")
+	configDb.Flushdb()
+
+	// initialize err variable
+	err := status.Error(codes.Unauthenticated, "")
+
+	// when config table is empty, will authorize with PopulateAuthStruct
+	mockpopulate := gomonkey.ApplyFunc(PopulateAuthStruct, func(username string, auth *common_utils.AuthInfo, r []string) error {
+		return nil
+	})
+	defer mockpopulate.Reset()
+
+	// check auth with nil cert name
+	ctx, cancel := CreateAuthorizationCtx()
+	ctx, err = ClientCertAuthenAndAuthor(ctx, "", false)
+	if err != nil {
+		t.Errorf("CommonNameMatch with empty config table should success: %v", err)
+	}
+
+	cancel()
+
+	// check get 1 cert name
+	ctx, cancel = CreateAuthorizationCtx()
+	configDb.Flushdb()
+	gnmiTable.Hset("certname1", "role@", "readwrite")
+	ctx, err = ClientCertAuthenAndAuthor(ctx, "GNMI_CLIENT_CERT", false)
+	if err != nil {
+		t.Errorf("CommonNameMatch with correct cert name should success: %v", err)
+	}
+
+	cancel()
+
+	// check get multiple cert names
+	ctx, cancel = CreateAuthorizationCtx()
+	configDb.Flushdb()
+	gnmiTable.Hset("certname1", "role@", "readwrite")
+	gnmiTable.Hset("certname2", "role@", "readonly")
+	ctx, err = ClientCertAuthenAndAuthor(ctx, "GNMI_CLIENT_CERT", false)
+	if err != nil {
+		t.Errorf("CommonNameMatch with correct cert name should success: %v", err)
+	}
+
+	cancel()
+
+	// check a invalid cert cname
+	ctx, cancel = CreateAuthorizationCtx()
+	configDb.Flushdb()
+	gnmiTable.Hset("certname2", "role@", "readonly")
+	ctx, err = ClientCertAuthenAndAuthor(ctx, "GNMI_CLIENT_CERT", false)
+	if err == nil {
+		t.Errorf("CommonNameMatch with invalid cert name should fail: %v", err)
+	}
+
+	cancel()
+
+	swsscommon.DeleteTable(gnmiTable)
+	swsscommon.DeleteDBConnector(configDb)
+}
+
+func TestAuthenticate(t *testing.T) {
+	if !swsscommon.SonicDBConfigIsInit() {
+		swsscommon.SonicDBConfigInitialize()
+	}
+
+	var tableName = "GNMI_CLIENT_CERT"
+	var configDb = swsscommon.NewDBConnector("CONFIG_DB", uint(0), true)
+	var gnmiTable = swsscommon.NewTable(configDb, tableName)
+	defer swsscommon.DeleteTable(gnmiTable)
+	defer swsscommon.DeleteDBConnector(configDb)
+	configDb.Flushdb()
+
+	// initialize err variable
+	err := status.Error(codes.Unauthenticated, "")
+
+	// check a invalid role
+	cfg := &Config{ConfigTableName: tableName, UserAuth: AuthTypes{"password": false, "cert": true, "jwt": false}}
+	ctx, cancel := CreateAuthorizationCtx()
+	configDb.Flushdb()
+	gnmiTable.Hset("certname1", "role@", "readonly")
+	// Call authenticate to verify the user's role. This should fail if the role is "readonly".
+	_, err = authenticate(cfg, ctx)
+	if err == nil {
+		t.Errorf("authenticate with readonly role should fail: %v", err)
+	}
+
+	cancel()
+}
+
 type MockServerStream struct {
 	grpc.ServerStream
 }


### PR DESCRIPTION
Add cert multiple roles support

#### Why I did it
Some scenarios need GNMI support multiple roles
Cherry-pick https://github.com/sonic-net/sonic-gnmi/pull/366

#### How I did it
Change CONFIG_DB schema and read multiple roles from CONFIG_DB

#### How to verify it
Manually test.
Add new UT.

#### Work item tracking
Microsoft ADO (number only): 31561802

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
Add cert multiple roles support

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

