### PR TITLE
Implement `show chassis module status`

### DIFF
--- a/gnmi_server/chassis_module_cli_test.go
+++ b/gnmi_server/chassis_module_cli_test.go
@@ -16,8 +16,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
-
-	show_client "github.com/sonic-net/sonic-gnmi/show_client"
 )
 
 // ModuleFixture represents a test module with all its properties
@@ -221,81 +219,4 @@ func TestGetShowChassisModuleStatus(t *testing.T) {
 			runTestGet(t, ctx, gClient, test.pathTarget, test.textPbPath, test.wantRetCode, test.wantRespVal, test.valTest)
 		})
 	}
-}
-
-func TestChassisModuleHelperFunctions(t *testing.T) {
-	// Test helper functions directly for better coverage
-
-	// Test CreateChassisModuleQueries
-	t.Run("CreateChassisModuleQueries - all modules", func(t *testing.T) {
-		queries := show_client.CreateChassisModuleQueries("")
-		if len(queries.State) != 1 || len(queries.Config) != 1 {
-			t.Error("Expected one query each for state and config")
-		}
-		if queries.State[0][1] != "CHASSIS_MODULE_TABLE" {
-			t.Error("Expected CHASSIS_MODULE_TABLE in state query")
-		}
-		if queries.Config[0][1] != "CHASSIS_MODULE" {
-			t.Error("Expected CHASSIS_MODULE in config query")
-		}
-	})
-
-	t.Run("CreateChassisModuleQueries - specific module", func(t *testing.T) {
-		queries := show_client.CreateChassisModuleQueries("DPU1")
-		if len(queries.State[0]) != 3 || queries.State[0][2] != "DPU1" {
-			t.Error("Expected module name in state query")
-		}
-		if len(queries.Config[0]) != 3 || queries.Config[0][2] != "DPU1" {
-			t.Error("Expected module name in config query")
-		}
-	})
-
-	// Test CreateModuleStatusFromFlatData
-	t.Run("CreateModuleStatusFromFlatData", func(t *testing.T) {
-		stateData := map[string]interface{}{
-			"desc":        "Test Description",
-			"slot":        "Slot1",
-			"oper_status": "Online",
-			"serial":      "TEST123",
-		}
-
-		configData := map[string]interface{}{
-			"admin_status": "down",
-		}
-
-		module := show_client.CreateModuleStatusFromFlatData("DPU1", stateData, configData)
-
-		if module.Name != "DPU1" {
-			t.Errorf("Expected name DPU1, got %s", module.Name)
-		}
-		if module.Description != "Test Description" {
-			t.Errorf("Expected description 'Test Description', got %s", module.Description)
-		}
-		if module.AdminStatus != "down" {
-			t.Errorf("Expected admin_status 'down', got %s", module.AdminStatus)
-		}
-		if module.OperStatus != "Online" {
-			t.Errorf("Expected oper_status 'Online', got %s", module.OperStatus)
-		}
-		if module.Serial != "TEST123" {
-			t.Errorf("Expected serial 'TEST123', got %s", module.Serial)
-		}
-		if module.Slot != "Slot1" {
-			t.Errorf("Expected slot 'Slot1', got %s", module.Slot)
-		}
-	})
-
-	t.Run("CreateModuleStatusFromFlatData - defaults", func(t *testing.T) {
-		stateData := map[string]interface{}{}
-		configData := map[string]interface{}{}
-
-		module := show_client.CreateModuleStatusFromFlatData("DPU1", stateData, configData)
-
-		if module.AdminStatus != "up" {
-			t.Errorf("Expected default admin_status 'up', got %s", module.AdminStatus)
-		}
-		if module.Slot != "N/A" {
-			t.Errorf("Expected default slot 'N/A', got %s", module.Slot)
-		}
-	})
 }

--- a/gnmi_server/chassis_module_cli_test.go
+++ b/gnmi_server/chassis_module_cli_test.go
@@ -119,7 +119,7 @@ func TestGetShowChassisModuleStatus(t *testing.T) {
 				elem: <name: "module" >
 				elem: <name: "status" key: <key: "dpu" value: "DPU99" > >
 			`,
-			wantRetCode: codes.OK,
+			wantRetCode: codes.NotFound,
 			testInit: func() {
 				AddDataSet(t, StateDbNum, "../testdata/CHASSIS_MODULE_STATE.txt")
 				AddDataSet(t, ConfigDbNum, "../testdata/CHASSIS_MODULE_CONFIG.txt")

--- a/gnmi_server/chassis_module_cli_test.go
+++ b/gnmi_server/chassis_module_cli_test.go
@@ -1,0 +1,229 @@
+package gnmi
+
+// chassis_module_cli_test.go
+
+// Tests SHOW chassis module status and SHOW chassis module status [dpu=DPU_NAME]
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"testing"
+	"time"
+
+	pb "github.com/openconfig/gnmi/proto/gnmi"
+
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+
+	show_client "github.com/sonic-net/sonic-gnmi/show_client"
+)
+
+func TestGetShowChassisModuleStatus(t *testing.T) {
+	s := createServer(t, ServerPort)
+	go runServer(t, s)
+	defer s.ForceStop()
+	defer ResetDataSetsAndMappings(t)
+
+	tlsConfig := &tls.Config{InsecureSkipVerify: true}
+	opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
+
+	conn, err := grpc.Dial(TargetAddr, opts...)
+	if err != nil {
+		t.Fatalf("Dialing to %q failed: %v", TargetAddr, err)
+	}
+	defer conn.Close()
+
+	gClient := pb.NewGNMIClient(conn)
+	ctx, cancel := context.WithTimeout(context.Background(), QueryTimeout*time.Second)
+	defer cancel()
+
+	// Expected JSON response for all modules
+	expectedAllModules := `{"DPU0":{"admin_status":"up","desc":"AMD Pensando DSC","oper_status":"Online","serial":"FLM29100D70-0","slot":"N/A","state_transition_in_progress":"False","transition_start_time":"2025-08-14T03:46:19.891919"},"DPU1":{"admin_status":"up","desc":"AMD Pensando DSC","oper_status":"Online","serial":"FLM29100D70-1","slot":"N/A","state_transition_in_progress":"False"},"DPU2":{"admin_status":"up","desc":"AMD Pensando DSC","oper_status":"Online","serial":"FLM29100D6U-0","slot":"N/A","state_transition_in_progress":"False"},"DPU3":{"admin_status":"down","desc":"AMD Pensando DSC","oper_status":"Online","serial":"FLM29100D6U-1","slot":"N/A","state_transition_in_progress":"False"}}`
+
+	// Expected JSON response for single module DPU1
+	expectedSingleModule := map[string]interface{}{
+		"DPU1": map[string]interface{}{
+			"name":          "DPU1",
+			"description":   "AMD Pensando DSC",
+			"physical_slot": "N/A",
+			"oper_status":   "Online",
+			"admin_status":  "up",
+			"serial":        "FLM29100D70-1",
+		},
+	}
+	expectedSingleModuleBytes, _ := json.MarshalIndent(expectedSingleModule, "", "  ")
+
+	ResetDataSetsAndMappings(t)
+
+	tests := []struct {
+		desc        string
+		pathTarget  string
+		textPbPath  string
+		wantRetCode codes.Code
+		wantRespVal interface{}
+		valTest     bool
+		testInit    func()
+	}{
+		{
+			desc:       "query SHOW chassis module status - no data",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "chassis" >
+				elem: <name: "module" >
+				elem: <name: "status" >
+			`,
+			wantRetCode: codes.OK,
+			valTest:     false,
+		},
+		{
+			desc:       "query SHOW chassis module status - all modules",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "chassis" >
+				elem: <name: "module" >
+				elem: <name: "status" >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: []byte(expectedAllModules),
+			valTest:     true,
+			testInit: func() {
+				AddDataSet(t, StateDbNum, "../testdata/CHASSIS_MODULE_STATE.txt")
+				AddDataSet(t, ConfigDbNum, "../testdata/CHASSIS_MODULE_CONFIG.txt")
+			},
+		},
+		{
+			desc:       "query SHOW chassis module status [dpu=DPU1] - specific module",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "chassis" >
+				elem: <name: "module" >
+				elem: <name: "status" key: <key: "dpu" value: "DPU1" > >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: expectedSingleModuleBytes,
+			valTest:     true,
+			testInit: func() {
+				FlushDataSet(t, StateDbNum)
+				FlushDataSet(t, ConfigDbNum)
+				AddDataSet(t, StateDbNum, "../testdata/CHASSIS_MODULE_STATE.txt")
+				AddDataSet(t, ConfigDbNum, "../testdata/CHASSIS_MODULE_CONFIG.txt")
+			},
+		},
+		{
+			desc:       "query SHOW chassis module status [dpu=DPU99] - module not found",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "chassis" >
+				elem: <name: "module" >
+				elem: <name: "status" key: <key: "dpu" value: "DPU99" > >
+			`,
+			wantRetCode: codes.OK,
+			testInit: func() {
+				AddDataSet(t, StateDbNum, "../testdata/CHASSIS_MODULE_STATE.txt")
+				AddDataSet(t, ConfigDbNum, "../testdata/CHASSIS_MODULE_CONFIG.txt")
+			},
+		},
+		{
+			desc:       "query SHOW chassis module status [dpu=] - empty dpu name",
+			pathTarget: "SHOW",
+			textPbPath: `
+				elem: <name: "chassis" >
+				elem: <name: "module" >
+				elem: <name: "status" key: <key: "dpu" value: "" > >
+			`,
+			wantRetCode: codes.InvalidArgument,
+			testInit: func() {
+				AddDataSet(t, StateDbNum, "../testdata/CHASSIS_MODULE_STATE.txt")
+				AddDataSet(t, ConfigDbNum, "../testdata/CHASSIS_MODULE_CONFIG.txt")
+			},
+		},
+	}
+
+	for _, test := range tests {
+		if test.testInit != nil {
+			test.testInit()
+		}
+		t.Run(test.desc, func(t *testing.T) {
+			runTestGet(t, ctx, gClient, test.pathTarget, test.textPbPath, test.wantRetCode, test.wantRespVal, test.valTest)
+		})
+	}
+}
+
+func TestChassisModuleHelperFunctions(t *testing.T) {
+	// Test helper functions directly for better coverage
+
+	// Test CreateChassisModuleQueries
+	t.Run("CreateChassisModuleQueries - all modules", func(t *testing.T) {
+		queries := show_client.CreateChassisModuleQueries("")
+		if len(queries.State) != 1 || len(queries.Config) != 1 {
+			t.Error("Expected one query each for state and config")
+		}
+		if queries.State[0][1] != "CHASSIS_MODULE_TABLE" {
+			t.Error("Expected CHASSIS_MODULE_TABLE in state query")
+		}
+		if queries.Config[0][1] != "CHASSIS_MODULE" {
+			t.Error("Expected CHASSIS_MODULE in config query")
+		}
+	})
+
+	t.Run("CreateChassisModuleQueries - specific module", func(t *testing.T) {
+		queries := show_client.CreateChassisModuleQueries("DPU1")
+		if len(queries.State[0]) != 3 || queries.State[0][2] != "DPU1" {
+			t.Error("Expected module name in state query")
+		}
+		if len(queries.Config[0]) != 3 || queries.Config[0][2] != "DPU1" {
+			t.Error("Expected module name in config query")
+		}
+	})
+
+	// Test CreateModuleStatusFromFlatData
+	t.Run("CreateModuleStatusFromFlatData", func(t *testing.T) {
+		stateData := map[string]interface{}{
+			"desc":        "Test Description",
+			"slot":        "Slot1",
+			"oper_status": "Online",
+			"serial":      "TEST123",
+		}
+
+		configData := map[string]interface{}{
+			"admin_status": "down",
+		}
+
+		module := show_client.CreateModuleStatusFromFlatData("DPU1", stateData, configData)
+
+		if module.Name != "DPU1" {
+			t.Errorf("Expected name DPU1, got %s", module.Name)
+		}
+		if module.Description != "Test Description" {
+			t.Errorf("Expected description 'Test Description', got %s", module.Description)
+		}
+		if module.AdminStatus != "down" {
+			t.Errorf("Expected admin_status 'down', got %s", module.AdminStatus)
+		}
+		if module.OperStatus != "Online" {
+			t.Errorf("Expected oper_status 'Online', got %s", module.OperStatus)
+		}
+		if module.Serial != "TEST123" {
+			t.Errorf("Expected serial 'TEST123', got %s", module.Serial)
+		}
+		if module.Slot != "Slot1" {
+			t.Errorf("Expected slot 'Slot1', got %s", module.Slot)
+		}
+	})
+
+	t.Run("CreateModuleStatusFromFlatData - defaults", func(t *testing.T) {
+		stateData := map[string]interface{}{}
+		configData := map[string]interface{}{}
+
+		module := show_client.CreateModuleStatusFromFlatData("DPU1", stateData, configData)
+
+		if module.AdminStatus != "up" {
+			t.Errorf("Expected default admin_status 'up', got %s", module.AdminStatus)
+		}
+		if module.Slot != "N/A" {
+			t.Errorf("Expected default slot 'N/A', got %s", module.Slot)
+		}
+	})
+}

--- a/show_client/chassis_module_cli.go
+++ b/show_client/chassis_module_cli.go
@@ -179,8 +179,13 @@ func getChassisModuleStatusByModule(moduleName string) ([]byte, error) {
 		return nil, err
 	}
 
-	// Check if the module exists in state data
+	// For specific module queries, the database should return flat data directly
+	// If no "desc" field exists, the module doesn't exist
 	if len(stateData) == 0 {
+		return nil, status.Errorf(codes.NotFound, "module %s not found", moduleName)
+	}
+
+	if _, hasDesc := stateData["desc"]; !hasDesc {
 		return nil, status.Errorf(codes.NotFound, "module %s not found", moduleName)
 	}
 

--- a/show_client/chassis_module_cli.go
+++ b/show_client/chassis_module_cli.go
@@ -1,0 +1,253 @@
+package show_client
+
+import (
+	"encoding/json"
+	"fmt"
+
+	log "github.com/golang/glog"
+	sdc "github.com/sonic-net/sonic-gnmi/sonic_data_client"
+)
+
+type ChassisModuleStatus struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Slot        string `json:"physical_slot"`
+	OperStatus  string `json:"oper_status"`
+	AdminStatus string `json:"admin_status"`
+	Serial      string `json:"serial"`
+}
+
+func getChassisModuleStatus(options sdc.OptionMap) ([]byte, error) {
+	log.V(2).Infof("getChassisModuleStatus: called with options: %v", getOptionsKeys(options))
+
+	// Check if a specific module is requested
+	if moduleStr, ok := options["dpu"].String(); ok {
+		log.V(2).Infof("getChassisModuleStatus: filtering for module: %s", moduleStr)
+		return getChassisModuleStatusByModule(options)
+	}
+
+	// Original logic for all modules
+	log.V(2).Infof("getChassisModuleStatus: getting all modules")
+
+	// Query both STATE_DB and CONFIG_DB
+	stateQueries := [][]string{
+		{"STATE_DB", "CHASSIS_MODULE_TABLE"},
+	}
+
+	configQueries := [][]string{
+		{"CONFIG_DB", "CHASSIS_MODULE"},
+	}
+
+	// Get data from both databases
+	stateData, err := GetDataFromQueries(stateQueries)
+	if err != nil {
+		log.V(2).Infof("getChassisModuleStatus: error getting state data: %v", err)
+		return nil, err
+	}
+
+	configData, err := GetDataFromQueries(configQueries)
+	if err != nil {
+		log.V(2).Infof("getChassisModuleStatus: error getting config data: %v", err)
+		return nil, err
+	}
+
+	log.V(2).Infof("getChassisModuleStatus: state data: %s", string(stateData))
+	log.V(2).Infof("getChassisModuleStatus: config data: %s", string(configData))
+
+	// Parse the JSON data
+	var stateMap map[string]interface{}
+	if err := json.Unmarshal(stateData, &stateMap); err != nil {
+		log.V(2).Infof("getChassisModuleStatus: error unmarshaling state data: %v", err)
+		return nil, err
+	}
+
+	var configMap map[string]interface{}
+	if err := json.Unmarshal(configData, &configMap); err != nil {
+		log.V(2).Infof("getChassisModuleStatus: error unmarshaling config data: %v", err)
+		return nil, err
+	}
+
+	// Merge the data
+	result := make(map[string]interface{})
+	for moduleName, stateInfo := range stateMap {
+		if stateInfoMap, ok := stateInfo.(map[string]interface{}); ok {
+			result[moduleName] = stateInfoMap
+
+			// Add admin_status from CONFIG_DB if available
+			if configInfo, exists := configMap[moduleName]; exists {
+				if configInfoMap, ok := configInfo.(map[string]interface{}); ok {
+					if adminStatus, hasAdmin := configInfoMap["admin_status"]; hasAdmin {
+						result[moduleName].(map[string]interface{})["admin_status"] = adminStatus
+					}
+				}
+			}
+		}
+	}
+
+	// Convert to JSON
+	jsonData, err := json.Marshal(result)
+	if err != nil {
+		log.V(2).Infof("getChassisModuleStatus: error marshaling result: %v", err)
+		return nil, err
+	}
+
+	log.V(2).Infof("getChassisModuleStatus: returning: %s", string(jsonData))
+	return jsonData, nil
+}
+
+func getChassisModuleStatusByModule(options sdc.OptionMap) ([]byte, error) {
+	// Extract module name from the path
+	// The path will be like ["SHOW", "chassis", "module", "status", "DPU0"]
+	// We need to get the last element which is the module name
+	moduleName := ""
+
+	// Try different ways to get the module name from the path
+	if moduleStr, ok := options["dpu"].String(); ok {
+		moduleName = moduleStr
+		log.V(2).Infof("getChassisModuleStatusByModule: module from dpu option: %s", moduleName)
+	} else {
+		// Try to get from the path elements
+		log.V(2).Infof("getChassisModuleStatusByModule: options keys: %v", getOptionsKeys(options))
+		return nil, fmt.Errorf("No module name specified in path")
+	}
+
+	if moduleName == "" {
+		return nil, fmt.Errorf("Empty module name")
+	}
+
+	log.V(2).Infof("getChassisModuleStatusByModule: processing module: %s", moduleName)
+
+	// Query both STATE_DB and CONFIG_DB for the specific module
+	stateQueries := [][]string{
+		{"STATE_DB", "CHASSIS_MODULE_TABLE", moduleName},
+	}
+
+	configQueries := [][]string{
+		{"CONFIG_DB", "CHASSIS_MODULE", moduleName},
+	}
+
+	log.V(2).Infof("getChassisModuleStatusByModule: state queries: %v", stateQueries)
+	log.V(2).Infof("getChassisModuleStatusByModule: config queries: %v", configQueries)
+
+	// Get state data
+	stateDataBytes, err := GetDataFromQueries(stateQueries)
+	if err != nil {
+		log.Errorf("Unable to get state data from queries %v, got err: %v", stateQueries, err)
+		return nil, err
+	}
+	log.V(2).Infof("getChassisModuleStatusByModule: state data bytes: %s", string(stateDataBytes))
+
+	// Get config data
+	configDataBytes, err := GetDataFromQueries(configQueries)
+	if err != nil {
+		log.Errorf("Unable to get config data from queries %v, got err: %v", configQueries, err)
+		return nil, err
+	}
+	log.V(2).Infof("getChassisModuleStatusByModule: config data bytes: %s", string(configDataBytes))
+
+	// Parse the JSON data
+	var stateData map[string]interface{}
+	if err := json.Unmarshal(stateDataBytes, &stateData); err != nil {
+		log.Errorf("Failed to unmarshal state data: %v", err)
+		return nil, err
+	}
+
+	var configData map[string]interface{}
+	if err := json.Unmarshal(configDataBytes, &configData); err != nil {
+		log.Errorf("Failed to unmarshal config data: %v", err)
+		return nil, err
+	}
+
+	// Check if the module exists in state data
+	if len(stateData) == 0 {
+		return nil, fmt.Errorf("Module %s not found", moduleName)
+	}
+
+	// Process the data for the specific module
+	result := make(map[string]interface{})
+	moduleStatusMap := make(map[string]ChassisModuleStatus)
+
+	// Process STATE_DB data - when querying specific module, data is returned as flat structure
+	log.V(2).Infof("getChassisModuleStatusByModule: processing state data with keys: %v", getMapKeys(stateData))
+
+	// For specific module queries, the data is returned as flat structure, not nested
+	module := ChassisModuleStatus{
+		Name:        moduleName,
+		AdminStatus: "up",  // Default value
+		Slot:        "N/A", // Default value
+	}
+
+	// Process the flat state data structure
+	for key, value := range stateData {
+		log.V(2).Infof("getChassisModuleStatusByModule: processing state key: %s", key)
+		if strValue, ok := value.(string); ok {
+			switch key {
+			case "desc":
+				module.Description = strValue
+			case "slot":
+				module.Slot = strValue
+			case "oper_status":
+				module.OperStatus = strValue
+			case "serial":
+				module.Serial = strValue
+			}
+		}
+	}
+
+	moduleStatusMap[moduleName] = module
+	log.V(2).Infof("getChassisModuleStatusByModule: added module %s: %+v", moduleName, module)
+
+	// Process CONFIG_DB data to get admin_status - also flat structure
+	log.V(2).Infof("getChassisModuleStatusByModule: processing config data with keys: %v", getMapKeys(configData))
+	for key, value := range configData {
+		log.V(2).Infof("getChassisModuleStatusByModule: processing config key: %s", key)
+		if strValue, ok := value.(string); ok {
+			if key == "admin_status" {
+				if existingModule, exists := moduleStatusMap[moduleName]; exists {
+					existingModule.AdminStatus = strValue
+					moduleStatusMap[moduleName] = existingModule
+					log.V(2).Infof("getChassisModuleStatusByModule: updated admin_status for module %s: %s", moduleName, strValue)
+				}
+			}
+		}
+	}
+
+	log.V(2).Infof("getChassisModuleStatusByModule: moduleStatusMap has %d modules", len(moduleStatusMap))
+
+	// Return the specific module
+	if module, exists := moduleStatusMap[moduleName]; exists {
+		result[moduleName] = module
+		log.V(2).Infof("getChassisModuleStatusByModule: returning module %s", moduleName)
+	} else {
+		log.V(2).Infof("getChassisModuleStatusByModule: module %s not found in moduleStatusMap", moduleName)
+		return nil, fmt.Errorf("Module %s not found", moduleName)
+	}
+
+	// Convert to JSON bytes
+	jsonBytes, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		log.Errorf("Failed to marshal chassis module status data: %v", err)
+		return nil, err
+	}
+
+	log.V(4).Infof("getChassisModuleStatusByModule, output: %v", string(jsonBytes))
+	return jsonBytes, nil
+}
+
+// Helper function to get map keys for debugging
+func getMapKeys(m map[string]interface{}) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+// Helper function to get options keys for debugging
+func getOptionsKeys(options sdc.OptionMap) []string {
+	keys := make([]string, 0)
+	for k := range options {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/show_client/chassis_module_cli.go
+++ b/show_client/chassis_module_cli.go
@@ -143,8 +143,24 @@ func getChassisModuleStatus(options sdc.OptionMap) ([]byte, error) {
 			continue
 		}
 
-		result[moduleName] = stateInfoMap
+		// Filter state data to only include expected fields
+		filteredState := make(map[string]interface{})
+		if desc, exists := stateInfoMap["desc"]; exists {
+			filteredState["desc"] = desc
+		}
+		if operStatus, exists := stateInfoMap["oper_status"]; exists {
+			filteredState["oper_status"] = operStatus
+		}
+		if serial, exists := stateInfoMap["serial"]; exists {
+			filteredState["serial"] = serial
+		}
+		if slot, exists := stateInfoMap["slot"]; exists {
+			filteredState["slot"] = slot
+		}
 
+		result[moduleName] = filteredState
+
+		// Add admin_status from CONFIG_DB if available
 		configInfo, exists := configData[moduleName]
 		if !exists {
 			continue
@@ -156,11 +172,9 @@ func getChassisModuleStatus(options sdc.OptionMap) ([]byte, error) {
 		}
 
 		adminStatus, hasAdmin := configInfoMap["admin_status"]
-		if !hasAdmin {
-			continue
+		if hasAdmin {
+			filteredState["admin_status"] = adminStatus
 		}
-
-		stateInfoMap["admin_status"] = adminStatus
 	}
 
 	// Convert to JSON

--- a/show_client/chassis_module_cli.go
+++ b/show_client/chassis_module_cli.go
@@ -8,6 +8,15 @@ import (
 	sdc "github.com/sonic-net/sonic-gnmi/sonic_data_client"
 )
 
+const (
+	stateDB            = "STATE_DB"
+	configDB           = "CONFIG_DB"
+	chassisModuleTable = "CHASSIS_MODULE_TABLE"
+	chassisModule      = "CHASSIS_MODULE"
+	defaultAdminStatus = "up"
+	defaultSlot        = "N/A"
+)
+
 type ChassisModuleStatus struct {
 	Name        string `json:"name"`
 	Description string `json:"description"`
@@ -17,169 +26,72 @@ type ChassisModuleStatus struct {
 	Serial      string `json:"serial"`
 }
 
-func getChassisModuleStatus(options sdc.OptionMap) ([]byte, error) {
-	log.V(2).Infof("getChassisModuleStatus: called with options: %v", getOptionsKeys(options))
-
-	// Check if a specific module is requested
-	if moduleStr, ok := options["dpu"].String(); ok {
-		log.V(2).Infof("getChassisModuleStatus: filtering for module: %s", moduleStr)
-		return getChassisModuleStatusByModule(options)
-	}
-
-	// Original logic for all modules
-	log.V(2).Infof("getChassisModuleStatus: getting all modules")
-
-	// Query both STATE_DB and CONFIG_DB
-	stateQueries := [][]string{
-		{"STATE_DB", "CHASSIS_MODULE_TABLE"},
-	}
-
-	configQueries := [][]string{
-		{"CONFIG_DB", "CHASSIS_MODULE"},
-	}
-
-	// Get data from both databases
-	stateData, err := GetDataFromQueries(stateQueries)
-	if err != nil {
-		log.V(2).Infof("getChassisModuleStatus: error getting state data: %v", err)
-		return nil, err
-	}
-
-	configData, err := GetDataFromQueries(configQueries)
-	if err != nil {
-		log.V(2).Infof("getChassisModuleStatus: error getting config data: %v", err)
-		return nil, err
-	}
-
-	log.V(2).Infof("getChassisModuleStatus: state data: %s", string(stateData))
-	log.V(2).Infof("getChassisModuleStatus: config data: %s", string(configData))
-
-	// Parse the JSON data
-	var stateMap map[string]interface{}
-	if err := json.Unmarshal(stateData, &stateMap); err != nil {
-		log.V(2).Infof("getChassisModuleStatus: error unmarshaling state data: %v", err)
-		return nil, err
-	}
-
-	var configMap map[string]interface{}
-	if err := json.Unmarshal(configData, &configMap); err != nil {
-		log.V(2).Infof("getChassisModuleStatus: error unmarshaling config data: %v", err)
-		return nil, err
-	}
-
-	// Merge the data
-	result := make(map[string]interface{})
-	for moduleName, stateInfo := range stateMap {
-		if stateInfoMap, ok := stateInfo.(map[string]interface{}); ok {
-			result[moduleName] = stateInfoMap
-
-			// Add admin_status from CONFIG_DB if available
-			if configInfo, exists := configMap[moduleName]; exists {
-				if configInfoMap, ok := configInfo.(map[string]interface{}); ok {
-					if adminStatus, hasAdmin := configInfoMap["admin_status"]; hasAdmin {
-						result[moduleName].(map[string]interface{})["admin_status"] = adminStatus
-					}
-				}
-			}
-		}
-	}
-
-	// Convert to JSON
-	jsonData, err := json.Marshal(result)
-	if err != nil {
-		log.V(2).Infof("getChassisModuleStatus: error marshaling result: %v", err)
-		return nil, err
-	}
-
-	log.V(2).Infof("getChassisModuleStatus: returning: %s", string(jsonData))
-	return jsonData, nil
+// Database query helper
+type dbQueries struct {
+	state  [][]string
+	config [][]string
 }
 
-func getChassisModuleStatusByModule(options sdc.OptionMap) ([]byte, error) {
-	// Extract module name from the path
-	// The path will be like ["SHOW", "chassis", "module", "status", "DPU0"]
-	// We need to get the last element which is the module name
-	moduleName := ""
-
-	// Try different ways to get the module name from the path
-	if moduleStr, ok := options["dpu"].String(); ok {
-		moduleName = moduleStr
-		log.V(2).Infof("getChassisModuleStatusByModule: module from dpu option: %s", moduleName)
-	} else {
-		// Try to get from the path elements
-		log.V(2).Infof("getChassisModuleStatusByModule: options keys: %v", getOptionsKeys(options))
-		return nil, fmt.Errorf("No module name specified in path")
+// Create database queries for chassis module data
+func createChassisModuleQueries(moduleName string) dbQueries {
+	queries := dbQueries{
+		state:  [][]string{{stateDB, chassisModuleTable}},
+		config: [][]string{{configDB, chassisModule}},
 	}
 
-	if moduleName == "" {
-		return nil, fmt.Errorf("Empty module name")
+	if moduleName != "" {
+		queries.state[0] = append(queries.state[0], moduleName)
+		queries.config[0] = append(queries.config[0], moduleName)
 	}
 
-	log.V(2).Infof("getChassisModuleStatusByModule: processing module: %s", moduleName)
+	return queries
+}
 
-	// Query both STATE_DB and CONFIG_DB for the specific module
-	stateQueries := [][]string{
-		{"STATE_DB", "CHASSIS_MODULE_TABLE", moduleName},
-	}
-
-	configQueries := [][]string{
-		{"CONFIG_DB", "CHASSIS_MODULE", moduleName},
-	}
-
-	log.V(2).Infof("getChassisModuleStatusByModule: state queries: %v", stateQueries)
-	log.V(2).Infof("getChassisModuleStatusByModule: config queries: %v", configQueries)
-
+// Get and parse data from databases
+func getChassisModuleData(queries dbQueries) (map[string]interface{}, map[string]interface{}, error) {
 	// Get state data
-	stateDataBytes, err := GetDataFromQueries(stateQueries)
+	stateDataBytes, err := GetDataFromQueries(queries.state)
 	if err != nil {
-		log.Errorf("Unable to get state data from queries %v, got err: %v", stateQueries, err)
-		return nil, err
+		log.Errorf("Unable to get state data from queries %v, got err: %v", queries.state, err)
+		return nil, nil, fmt.Errorf("failed to get state data: %w", err)
 	}
-	log.V(2).Infof("getChassisModuleStatusByModule: state data bytes: %s", string(stateDataBytes))
+	log.V(2).Infof("State data bytes: %s", string(stateDataBytes))
 
 	// Get config data
-	configDataBytes, err := GetDataFromQueries(configQueries)
+	configDataBytes, err := GetDataFromQueries(queries.config)
 	if err != nil {
-		log.Errorf("Unable to get config data from queries %v, got err: %v", configQueries, err)
-		return nil, err
+		log.Errorf("Unable to get config data from queries %v, got err: %v", queries.config, err)
+		return nil, nil, fmt.Errorf("failed to get config data: %w", err)
 	}
-	log.V(2).Infof("getChassisModuleStatusByModule: config data bytes: %s", string(configDataBytes))
+	log.V(2).Infof("Config data bytes: %s", string(configDataBytes))
 
-	// Parse the JSON data
+	// Parse state data
 	var stateData map[string]interface{}
 	if err := json.Unmarshal(stateDataBytes, &stateData); err != nil {
 		log.Errorf("Failed to unmarshal state data: %v", err)
-		return nil, err
+		return nil, nil, fmt.Errorf("failed to unmarshal state data: %w", err)
 	}
 
+	// Parse config data
 	var configData map[string]interface{}
 	if err := json.Unmarshal(configDataBytes, &configData); err != nil {
 		log.Errorf("Failed to unmarshal config data: %v", err)
-		return nil, err
+		return nil, nil, fmt.Errorf("failed to unmarshal config data: %w", err)
 	}
 
-	// Check if the module exists in state data
-	if len(stateData) == 0 {
-		return nil, fmt.Errorf("Module %s not found", moduleName)
-	}
+	return stateData, configData, nil
+}
 
-	// Process the data for the specific module
-	result := make(map[string]interface{})
-	moduleStatusMap := make(map[string]ChassisModuleStatus)
-
-	// Process STATE_DB data - when querying specific module, data is returned as flat structure
-	log.V(2).Infof("getChassisModuleStatusByModule: processing state data with keys: %v", getMapKeys(stateData))
-
-	// For specific module queries, the data is returned as flat structure, not nested
+// Create ChassisModuleStatus from flat data structure
+func createModuleStatusFromFlatData(moduleName string, stateData, configData map[string]interface{}) ChassisModuleStatus {
 	module := ChassisModuleStatus{
 		Name:        moduleName,
-		AdminStatus: "up",  // Default value
-		Slot:        "N/A", // Default value
+		AdminStatus: defaultAdminStatus,
+		Slot:        defaultSlot,
 	}
 
-	// Process the flat state data structure
+	// Process state data
 	for key, value := range stateData {
-		log.V(2).Infof("getChassisModuleStatusByModule: processing state key: %s", key)
 		if strValue, ok := value.(string); ok {
 			switch key {
 			case "desc":
@@ -194,40 +106,99 @@ func getChassisModuleStatusByModule(options sdc.OptionMap) ([]byte, error) {
 		}
 	}
 
-	moduleStatusMap[moduleName] = module
-	log.V(2).Infof("getChassisModuleStatusByModule: added module %s: %+v", moduleName, module)
-
-	// Process CONFIG_DB data to get admin_status - also flat structure
-	log.V(2).Infof("getChassisModuleStatusByModule: processing config data with keys: %v", getMapKeys(configData))
+	// Process config data
 	for key, value := range configData {
-		log.V(2).Infof("getChassisModuleStatusByModule: processing config key: %s", key)
 		if strValue, ok := value.(string); ok {
 			if key == "admin_status" {
-				if existingModule, exists := moduleStatusMap[moduleName]; exists {
-					existingModule.AdminStatus = strValue
-					moduleStatusMap[moduleName] = existingModule
-					log.V(2).Infof("getChassisModuleStatusByModule: updated admin_status for module %s: %s", moduleName, strValue)
+				module.AdminStatus = strValue
+			}
+		}
+	}
+
+	return module
+}
+
+func getChassisModuleStatus(options sdc.OptionMap) ([]byte, error) {
+	log.V(2).Infof("getChassisModuleStatus: called with options: %v", getOptionsKeys(options))
+
+	// Check if a specific module is requested
+	if moduleStr, ok := options["dpu"].String(); ok {
+		log.V(2).Infof("getChassisModuleStatus: filtering for module: %s", moduleStr)
+		return getChassisModuleStatusByModule(moduleStr)
+	}
+
+	// Get data for all modules
+	log.V(2).Infof("getChassisModuleStatus: getting all modules")
+	queries := createChassisModuleQueries("")
+	stateData, configData, err := getChassisModuleData(queries)
+	if err != nil {
+		return nil, err
+	}
+
+	// Merge the data
+	result := make(map[string]interface{})
+	for moduleName, stateInfo := range stateData {
+		if stateInfoMap, ok := stateInfo.(map[string]interface{}); ok {
+			result[moduleName] = stateInfoMap
+
+			// Add admin_status from CONFIG_DB if available
+			if configInfo, exists := configData[moduleName]; exists {
+				if configInfoMap, ok := configInfo.(map[string]interface{}); ok {
+					if adminStatus, hasAdmin := configInfoMap["admin_status"]; hasAdmin {
+						result[moduleName].(map[string]interface{})["admin_status"] = adminStatus
+					}
 				}
 			}
 		}
 	}
 
-	log.V(2).Infof("getChassisModuleStatusByModule: moduleStatusMap has %d modules", len(moduleStatusMap))
-
-	// Return the specific module
-	if module, exists := moduleStatusMap[moduleName]; exists {
-		result[moduleName] = module
-		log.V(2).Infof("getChassisModuleStatusByModule: returning module %s", moduleName)
-	} else {
-		log.V(2).Infof("getChassisModuleStatusByModule: module %s not found in moduleStatusMap", moduleName)
-		return nil, fmt.Errorf("Module %s not found", moduleName)
+	// Convert to JSON
+	jsonData, err := json.Marshal(result)
+	if err != nil {
+		log.V(2).Infof("getChassisModuleStatus: error marshaling result: %v", err)
+		return nil, fmt.Errorf("failed to marshal result: %w", err)
 	}
 
-	// Convert to JSON bytes
+	log.V(2).Infof("getChassisModuleStatus: returning: %s", string(jsonData))
+	return jsonData, nil
+}
+
+func getChassisModuleStatusByModule(moduleName string) ([]byte, error) {
+	if moduleName == "" {
+		return nil, fmt.Errorf("empty module name")
+	}
+
+	log.V(2).Infof("getChassisModuleStatusByModule: processing module: %s", moduleName)
+
+	// Get data for specific module
+	queries := createChassisModuleQueries(moduleName)
+	stateData, configData, err := getChassisModuleData(queries)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check if the module exists in state data
+	if len(stateData) == 0 {
+		return nil, fmt.Errorf("module %s not found", moduleName)
+	}
+
+	log.V(2).Infof("getChassisModuleStatusByModule: processing state data with keys: %v", getMapKeys(stateData))
+	log.V(2).Infof("getChassisModuleStatusByModule: processing config data with keys: %v", getMapKeys(configData))
+
+	// Create module status from flat data structure
+	module := createModuleStatusFromFlatData(moduleName, stateData, configData)
+	log.V(2).Infof("getChassisModuleStatusByModule: created module %s: %+v", moduleName, module)
+
+	// Create result
+	result := map[string]interface{}{
+		moduleName: module,
+	}
+
+	// Convert to JSON
 	jsonBytes, err := json.MarshalIndent(result, "", "  ")
 	if err != nil {
 		log.Errorf("Failed to marshal chassis module status data: %v", err)
-		return nil, err
+		return nil, fmt.Errorf("failed to marshal result: %w", err)
 	}
 
 	log.V(4).Infof("getChassisModuleStatusByModule, output: %v", string(jsonBytes))
@@ -245,7 +216,7 @@ func getMapKeys(m map[string]interface{}) []string {
 
 // Helper function to get options keys for debugging
 func getOptionsKeys(options sdc.OptionMap) []string {
-	keys := make([]string, 0)
+	keys := make([]string, 0, len(options))
 	for k := range options {
 		keys = append(keys, k)
 	}

--- a/show_client/show_common.go
+++ b/show_client/show_common.go
@@ -16,6 +16,10 @@ import (
 const AppDBPortTable = "PORT_TABLE"
 const StateDBPortTable = "PORT_TABLE"
 
+// Database names
+const StateDB = "STATE_DB"
+const ConfigDB = "CONFIG_DB"
+
 const (
 	dbIndex    = 0 // The first index for a query will be the DB
 	tableIndex = 1 // The second index for a query will be the table

--- a/show_client/show_opts.go
+++ b/show_client/show_opts.go
@@ -12,6 +12,7 @@ const (
 	showCmdOptionInterfaceDesc     = "[interface=TEXT] Filter by single interface name"
 	showCmdOptionPeriodDesc        = "[period=INTEGER] Display statistics over a specified period (in seconds)"
 	showCmdOptionJsonDesc          = "[json=true] No-op since response is in json format"
+	showCmdOptionDpuDesc           = "[dpu=TEXT] Filter by DPU module name"
 )
 
 var (
@@ -60,6 +61,12 @@ var (
 	showCmdOptionFetchFromHW = sdc.NewShowCmdOption(
 		"fetch-from-hardware",
 		showCmdOptionUnimplementedDesc,
+		sdc.StringValue,
+	)
+
+	showCmdOptionDpu = sdc.NewShowCmdOption(
+		"dpu",
+		showCmdOptionDpuDesc,
 		sdc.StringValue,
 	)
 )

--- a/show_client/show_paths.go
+++ b/show_client/show_paths.go
@@ -19,6 +19,12 @@ func init() {
 		nil,
 	)
 	sdc.RegisterCliPath(
+		[]string{"SHOW", "chassis", "module", "status"},
+		getChassisModuleStatus,
+		nil,
+		showCmdOptionDpu,
+	)
+	sdc.RegisterCliPath(
 		[]string{"SHOW", "clock"},
 		getDate,
 		map[string]string{

--- a/testdata/CHASSIS_MODULE_CONFIG.txt
+++ b/testdata/CHASSIS_MODULE_CONFIG.txt
@@ -1,0 +1,14 @@
+{
+    "CHASSIS_MODULE|DPU0": {
+      "admin_status": "up"
+    },
+    "CHASSIS_MODULE|DPU1": {
+      "admin_status": "up"
+    },
+    "CHASSIS_MODULE|DPU2": {
+      "admin_status": "up"
+    },
+    "CHASSIS_MODULE|DPU3": {
+      "admin_status": "down"
+    }
+}

--- a/testdata/CHASSIS_MODULE_STATE.txt
+++ b/testdata/CHASSIS_MODULE_STATE.txt
@@ -1,0 +1,31 @@
+{
+    "CHASSIS_MODULE_TABLE|DPU0": {
+      "desc": "AMD Pensando DSC",
+      "oper_status": "Online",
+      "serial": "FLM29100D70-0",
+      "slot": "N/A",
+      "state_transition_in_progress": "False",
+      "transition_start_time": "2025-08-14T03:46:19.891919"
+    },
+    "CHASSIS_MODULE_TABLE|DPU1": {
+      "desc": "AMD Pensando DSC",
+      "oper_status": "Online",
+      "serial": "FLM29100D70-1",
+      "slot": "N/A",
+      "state_transition_in_progress": "False"
+    },
+    "CHASSIS_MODULE_TABLE|DPU2": {
+      "desc": "AMD Pensando DSC",
+      "oper_status": "Online",
+      "serial": "FLM29100D6U-0",
+      "slot": "N/A",
+      "state_transition_in_progress": "False"
+    },
+    "CHASSIS_MODULE_TABLE|DPU3": {
+      "desc": "AMD Pensando DSC",
+      "oper_status": "Online",
+      "serial": "FLM29100D6U-1",
+      "slot": "N/A",
+      "state_transition_in_progress": "False"
+    }
+}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Add support for `show chassis module status`
#### How I did it
Implement logic is smae as sonic-utilites.
#### How to verify it
UT and manual verifeid in DUT:
```
admin@str3-8102-07:~$ docker exec -it telemetry gnmi_get -xpath_target SHOW -xpath chassis/module/status[dpu=DPU1] -target_addr 127.0.0.1:50051 -logtostderr -insecure true
== getRequest:
prefix: <
  target: "SHOW"
>
path: <
  elem: <
    name: "chassis"
  >
  elem: <
    name: "module"
  >
  elem: <
    name: "status"
    key: <
      key: "dpu"
      value: "DPU1"
    >
  >
>
encoding: JSON_IETF

== getResponse:
notification: <
  timestamp: 1755248754884228628
  prefix: <
    target: "SHOW"
  >
  update: <
    path: <
      elem: <
        name: "chassis"
      >
      elem: <
        name: "module"
      >
      elem: <
        name: "status"
        key: <
          key: "dpu"
          value: "DPU1"
        >
      >
    >
    val: <
      json_ietf_val: "{\n  \"DPU1\": {\n    \"name\": \"DPU1\",\n    \"description\": \"AMD Pensando DSC\",\n    \"physical_slot\": \"N/A\",\n    \"oper_status\": \"Online\",\n    \"admin_status\": \"up\",\n    \"serial\": \"FLM29100D70-1\"\n  }\n}"
    >
  >
>

admin@str3-8102-07:~$ docker exec -it telemetry gnmi_get -xpath_target SHOW -xpath chassis/module/status -target_addr 127.0.0.1:50051 -logtostderr -insecure true
== getRequest:
prefix: <
  target: "SHOW"
>
path: <
  elem: <
    name: "chassis"
  >
  elem: <
    name: "module"
  >
  elem: <
    name: "status"
  >
>
encoding: JSON_IETF

== getResponse:
notification: <
  timestamp: 1755248763946372448
  prefix: <
    target: "SHOW"
  >
  update: <
    path: <
      elem: <
        name: "chassis"
      >
      elem: <
        name: "module"
      >
      elem: <
        name: "status"
      >
    >
    val: <
      json_ietf_val: "{\"DPU0\":{\"admin_status\":\"up\",\"desc\":\"AMD Pensando DSC\",\"oper_status\":\"Online\",\"serial\":\"FLM29100D70-0\",\"slot\":\"N/A\",\"state_transition_in_progress\":\"False\",\"transition_start_time\":\"2025-08-14T03:46:19.891919\"},\"DPU1\":{\"admin_status\":\"up\",\"desc\":\"AMD Pensando DSC\",\"oper_status\":\"Online\",\"serial\":\"FLM29100D70-1\",\"slot\":\"N/A\",\"state_transition_in_progress\":\"False\"},\"DPU2\":{\"admin_status\":\"up\",\"desc\":\"AMD Pensando DSC\",\"oper_status\":\"Online\",\"serial\":\"FLM29100D6U-0\",\"slot\":\"N/A\",\"state_transition_in_progress\":\"False\"},\"DPU3\":{\"admin_status\":\"up\",\"desc\":\"AMD Pensando DSC\",\"oper_status\":\"Online\",\"serial\":\"FLM29100D6U-1\",\"slot\":\"N/A\",\"state_transition_in_progress\":\"False\"},\"DPU4\":{\"admin_status\":\"up\",\"desc\":\"AMD Pensando DSC\",\"oper_status\":\"Online\",\"serial\":\"FLM29100D7X-0\",\"slot\":\"N/A\",\"state_transition_in_progress\":\"False\"},\"DPU5\":{\"admin_status\":\"up\",\"desc\":\"AMD Pensando DSC\",\"oper_status\":\"Online\",\"serial\":\"FLM29100D7X-1\",\"slot\":\"N/A\",\"state_transition_in_progress\":\"False\"},\"DPU6\":{\"admin_status\":\"up\",\"desc\":\"AMD Pensando DSC\",\"oper_status\":\"Online\",\"serial\":\"FLM29100D7M-0\",\"slot\":\"N/A\",\"state_transition_in_progress\":\"False\"},\"DPU7\":{\"admin_status\":\"up\",\"desc\":\"AMD Pensando DSC\",\"oper_status\":\"Online\",\"serial\":\"FLM29100D7M-1\",\"slot\":\"N/A\",\"state_transition_in_progress\":\"False\"}}"
    >
  >
>
```
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

