### PR TITLE
Fix ZMQ lost data when connection break issue

### DIFF
--- a/sonic_data_client/mixed_db_client.go
+++ b/sonic_data_client/mixed_db_client.go
@@ -299,12 +299,12 @@ type ActionNeedRetry func() error
 func RetryHelper(zmqClient swsscommon.ZmqClient, action ActionNeedRetry) error {
 	var retry uint = 0
 	var retry_delay = time.Duration(RETRY_DELAY_MILLISECOND) * time.Millisecond
-	ConnectionResetErr := "zmq connection break"
-	ConnectionBreakErr := "Resource temporarily unavailable"
+	ConnectionBreakErr := "zmq connection break"
+	ConnectionUnavailableErr := "Resource temporarily unavailable"
 	for {
 		err := action()
 		if err != nil {
-			if strings.Contains(err.Error(), ConnectionResetErr) || strings.Contains(err.Error(), ConnectionBreakErr) {
+			if strings.Contains(err.Error(), ConnectionBreakErr) || strings.Contains(err.Error(), ConnectionUnavailableErr) {
 				if retry <= MAX_RETRY_COUNT {
 					log.V(6).Infof("RetryHelper: connection error: %v, reconnect and retry later", err)
 					time.Sleep(retry_delay)


### PR DESCRIPTION
Fix ZMQ lost data when connection break issue

#### Why I did it
Gnmi configuration fails for the first dash object when DPU is powered off and powered back on due to zmq connection.
This is because ZMQ is reconnecting and note set ZMQ_IMMEDIATE flag.

#### How I did it
Improve GNMI to handle ZMQ 'Resource temporarily unavailable' error and retry.

##### Work item tracking
- Microsoft ADO: 33995986

#### How to verify it
Pass all test cases.
Manually verify:
// shutdown ZMQ server side and call GNMI client:
2025 Jul 31 02:23:09.115524 vlab-01 INFO gnmi#supervisord: gnmi-native I0731 02:23:09.112746      24 mixed_db_client.go:1028] handleTableData: tblPath { APPL_DB DASH_VNET_TABLE  :  {"Vnet435": {"vni": "1000", "guid": "559c6ce8-26ab-4193-b946-ccc6e8f930b2"}}  -1 0    }
2025 Jul 31 02:23:09.116642 vlab-01 INFO gnmi#supervisord: gnmi-native I0731 02:23:09.112847      24 mixed_db_client.go:264] Create ZmqProducerStateTable:  DASH_VNET_TABLE

// ZMQ send will failed because server side unavailable:
2025 Jul 31 02:23:50.202213 vlab-01 INFO gnmi#supervisord: gnmi-native I0731 02:23:50.174643      24 mixed_db_client.go:309] RetryHelper: connection error: zmq send failed, endpoint: tcp://127.0.0.1:8100, zmqerrno: 11:Resource temporarily unavailable, msg length:149: Input/output error, reconnect and retry later

// start ZMQ server side, zmq send will retry and success:
2025 Jul 31 02:23:55.578090 vlab-01 INFO gnmi#supervisord: gnmi-native 2025/07/31 02:23:55 INFO: [transport] [server-transport 0xc0012e8180] Closing: EOF
2025 Jul 31 02:23:55.619753 vlab-01 INFO gnmi#supervisord: gnmi-native 2025/07/31 02:23:55 INFO: [transport] [server-transport 0xc0012e8180] loopyWriter exiting with error: transport closed by client

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
Fix ZMQ lost data when connection break issue

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

