### PR TITLE
gNOI: Add support for Healthz List and Check RPC

### DIFF
--- a/gnmi_server/gnoi_healthz.go
+++ b/gnmi_server/gnoi_healthz.go
@@ -206,3 +206,11 @@ func (srv *HealthzServer) Get(ctx context.Context, req *healthz.GetRequest) (*he
 	log.Warning("Healthz.Get received unsupported component path")
 	return nil, status.Errorf(codes.Unimplemented, "Healthz.Get is unimplemented for component: [%s].", path.GetElem())
 }
+
+func (srv *HealthzServer) List(ctx context.Context, req *healthz.ListRequest) (*healthz.ListResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "gNOI Healthz List not implemented")
+}
+
+func (srv *HealthzServer) Check(ctx context.Context, req *healthz.CheckRequest) (*healthz.CheckResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "gNOI Healthz Check not implemented")
+}

--- a/gnmi_server/gnoi_healthz_test.go
+++ b/gnmi_server/gnoi_healthz_test.go
@@ -412,6 +412,20 @@ var testHealthzCases = []struct {
 			testErr(err, codes.Unimplemented, "Healthz.Get is unimplemented", t)
 		},
 	},
+	{
+		desc: "HealthzListFailsForInvalidComponent",
+		f: func(ctx context.Context, t *testing.T, sc healthz.HealthzClient) {
+			_, err := sc.List(ctx, &healthz.ListRequest{})
+			testErr(err, codes.Unimplemented, "gNOI Healthz List not implemented", t)
+		},
+	},
+	{
+		desc: "HealthzCheckFailsForInvalidComponent",
+		f: func(ctx context.Context, t *testing.T, sc healthz.HealthzClient) {
+			_, err := sc.Check(ctx, &healthz.CheckRequest{})
+			testErr(err, codes.Unimplemented, "gNOI Healthz Check not implemented", t)
+		},
+	},
 }
 
 // TestHealthzServer tests implementation of gnoi.Healthz server.


### PR DESCRIPTION
**Dependency Chain for Merge**

Please follow this merge order,

https://github.com/sonic-net/sonic-gnmi/pull/485 (Must be merged first) -> https://github.com/sonic-net/sonic-gnmi/pull/486 -> https://github.com/sonic-net/sonic-gnmi/pull/507 -> https://github.com/sonic-net/sonic-gnmi/pull/487 -> https://github.com/sonic-net/sonic-gnmi/pull/488 -> https://github.com/sonic-net/sonic-gnmi/pull/489 -> https://github.com/sonic-net/sonic-gnmi/pull/509

**Dependent BE PR**
https://github.com/sonic-net/sonic-host-services/pull/295/

**[UMF] gNOI Healthz Service -Test Results**

**Manual CLI Testing**

Since component-level debug collection not supported in SONiC upstream, no debug data being collected from any of the components and only below logs collected for host artifacts based on log level "alert-info".  Along with alert-info, captured the logs for critical-info and all-info which can be find [here](https://docs.google.com/document/d/1hQ_rq-glg-HjhAKchGJv5-3lmKX_D1xZZqwnJL-lXBQ/edit?tab=t.0)

**Get RPC**
```
admin@sonic:~$docker exec gnmi gnoi_client -target 127.0.0.1:8080 -notls -module Healthz -rpc Get -jsonin "{\"path\": \"/components/component[name=gnmi]/healthz/alert-info\"}"

Healthz Status for Component: /components/component/healthz/alert-info
Status: STATUS_HEALTHY
Acknowledged: false
ID: /tmp/dump/sonic_20250812_131059426171.tar.gz
Artifacts:
  - Artifact ID: /tmp/dump/sonic_20250812_131059426171.tar.gz
    File Name: /tmp/dump/sonic_20250812_131059426171.tar.gz
    File Size: 240073 bytes
    Hash Method: SHA256
    Hash Value: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855

admin@sonic:~$ sudo ls /tmp/dump/
sonic_20250812_131059426171.tar.gz

admin@sonic:~$docker exec -it gnmi bash
root@sonic:/# ls /mnt/host/tmp/dump
sonic_20250812_131059426171.tar.gz
```

**Artifact RPC**
```
admin@sonic:~$docker exec gnmi gnoi_client -target 127.0.0.1:8080 -notls -module Healthz -rpc Artifact -id "/tmp/dump/sonic_20250812_131059426171.tar.gz"

Received header: 
id:"/tmp/dump/sonic_20250812_131059426171.tar.gz" file:{name:"/tmp/dump/sonic_20250812_131059426171.tar.gz" size 240073 hash:{method:SHA256 hash:"\xe3\xb0\xc4B\x98\xfc\x1c\x14\x9a\xfb\xf4șo\xb9$'\xaeA\xe4d\x9b\x93L\xa4\x95\x99\x1bxR\xb8U"}}
Received bytes chunk: 4096 bytes (total=4096)
Received bytes chunk: 4096 bytes (total=8192)
Received bytes chunk: 4096 bytes (total=12288)
Received bytes chunk: 4096 bytes (total=16384)
Received bytes chunk: 4096 bytes (total=20480)
Received bytes chunk: 4096 bytes (total=24576)
Received bytes chunk: 4096 bytes (total=28672)
Received bytes chunk: 4096 bytes (total=32768)
Received bytes chunk: 4096 bytes (total=36864)
Received bytes chunk: 4096 bytes (total=40960)
Received bytes chunk: 4096 bytes (total=45056)
Received bytes chunk: 4096 bytes (total=49152)
Received bytes chunk: 4096 bytes (total=53248)
Received bytes chunk: 4096 bytes (total=57344)
Received bytes chunk: 4096 bytes (total=61440)
Received bytes chunk: 4096 bytes (total=65536)
Received bytes chunk: 4096 bytes (total=69632)
Received bytes chunk: 4096 bytes (total=73728)
Received bytes chunk: 4096 bytes (total=77824)
Received bytes chunk: 4096 bytes (total=81920)
Received bytes chunk: 4096 bytes (total=86016)
Received bytes chunk: 4096 bytes (total=90112)
Received bytes chunk: 4096 bytes (total=94208)
Received bytes chunk: 4096 bytes (total=98304)
Received bytes chunk: 4096 bytes (total=102400)
Received bytes chunk: 4096 bytes (total=106496)
Received bytes chunk: 4096 bytes (total=110592)
Received bytes chunk: 4096 bytes (total=114688)
Received bytes chunk: 4096 bytes (total=118784)
Received bytes chunk: 4096 bytes (total=122880)
Received bytes chunk: 4096 bytes (total=126976)
Received bytes chunk: 4096 bytes (total=131072)
Received bytes chunk: 4096 bytes (total=135168)
Received bytes chunk: 4096 bytes (total=139264)
Received bytes chunk: 4096 bytes (total=143360)
Received bytes chunk: 4096 bytes (total=147456)
Received bytes chunk: 4096 bytes (total=151552)
Received bytes chunk: 4096 bytes (total=155648)
Received bytes chunk: 4096 bytes (total=159744)
Received bytes chunk: 4096 bytes (total=163840)
Received bytes chunk: 4096 bytes (total=167936)
Received bytes chunk: 4096 bytes (total=172032)
Received bytes chunk: 4096 bytes (total=176128)
Received bytes chunk: 4096 bytes (total=180224)
Received bytes chunk: 4096 bytes (total=184320)
Received bytes chunk: 4096 bytes (total=188416)
Received bytes chunk: 4096 bytes (total=192512)
Received bytes chunk: 4096 bytes (total=196608)
Received bytes chunk: 4096 bytes (total=200704)
Received bytes chunk: 4096 bytes (total=204800)
Received bytes chunk: 4096 bytes (total=208896)
Received bytes chunk: 4096 bytes (total=212992)
Received bytes chunk: 4096 bytes (total=217088)
Received bytes chunk: 4096 bytes (total=221184)
Received bytes chunk: 4096 bytes (total=225280)
Received bytes chunk: 4096 bytes (total=229376)
Received bytes chunk: 4096 bytes (total=233472)
Received bytes chunk: 4096 bytes (total=237568)
Received bytes chunk: 2505 bytes (total=240073)
Received trailer: 
Final received size: 240073 bytes
Artifact Response success
```

**Acknowledge RPC**
```
admin@sonic:~$docker exec gnmi gnoi_client -target 127.0.0.1:8080 -notls -module Healthz -rpc Acknowledge -jsonin '{"path": "/components/component[name=gnmi]/healthz/alert-info", "id": "/tmp/dump/sonic_20250812_131059426171.tar.gz"}'

Acknowledge response: <nil>

admin@sonic:~$ ls /tmp/dump
<Artifact file has been removed successfully on Host>

root@sonic:/# ls /mnt/host/tmp/dump
<Artifact file has been removed successfully on gnmi container>
```
**List RPC**
```
admin@sonic:~$docker exec gnmi gnoi_client -target 127.0.0.1:8080 -notls -module Healthz -rpc List -jsonin "{\"path\":\"/components/component[name=healthz]\", \"include_acknowledged\": true}"

Healthz.List RPC not implemented on server
```

**Check RPC**
```
admin@sonic:~$docker exec gnmi gnoi_client -target 127.0.0.1:8080 -notls -module Healthz -rpc Check -jsonin "{\"path\":\"/components/component[name=healthz]\", \"event_id\": \"event-abc123\"}"

Healthz.Check RPC not implemented on server
```
**Unit Test Results**
```
cd sonic-gnmi
make all && make check_gotest ENABLE_TRANSLIB_WRITE=y
=== RUN   TestHealthzServer
=== RUN   TestHealthzServer/HealthzGetForInvalidPaths
=== RUN   TestHealthzServer/GetDebugData_Marshal_error
=== RUN   TestHealthzServer/GetDebugData_NewDbusClient_Error
=== RUN   TestHealthzServer/Get_fail_Authentication_error
=== RUN   TestHealthzServer/GetDebugData_HealthzCollect_DBus_Error
=== RUN   TestHealthzServer/GetDebugData-WaitForArtifact_error
=== RUN   TestHealthzServer/WaitForArtifact_NewDbusClient_Error
=== RUN   TestHealthzServer/GetDebugData_Success_Path
=== RUN   TestHealthzServer/HealthzGetForValidPaths
=== RUN   TestHealthzServer/TestgetDebugData_emptyPath
=== RUN   TestHealthzServer/HealthzCheck_SuccessPath (0.00s)
=== RUN   TestHealthzServer/HealthzListFailsForInvalidComponent
=== RUN   TestHealthzServer/HealthzCheckFailsForInvalidComponent
=== RUN   TestHealthzServer/Acknowledge_fails_with_Authentication_Error
=== RUN   TestHealthzServer/TestHealthzServer_Acknowledge
=== RUN   TestHealthzServer/TestHealthzServer_Acknowledge_DBUS_Error
=== RUN   TestHealthzServer/Acknowledge_NewDbusClient_Error
=== RUN   TestHealthzServer/TestHealthzArtifact_FileNotFound
=== RUN  TestHealthzServer/TestHealthzArtifact_InvalidPath (0.00s)
=== RUN  TestHealthzServer/TestHealthzArtifact_ValidPath (0.00s)
=== RUN  TestHealthzServer/TestHealthzArtifact_SeekFailure (0.00s)
=== RUN  TestHealthzServer/TestHealthzArtifact_HeaderSendFailure (0.00s)
=== RUN  TestHealthzServer/TestHealthzArtifact_TrailerSendFailure (0.00s)
=== RUN  TestHealthzServer/TestHealthzArtifact_FileReadFailure (0.00s)
=== RUN  TestHealthzServer/TestHealthzArtifact_ChunkSendFailure (0.00s)
--- PASS: TestHealthzServer (3.96s)
--- PASS: TestHealthzServer/HealthzGetForInvalidPaths (0.03s)
--- PASS: TestHealthzServer/GetDebugData_Marshal_error (0.00s)
--- PASS: TestHealthzServer/GetDebugData_NewDbusClient_Error (0.00s)
--- PASS: TestHealthzServer/Get_fail_Authentication_error (0.02s)
--- PASS: TestHealthzServer/GetDebugData_HealthzCollect_DBus_Error (0.00s)
--- PASS: TestHealthzServer/GetDebugData-WaitForArtifact_error (0.00s)
--- PASS: TestHealthzServer/WaitForArtifact_NewDbusClient_Error (0.00s)
--- PASS: TestHealthzServer/GetDebugData_Success_Path (0.00s)
--- PASS: TestHealthzServer/HealthzGetForValidPaths (0.02s)
--- PASS: TestHealthzServer/TestgetDebugData_emptyPath (0.00s)
--- PASS: TestHealthzServer/HealthzCheck_SuccessPath (0.00s)
--- PASS: TestHealthzServer/HealthzListFailsForInvalidComponent (0.02s)
--- PASS: TestHealthzServer/HealthzCheckFailsForInvalidComponent (0.02s)
--- PASS: TestHealthzServer/Acknowledge_fails_with_Authentication_Error (0.02s)
--- PASS: TestHealthzServer/TestHealthzServer_Acknowledge (0.02s)
--- PASS: TestHealthzServer/TestHealthzServer_Acknowledge_DBUS_Error (0.02s)
--- PASS: TestHealthzServer/Acknowledge_NewDbusClient_Error (0.02s)
--- PASS: TestHealthzServer/TestHealthzArtifact_FileNotFound (0.00s)
--- PASS: TestHealthzServer/TestHealthzArtifact_InvalidPath (0.00s)
--- PASS: TestHealthzServer/TestHealthzArtifact_ValidPath (0.00s)
--- PASS: TestHealthzServer/TestHealthzArtifact_SeekFailure (0.00s)
--- PASS: TestHealthzServer/TestHealthzArtifact_HeaderSendFailure (0.00s)
--- PASS: TestHealthzServer/TestHealthzArtifact_TrailerSendFailure (0.00s)
--- PASS: TestHealthzServer/TestHealthzArtifact_FileReadFailure (0.00s)
--- PASS: TestHealthzServer/TestHealthzArtifact_ChunkSendFailure (0.00s)

```