### PR TITLE
Add dom and port options for SHOW client

### DIFF
--- a/show_client/show_opts.go
+++ b/show_client/show_opts.go
@@ -59,13 +59,13 @@ var (
 		sdc.StringValue,
 	)
 
-	showCmdOptionInterface = sdc.NewShowCmdOption(
+	showCmdOptionPort = sdc.NewShowCmdOption(
 		"port",
 		showCmdOptionPortDesc,
 		sdc.StringValue,
 	)
 
-	showCmdOptionInterface = sdc.NewShowCmdOption(
+	showCmdOptionDom = sdc.NewShowCmdOption(
 		"dom",
 		showCmdOptionDomDesc,
 		sdc.BoolValue,


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
In the `show interfaces transceiver eeprom` command, two additional options, --dom and --port, were not present in the previous implementation. This PR introduces these options:
```
@cli.command()
@click.option('-p', '--port', metavar='<port_name>', help="Display SFP EEPROM data for port <port_name> only")
@click.option('-d', '--dom', 'dump_dom', is_flag=True, help="Also display Digital Optical Monitoring (DOM) data")
@click.option('-n', '--namespace', default=None, help="Display interfaces for specific namespace")
def eeprom(port, dump_dom, namespace):
```

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

