### PR TITLE
[202311] Add cert multiple roles support

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,6 +17,15 @@ pr:
     - 202???
     - 201???
 
+variables:
+  - name: BUILD_BRANCH
+    ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+      value: $(System.PullRequest.TargetBranch)
+    ${{ else }}:
+      value: $(Build.SourceBranchName)
+  - name: UNIT_TEST_FLAG
+    value: 'ENABLE_TRANSLIB_WRITE=y'
+
 resources:
   repositories:
   - repository: sonic-mgmt-common
@@ -28,6 +37,7 @@ resources:
     type: github
     name: sonic-net/sonic-swss-common
     endpoint: sonic-net
+    ref: refs/heads/$(BUILD_BRANCH)
 
 stages:
 - stage: Build
@@ -67,28 +77,20 @@ stages:
       inputs:
         source: specific
         project: build
-        pipeline: 1
+        pipeline: 142
         artifact: sonic-buildimage.vs
         runVersion: 'latestFromBranch'
-        runBranch: 'refs/heads/master'
+        runBranch: 'refs/heads/$(BUILD_BRANCH)'
         patterns: |
-            target/debs/bullseye/libyang*.deb
-            target/debs/bullseye/libnl*.deb
-      displayName: "Download bullseye debs"
-
-    - task: DownloadPipelineArtifact@2
-      inputs:
-        source: specific
-        project: build
-        pipeline: 127
-        artifact: sonic-mgmt-common
-        runVersion: 'latestFromBranch'
-        runBranch: 'refs/heads/master'
-      displayName: "Download sonic-mgmt-common"
+            target/debs/bookworm/libyang*.deb
+            target/debs/bookworm/libnl*.deb
+            target/python-wheels/bookworm/sonic_yang_models*.whl
+      displayName: "Download bookworm debs"
 
     - script: |
         # PYTEST
         sudo pip3 install -U pytest
+        sudo pip3 install -U jsonpatch
 
         # REDIS
         sudo apt-get update
@@ -101,6 +103,12 @@ stages:
         # LIBYANG
         sudo dpkg -i ../target/debs/bullseye/libyang*1.0.73*.deb
       displayName: "Install dependency"
+
+    - script: |
+        # SONIC YANGS
+        set -ex
+        sudo pip3 install ../target/python-wheels/bullseye/sonic_yang_models-1.0-py3-none-any.whl
+      displayName: "Install sonic yangs"
 
     - script: |
         # LIBSWSSCOMMON
@@ -127,7 +135,7 @@ stages:
         pipeline: Azure.sonic-swss-common
         artifact: sonic-swss-common
         runVersion: 'latestFromBranch'
-        runBranch: 'refs/heads/master'
+        runBranch: 'refs/heads/$(BUILD_BRANCH)'
       displayName: "Download sonic-swss-common"
 
     - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -82,10 +82,10 @@ stages:
         runVersion: 'latestFromBranch'
         runBranch: 'refs/heads/$(BUILD_BRANCH)'
         patterns: |
-            target/debs/bookworm/libyang*.deb
-            target/debs/bookworm/libnl*.deb
-            target/python-wheels/bookworm/sonic_yang_models*.whl
-      displayName: "Download bookworm debs"
+            target/debs/bullseye/libyang*.deb
+            target/debs/bullseye/libnl*.deb
+            target/python-wheels/bullseye/sonic_yang_models*.whl
+      displayName: "Download bullseye debs"
 
     - script: |
         # PYTEST

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,7 +37,7 @@ stages:
     timeoutInMinutes: 60
 
     pool:
-      vmImage: ubuntu-20.04
+      vmImage: ubuntu-22.04
 
     variables:
       DIFF_COVER_CHECK_THRESHOLD: 80

--- a/gnmi_server/clientCertAuth.go
+++ b/gnmi_server/clientCertAuth.go
@@ -3,7 +3,6 @@ package gnmi
 import (
 	"strings"
 
-	"github.com/golang/glog"
 	"github.com/sonic-net/sonic-gnmi/common_utils"
 	"github.com/sonic-net/sonic-gnmi/swsscommon"
 	"github.com/golang/glog"

--- a/gnmi_server/clientCertAuth.go
+++ b/gnmi_server/clientCertAuth.go
@@ -1,6 +1,9 @@
 package gnmi
 
 import (
+	"strings"
+
+	"github.com/golang/glog"
 	"github.com/sonic-net/sonic-gnmi/common_utils"
 	"github.com/sonic-net/sonic-gnmi/swsscommon"
 	"github.com/golang/glog"
@@ -58,7 +61,11 @@ func PopulateAuthStructByCommonName(certCommonName string, auth *common_utils.Au
 
 	var fieldValuePairs = configDbConnector.Get_entry(serviceConfigTableName, certCommonName)
 	if fieldValuePairs.Size() > 0 {
-		if fieldValuePairs.Has_key("role") {
+		if fieldValuePairs.Has_key("role@") {
+			var role = fieldValuePairs.Get("role@")
+			auth.Roles = strings.Split(role, ",")
+		} else if fieldValuePairs.Has_key("role") {
+			// Backward compatibility for single role DB schema
 			var role = fieldValuePairs.Get("role")
 			auth.Roles = []string{role}
 		}

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -4267,35 +4267,6 @@ func TestClientCertAuthenAndAuthorMultiRole(t *testing.T) {
 	swsscommon.DeleteDBConnector(configDb)
 }
 
-func TestAuthenticate(t *testing.T) {
-	if !swsscommon.SonicDBConfigIsInit() {
-		swsscommon.SonicDBConfigInitialize()
-	}
-
-	var tableName = "GNMI_CLIENT_CERT"
-	var configDb = swsscommon.NewDBConnector("CONFIG_DB", uint(0), true)
-	var gnmiTable = swsscommon.NewTable(configDb, tableName)
-	defer swsscommon.DeleteTable(gnmiTable)
-	defer swsscommon.DeleteDBConnector(configDb)
-	configDb.Flushdb()
-
-	// initialize err variable
-	err := status.Error(codes.Unauthenticated, "")
-
-	// check a invalid role
-	cfg := &Config{ConfigTableName: tableName, UserAuth: AuthTypes{"password": false, "cert": true, "jwt": false}}
-	ctx, cancel := CreateAuthorizationCtx()
-	configDb.Flushdb()
-	gnmiTable.Hset("certname1", "role@", "readonly")
-	// Call authenticate to verify the user's role. This should fail if the role is "readonly".
-	_, err = authenticate(cfg, ctx)
-	if err == nil {
-		t.Errorf("authenticate with readonly role should fail: %v", err)
-	}
-
-	cancel()
-}
-
 type MockServerStream struct {
 	grpc.ServerStream
 }

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -4222,7 +4222,7 @@ func TestClientCertAuthenAndAuthorMultiRole(t *testing.T) {
 
 	// check auth with nil cert name
 	ctx, cancel := CreateAuthorizationCtx()
-	ctx, err = ClientCertAuthenAndAuthor(ctx, "", false)
+	ctx, err = ClientCertAuthenAndAuthor(ctx, "")
 	if err != nil {
 		t.Errorf("CommonNameMatch with empty config table should success: %v", err)
 	}
@@ -4233,7 +4233,7 @@ func TestClientCertAuthenAndAuthorMultiRole(t *testing.T) {
 	ctx, cancel = CreateAuthorizationCtx()
 	configDb.Flushdb()
 	gnmiTable.Hset("certname1", "role@", "readwrite")
-	ctx, err = ClientCertAuthenAndAuthor(ctx, "GNMI_CLIENT_CERT", false)
+	ctx, err = ClientCertAuthenAndAuthor(ctx, "GNMI_CLIENT_CERT")
 	if err != nil {
 		t.Errorf("CommonNameMatch with correct cert name should success: %v", err)
 	}
@@ -4245,7 +4245,7 @@ func TestClientCertAuthenAndAuthorMultiRole(t *testing.T) {
 	configDb.Flushdb()
 	gnmiTable.Hset("certname1", "role@", "readwrite")
 	gnmiTable.Hset("certname2", "role@", "readonly")
-	ctx, err = ClientCertAuthenAndAuthor(ctx, "GNMI_CLIENT_CERT", false)
+	ctx, err = ClientCertAuthenAndAuthor(ctx, "GNMI_CLIENT_CERT")
 	if err != nil {
 		t.Errorf("CommonNameMatch with correct cert name should success: %v", err)
 	}
@@ -4256,7 +4256,7 @@ func TestClientCertAuthenAndAuthorMultiRole(t *testing.T) {
 	ctx, cancel = CreateAuthorizationCtx()
 	configDb.Flushdb()
 	gnmiTable.Hset("certname2", "role@", "readonly")
-	ctx, err = ClientCertAuthenAndAuthor(ctx, "GNMI_CLIENT_CERT", false)
+	ctx, err = ClientCertAuthenAndAuthor(ctx, "GNMI_CLIENT_CERT")
 	if err == nil {
 		t.Errorf("CommonNameMatch with invalid cert name should fail: %v", err)
 	}


### PR DESCRIPTION
Add cert multiple roles support
This is cherry-pick PR for https://github.com/sonic-net/sonic-gnmi/pull/366

#### Why I did it
Some scenarios need GNMI support multiple roles

#### How I did it
Change CONFIG_DB schema and read multiple roles from CONFIG_DB

#### How to verify it
Manually test.
Add new UT.

#### Work item tracking
Microsoft ADO (number only): 31561802

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
Add cert multiple roles support

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

