### PR TITLE
Add SHOW implementation for interface transceiver error-status.

### DIFF
--- a/gnmi_server/interface_transceiver_cli_test.go
+++ b/gnmi_server/interface_transceiver_cli_test.go
@@ -91,7 +91,7 @@ func TestGetTransceiverErrorStatus(t *testing.T) {
 			pathTarget: "SHOW",
 			textPbPath: `
 				elem: <name: "interface"
-				       key: { key: "port" value: "Ethernet90" }>
+				       key: { key: "interfaces" value: "Ethernet90" }>
 				elem: <name: "transceiver" >
 				elem: <name: "error-status" >
 			`,

--- a/gnmi_server/interface_transceiver_cli_test.go
+++ b/gnmi_server/interface_transceiver_cli_test.go
@@ -1,0 +1,118 @@
+package gnmi
+
+// interface_transceiver_cli_test.go
+
+// Tests SHOW interface transceiver commands
+
+import (
+	"crypto/tls"
+	"testing"
+	"time"
+
+	pb "github.com/openconfig/gnmi/proto/gnmi"
+
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+)
+
+func TestGetTransceiverErrorStatus(t *testing.T) {
+	s := createServer(t, ServerPort)
+	go runServer(t, s)
+	defer s.ForceStop()
+	defer ResetDataSetsAndMappings(t)
+
+	tlsConfig := &tls.Config{InsecureSkipVerify: true}
+	opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
+
+	conn, err := grpc.Dial(TargetAddr, opts...)
+	if err != nil {
+		t.Fatalf("Dialing to %q failed: %v", TargetAddr, err)
+	}
+	defer conn.Close()
+
+	gClient := pb.NewGNMIClient(conn)
+	ctx, cancel := context.WithTimeout(context.Background(), QueryTimeout*time.Second)
+	defer cancel()
+
+	transceiverErrorStatusFileName := "../testdata/TRANSCEIVER_STATUS_SW.txt"
+	transceiverErrorStatus := `{"Ethernet90":{"cmis_state": "READY","error": "N/A","status": "1"},"Ethernet91": {"cmis_state": "READY","error": "N/A","status": "1"},"Ethernet92": {"cmis_state": "READY","error": "N/A","status": "1"},"Ethernet93": {"cmis_state": "READY","error": "N/A","status": "1"},"Ethernet94": {"cmis_state": "READY","error": "N/A","status": "1"},"Ethernet95": {"cmis_state": "READY","error": "N/A","status": "1"},"Ethernet96": {"cmis_state": "READY","error": "N/A","status": "1"},"Ethernet97": {"cmis_state": "READY","error": "N/A","status": "1"},"Ethernet98": {"cmis_state": "READY","error": "N/A","status": "1"},"Ethernet99": {"cmis_state": "READY","error": "N/A","status": "1"}}`
+	transceiverErrorStatusPort := `{"cmis_state": "READY","error": "N/A","status": "1"}`
+	ResetDataSetsAndMappings(t)
+
+	tests := []struct {
+		desc        string
+		pathTarget  string
+		textPbPath  string
+		wantRetCode codes.Code
+		wantRespVal interface{}
+		valTest     bool
+		testInit    func()
+	}{
+		{
+			desc:       "query SHOW interface transceiver error-status read error",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "" >
+				elem: <name: "transceiver" >
+				elem: <name: "error-status" >
+			`,
+			wantRetCode: codes.NotFound,
+		},
+		{
+			desc:       "query SHOW interface transceiver error-status NO interface dataset",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "interface" >
+				elem: <name: "transceiver" >
+				elem: <name: "error-status" >
+			`,
+			wantRetCode: codes.OK,
+		},
+		{
+			desc:       "query SHOW interface transceiver error-status",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "interface" >
+				elem: <name: "transceiver" >
+				elem: <name: "error-status" >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: []byte(transceiverErrorStatus),
+			valTest:     true,
+			testInit: func() {
+				FlushDataSet(t, StateDbNum)
+				AddDataSet(t, StateDbNum, transceiverErrorStatusFileName)
+			},
+		},
+		{
+			desc:       "query SHOW interface transceiver error-status port option",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "interface"
+				       key: { key: "port" value: "Ethernet90" }>
+				elem: <name: "transceiver" >
+				elem: <name: "error-status" >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: []byte(transceiverErrorStatusPort),
+			valTest:     true,
+			testInit: func() {
+				FlushDataSet(t, StateDbNum)
+				AddDataSet(t, StateDbNum, transceiverErrorStatusFileName)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		if test.testInit != nil {
+			test.testInit()
+		}
+
+		t.Run(test.desc, func(t *testing.T) {
+			runTestGet(t, ctx, gClient, test.pathTarget, test.textPbPath, test.wantRetCode, test.wantRespVal, test.valTest)
+		})
+
+	}
+}

--- a/gnmi_server/interface_transceiver_cli_test.go
+++ b/gnmi_server/interface_transceiver_cli_test.go
@@ -90,9 +90,9 @@ func TestGetTransceiverErrorStatus(t *testing.T) {
 			desc:       "query SHOW interface transceiver error-status port option",
 			pathTarget: "SHOW",
 			textPbPath: `
-				elem: <name: "interface" key: { key: "interface" value: "Ethernet90" }>
+				elem: <name: "interface" >
 				elem: <name: "transceiver" >
-				elem: <name: "error-status" >
+				elem: <name: "error-status" key: { key: "interface" value: "Ethernet90" }>
 			`,
 			wantRetCode: codes.OK,
 			wantRespVal: []byte(transceiverErrorStatusPort),

--- a/gnmi_server/interface_transceiver_cli_test.go
+++ b/gnmi_server/interface_transceiver_cli_test.go
@@ -90,7 +90,7 @@ func TestGetTransceiverErrorStatus(t *testing.T) {
 			desc:       "query SHOW interface transceiver error-status port option",
 			pathTarget: "SHOW",
 			textPbPath: `
-				elem: <name: "interface" key: { key: "interfaces" value: "Ethernet90" }>
+				elem: <name: "interface" key: { key: "interface" value: "Ethernet90" }>
 				elem: <name: "transceiver" >
 				elem: <name: "error-status" >
 			`,

--- a/gnmi_server/interface_transceiver_cli_test.go
+++ b/gnmi_server/interface_transceiver_cli_test.go
@@ -90,8 +90,7 @@ func TestGetTransceiverErrorStatus(t *testing.T) {
 			desc:       "query SHOW interface transceiver error-status port option",
 			pathTarget: "SHOW",
 			textPbPath: `
-				elem: <name: "interface"
-				       key: { key: "interfaces" value: "Ethernet90" }>
+				elem: <name: "interface" key: { key: "interfaces" value: "Ethernet90" }>
 				elem: <name: "transceiver" >
 				elem: <name: "error-status" >
 			`,

--- a/show_client/interface_transceiver_cli.go
+++ b/show_client/interface_transceiver_cli.go
@@ -2,7 +2,7 @@ package show_client
 
 import (
 	log "github.com/golang/glog"
-	gnmipb "github.com/openconfig/gnmi/proto/gnmi"
+	sdc "github.com/sonic-net/sonic-gnmi/sonic_data_client"
 )
 
 func getTransceiverErrorStatus(options sdc.OptionMap) ([]byte, error) {

--- a/show_client/interface_transceiver_cli.go
+++ b/show_client/interface_transceiver_cli.go
@@ -10,6 +10,7 @@ func getTransceiverErrorStatus(options sdc.OptionMap) ([]byte, error) {
 	if intf, ok := options["interface"].String(); ok {
 		intf = intf
 	}
+	log.Errorf("Get intf %v", intf)
 
 	var queries [][]string
 	if intf == "" {

--- a/show_client/interface_transceiver_cli.go
+++ b/show_client/interface_transceiver_cli.go
@@ -6,19 +6,19 @@ import (
 )
 
 func getTransceiverErrorStatus(options sdc.OptionMap) ([]byte, error) {
-	var intfs []string
-	if interfaces, ok := options["interfaces"].Strings(); ok {
-		intfs = interfaces
+	var intf string
+	if intf, ok := options["interface"].Strings(); ok {
+		intf = intf
 	}
 
 	var queries [][]string
-	if len(intfs) == 0 {
+	if intf == "" {
 		queries = [][]string{
 			{"STATE_DB", "TRANSCEIVER_STATUS_SW"},
 		}
 	} else {
 		queries = [][]string{
-			{"STATE_DB", "TRANSCEIVER_STATUS_SW", intfs[0]},
+			{"STATE_DB", "TRANSCEIVER_STATUS_SW", intf},
 		}
 	}
 

--- a/show_client/interface_transceiver_cli.go
+++ b/show_client/interface_transceiver_cli.go
@@ -1,0 +1,28 @@
+package show_client
+
+import (
+	log "github.com/golang/glog"
+	gnmipb "github.com/openconfig/gnmi/proto/gnmi"
+)
+
+func getTransceiverErrorStatus(prefix, path *gnmipb.Path) ([]byte, error) {
+	port := ParseOptionsFromPath(path, "port")
+
+	var queries [][]string
+	if len(port) == 0 {
+		queries = [][]string{
+			{"STATE_DB", "TRANSCEIVER_STATUS_SW"},
+		}
+	} else {
+		queries = [][]string{
+			{"STATE_DB", "TRANSCEIVER_STATUS_SW", port[0]},
+		}
+	}
+
+	data, err := GetDataFromQueries(queries)
+	if err != nil {
+		log.Errorf("Unable to get data from queries %v, got err: %v", queries, err)
+		return nil, err
+	}
+	return data, nil
+}

--- a/show_client/interface_transceiver_cli.go
+++ b/show_client/interface_transceiver_cli.go
@@ -7,10 +7,9 @@ import (
 
 func getTransceiverErrorStatus(options sdc.OptionMap) ([]byte, error) {
 	var intf string
-	if intf, ok := options["interface"].String(); ok {
-		intf = intf
+	if v, ok := options["interface"].String(); ok {
+		intf = v
 	}
-	log.Errorf("Get intf %v", intf)
 
 	var queries [][]string
 	if intf == "" {

--- a/show_client/interface_transceiver_cli.go
+++ b/show_client/interface_transceiver_cli.go
@@ -6,7 +6,7 @@ import (
 )
 
 func getTransceiverErrorStatus(options sdc.OptionMap) ([]byte, error) {
-	var ports string
+	var ports []string
 	if port, ok := options["port"].Strings(); ok {
 		ports = port
 	}
@@ -18,7 +18,7 @@ func getTransceiverErrorStatus(options sdc.OptionMap) ([]byte, error) {
 		}
 	} else {
 		queries = [][]string{
-			{"STATE_DB", "TRANSCEIVER_STATUS_SW", ports},
+			{"STATE_DB", "TRANSCEIVER_STATUS_SW", ports[0]},
 		}
 	}
 

--- a/show_client/interface_transceiver_cli.go
+++ b/show_client/interface_transceiver_cli.go
@@ -7,7 +7,7 @@ import (
 
 func getTransceiverErrorStatus(options sdc.OptionMap) ([]byte, error) {
 	var intfs []string
-	if interfaces, ok := options["interface"].Strings(); ok {
+	if interfaces, ok := options["interfaces"].Strings(); ok {
 		intfs = interfaces
 	}
 

--- a/show_client/interface_transceiver_cli.go
+++ b/show_client/interface_transceiver_cli.go
@@ -7,7 +7,7 @@ import (
 
 func getTransceiverErrorStatus(options sdc.OptionMap) ([]byte, error) {
 	var intf string
-	if intf, ok := options["interface"].Strings(); ok {
+	if intf, ok := options["interface"].String(); ok {
 		intf = intf
 	}
 

--- a/show_client/interface_transceiver_cli.go
+++ b/show_client/interface_transceiver_cli.go
@@ -5,17 +5,20 @@ import (
 	gnmipb "github.com/openconfig/gnmi/proto/gnmi"
 )
 
-func getTransceiverErrorStatus(prefix, path *gnmipb.Path) ([]byte, error) {
-	port := ParseOptionsFromPath(path, "port")
+func getTransceiverErrorStatus(options sdc.OptionMap) ([]byte, error) {
+	var ports string
+	if port, ok := options["port"].Strings(); ok {
+		ports = port
+	}
 
 	var queries [][]string
-	if len(port) == 0 {
+	if len(ports) == 0 {
 		queries = [][]string{
 			{"STATE_DB", "TRANSCEIVER_STATUS_SW"},
 		}
 	} else {
 		queries = [][]string{
-			{"STATE_DB", "TRANSCEIVER_STATUS_SW", port[0]},
+			{"STATE_DB", "TRANSCEIVER_STATUS_SW", ports},
 		}
 	}
 

--- a/show_client/interface_transceiver_cli.go
+++ b/show_client/interface_transceiver_cli.go
@@ -6,19 +6,19 @@ import (
 )
 
 func getTransceiverErrorStatus(options sdc.OptionMap) ([]byte, error) {
-	var ports []string
-	if port, ok := options["port"].Strings(); ok {
-		ports = port
+	var intfs []string
+	if interfaces, ok := options["interface"].Strings(); ok {
+		intfs = interfaces
 	}
 
 	var queries [][]string
-	if len(ports) == 0 {
+	if len(intfs) == 0 {
 		queries = [][]string{
 			{"STATE_DB", "TRANSCEIVER_STATUS_SW"},
 		}
 	} else {
 		queries = [][]string{
-			{"STATE_DB", "TRANSCEIVER_STATUS_SW", ports[0]},
+			{"STATE_DB", "TRANSCEIVER_STATUS_SW", intfs[0]},
 		}
 	}
 

--- a/show_client/show_paths.go
+++ b/show_client/show_paths.go
@@ -61,7 +61,7 @@ func init() {
 		getWatermarkTelemetryInterval,
 		nil,
 	)
-  sdc.RegisterCliPath(
+	sdc.RegisterCliPath(
 		[]string{"SHOW", "interface", "transceiver", "error-status"},
 		getTransceiverErrorStatus,
 		nil,

--- a/show_client/show_paths.go
+++ b/show_client/show_paths.go
@@ -56,4 +56,8 @@ func init() {
 		nil,
 		sdc.RequiredOption(showCmdOptionInterface),
 	)
+	sdc.RegisterCliPath(
+		[]string{"SHOW", "interface", "transceiver", "error-status"},
+		getTransceiverErrorStatus,
+	)
 }

--- a/show_client/show_paths.go
+++ b/show_client/show_paths.go
@@ -63,5 +63,6 @@ func init() {
 		showCmdOptionVerbose,
 		sdc.UnimplementedOption(showCmdOptionNamespace),
 		sdc.UnimplementedOption(showCmdOptionFetchFromHW),
+		showCmdOptionInterfaces,
 	)
 }

--- a/show_client/show_paths.go
+++ b/show_client/show_paths.go
@@ -68,6 +68,6 @@ func init() {
 		showCmdOptionVerbose,
 		sdc.UnimplementedOption(showCmdOptionNamespace),
 		sdc.UnimplementedOption(showCmdOptionFetchFromHW),
-		showCmdOptionInterfaces,
+		showCmdOptionInterface,
 	)
 }

--- a/show_client/show_paths.go
+++ b/show_client/show_paths.go
@@ -59,5 +59,9 @@ func init() {
 	sdc.RegisterCliPath(
 		[]string{"SHOW", "interface", "transceiver", "error-status"},
 		getTransceiverErrorStatus,
+		nil,
+		showCmdOptionVerbose,
+		sdc.UnimplementedOption(showCmdOptionNamespace),
+		sdc.UnimplementedOption(showCmdOptionFetchFromHW),
 	)
 }

--- a/testdata/TRANSCEIVER_STATUS_SW.txt
+++ b/testdata/TRANSCEIVER_STATUS_SW.txt
@@ -1,0 +1,53 @@
+{
+    "TRANSCEIVER_STATUS_SW|Ethernet90": {
+        "cmis_state": "READY",
+        "error": "N/A",
+        "status": "1"
+    },
+    "TRANSCEIVER_STATUS_SW|Ethernet91": {
+        "cmis_state": "READY",
+        "error": "N/A",
+        "status": "1"
+    },
+    "TRANSCEIVER_STATUS_SW|Ethernet92": {
+        "cmis_state": "READY",
+        "error": "N/A",
+        "status": "1"
+    },
+    "TRANSCEIVER_STATUS_SW|Ethernet93": {
+        "cmis_state": "READY",
+        "error": "N/A",
+        "status": "1"
+    },
+    "TRANSCEIVER_STATUS_SW|Ethernet94": {
+        "cmis_state": "READY",
+        "error": "N/A",
+        "status": "1"
+    },
+    "TRANSCEIVER_STATUS_SW|Ethernet95": {
+        "cmis_state": "READY",
+        "error": "N/A",
+        "status": "1"
+    },
+    "TRANSCEIVER_STATUS_SW|Ethernet96": {
+        "cmis_state": "READY",
+        "error": "N/A",
+        "status": "1"
+    },
+    "TRANSCEIVER_STATUS_SW|Ethernet97": {
+        "cmis_state": "READY",
+        "error": "N/A",
+        "status": "1"
+    },
+    "TRANSCEIVER_STATUS_SW|Ethernet98": {
+        "cmis_state": "READY",
+        "error": "N/A",
+        "status": "1"
+    },
+    "TRANSCEIVER_STATUS_SW|Ethernet99": {
+        "cmis_state": "READY",
+        "error": "N/A",
+        "status": "1"
+    }
+}
+


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Add support for SHOW interface tansceiver error-status

This PR will add the implementation of a new data path "SHOW" that will allow clients to query PATHS similar to show commands that are executed on the host.

In this PR we are focusing on the implementation of show interface tansceiver error-status in telemetry such that the following paths are supported. SHOW/interface/transceiver/error-status

#### How I did it

Added a new SHOW client that supports GET operations only and can support DB reads.

#### How to verify it

UT and manually run

```
root@str5-7060x6-512-5:/# gnmi_get -xpath_target SHOW -xpath interface/transceiver/error-status -target_addr 127.0.0.1:50051 -logtostderr -insecure true
== getRequest:
prefix: <
  target: "SHOW"
>
path: <
  elem: <
    name: "interface"
  >
  elem: <
    name: "transceiver"
  >
  elem: <
    name: "error-status"
  >
>
encoding: JSON_IETF

== getResponse:
notification: <
  timestamp: 1754380344230707564
  prefix: <
    target: "SHOW"
  >
  update: <
    path: <
      elem: <
        name: "interface"
      >
      elem: <
        name: "transceiver"
      >
      elem: <
        name: "error-status"
      >
    >
    val: <
      json_ietf_val: "{\"Ethernet0\":{\"cmis_state\":\"READY\",\"error\":\"N/A\",\"status\":\"1\"},\"Ethernet1\":{\"cmis_state\":\"READY\",\"error\":\"N/A\",\"status\":\"1\"},\"Ethernet10\":{\"cmis_state\":\"READY\",\"error\":\"N/A\",\"status\":\"1\"},\"Ethernet100\":{\"cmis_state\":\"READY\",\"error\":\"N/A\",\"status\":\"1\"},\"Ethernet101\":{\"cmis_state\":\"READY\",\"error\":\"N/A\",\"status\":\"1\"},\"Ethernet102\":{\"cmis_state\":\"READY\",\"error\":\"N/A\",\"status\":\"1\"},\"Ethernet103\":{\"cmis_state\":\"READY\",\"error\":\"N/A\",\"status\":\"1\"},\"Ethernet104\":{\"cmis_state\":\"READY\",\"error\":\"N/A\",\"status\":\"1\"},\"Ethernet105\":{\"cmis_state\":\"READY\",\"error\":\"N/A\",\"status\":\"1\"},\"Ethernet106\":{\"cmis_state\":\"READY\",\"error\":\"N/A\",\"status\":\"1\"}.......}"
    >
  >
>

```

```
root@str5-7060x6-512-5:/# gnmi_get -xpath_target SHOW -xpath interface[port=Ethernet68]/transceiver/error-status -target_addr 127.0.0.1:50051 -logtostderr -insecure true
== getRequest:
prefix: <
  target: "SHOW"
>
path: <
  elem: <
    name: "interface"
    key: <
      key: "port"
      value: "Ethernet68"
    >
  >
  elem: <
    name: "transceiver"
  >
  elem: <
    name: "error-status"
  >
>
encoding: JSON_IETF

== getResponse:
notification: <
  timestamp: 1754534213959768489
  prefix: <
    target: "SHOW"
  >
  update: <
    path: <
      elem: <
        name: "interface"
        key: <
          key: "port"
          value: "Ethernet68"
        >
      >
      elem: <
        name: "transceiver"
      >
      elem: <
        name: "error-status"
      >
    >
    val: <
      json_ietf_val: "{\"cmis_state\":\"READY\",\"error\":\"N/A\",\"status\":\"1\"}"
    >
  >
>
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

