### PR TITLE
Add ability to bind GNMI server to a VRF

### DIFF
--- a/gnmi_server/server.go
+++ b/gnmi_server/server.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/Azure/sonic-mgmt-common/translib"
@@ -211,6 +212,7 @@ type Config struct {
 	ZmqPort             string
 	IdleConnDuration    int
 	ConfigTableName     string
+	GnmiVrf             string
 	Vrf                 string
 	EnableCrl           bool
 	// Path to the directory where image is stored.
@@ -480,7 +482,31 @@ func SrvAdvConfig(cfg *Config) ([]grpc.ServerOption, []certprovider.Provider, er
 }
 
 // NewServer returns an initialized Server.
-//
+func createVrfListener(vrf string, port int64) (net.Listener, error) {
+	lc := net.ListenConfig{
+		Control: func(network, address string, c syscall.RawConn) error {
+			var err error
+			ctrlErr := c.Control(func(fd uintptr) {
+				err = syscall.SetsockoptString(int(fd), syscall.SOL_SOCKET, syscall.SO_BINDTODEVICE, vrf)
+			})
+			if ctrlErr != nil {
+				return ctrlErr
+			}
+			if err != nil {
+				return fmt.Errorf("failed to bind socket to VRF %s: %v", vrf, err)
+			}
+			return nil
+		},
+	}
+
+	listener, err := lc.Listen(context.Background(), "tcp", fmt.Sprintf(":%d", port))
+	if err != nil {
+		return nil, err
+	}
+	log.V(1).Infof("Created VRF-bound listener on VRF %s, port %d", vrf, port)
+	return listener, nil
+}
+
 // tlsOpts contains TLS credentials and is used only for the TCP listener.
 // commonOpts contains interceptors, keepalive params, etc. and is used for both listeners.
 //
@@ -553,7 +579,12 @@ func NewServer(config *Config, tlsOpts []grpc.ServerOption, commonOpts []grpc.Se
 		srv.s = grpc.NewServer(tcpOpts...)
 		reflection.Register(srv.s)
 
-		srv.lis, err = net.Listen("tcp", fmt.Sprintf(":%d", config.Port))
+		// Create VRF-aware listener if GNMI VRF is specified
+		if config.GnmiVrf != "" && config.GnmiVrf != "default" {
+			srv.lis, err = createVrfListener(config.GnmiVrf, config.Port)
+		} else {
+			srv.lis, err = net.Listen("tcp", fmt.Sprintf(":%d", config.Port))
+		}
 		if err != nil {
 			log.Warningf("Failed to open listener port %d: %v; disabling TCP listener", config.Port, err)
 			srv.s.Stop()

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -5899,6 +5899,175 @@ func TestInvalidServer(t *testing.T) {
 	}
 }
 
+func TestServerConfigGnmiVrf(t *testing.T) {
+	// Test GNMI server creation with VRF configuration
+	cfg := &Config{
+		Port:                8082,
+		EnableTranslibWrite: true,
+		EnableNativeWrite:   true,
+		Threshold:           100,
+		GnmiVrf:             "mgmt",
+		Vrf:                 "",
+	}
+	s, err := NewServer(cfg, []grpc.ServerOption{}, []grpc.ServerOption{})
+	if s != nil {
+		defer func() {
+			s.ForceStop()
+			if s.lis != nil {
+				s.lis.Close()
+			}
+		}()
+	}
+	if err != nil {
+		t.Logf("Expected error when VRF doesn't exist: %v", err)
+		if !contains(err.Error(), "VRF") && !contains(err.Error(), "bind") && !contains(err.Error(), "BINDTODEVICE") {
+			t.Logf("Error message: %v", err)
+		}
+		return
+	}
+	if cfg.GnmiVrf != "mgmt" {
+		t.Errorf("Expected gnmiVrf to be 'mgmt', got '%s'", cfg.GnmiVrf)
+	}
+	if s.lis == nil {
+		t.Errorf("Expected server listener to be created")
+	} else {
+		addr := s.lis.Addr()
+		if addr == nil {
+			t.Errorf("Expected server listener to have an address")
+		} else {
+			t.Logf("Server successfully bound to address: %s with VRF: %s", addr.String(), s.config.GnmiVrf)
+		}
+	}
+}
+
+func TestServerConfigZmqVrf(t *testing.T) {
+	// Test that ZMQ VRF field is properly set in config
+	cfg := &Config{
+		Port:                8083,
+		EnableTranslibWrite: true,
+		EnableNativeWrite:   true,
+		Threshold:           100,
+		GnmiVrf:             "",
+		Vrf:                 "mgmt",
+	}
+	s, err := NewServer(cfg, []grpc.ServerOption{}, []grpc.ServerOption{})
+	if s != nil {
+		defer func() {
+			s.ForceStop()
+			if s.lis != nil {
+				s.lis.Close()
+			}
+		}()
+	}
+	if err != nil {
+		t.Errorf("Failed to create server: %v", err)
+		return
+	}
+	if s.config.Vrf != "mgmt" {
+		t.Errorf("Expected Vrf to be 'mgmt', got '%s'", s.config.Vrf)
+	}
+}
+
+func TestServerConfigGnmiVrfEmptyAndDefault(t *testing.T) {
+	// Test that empty GnmiVrf and "default" GnmiVrf both use default listener
+	tests := []struct {
+		name    string
+		gnmiVrf string
+	}{
+		{"empty GnmiVrf", ""},
+		{"default GnmiVrf", "default"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{
+				Port:                8084,
+				EnableTranslibWrite: true,
+				EnableNativeWrite:   true,
+				Threshold:           100,
+				GnmiVrf:             tt.gnmiVrf,
+				Vrf:                 "",
+			}
+			s, err := NewServer(cfg, []grpc.ServerOption{}, []grpc.ServerOption{})
+			if s != nil {
+				defer func() {
+					s.ForceStop()
+					if s.lis != nil {
+						s.lis.Close()
+					}
+				}()
+			}
+			if err != nil {
+				t.Errorf("Failed to create server with GnmiVrf=%q: %v", tt.gnmiVrf, err)
+				return
+			}
+			if s.lis == nil {
+				t.Errorf("Expected server listener to be created")
+			} else {
+				t.Logf("Server with GnmiVrf=%q created on: %s", tt.gnmiVrf, s.lis.Addr().String())
+			}
+		})
+	}
+}
+
+func TestCreateVrfListenerBindToDeviceError(t *testing.T) {
+	_, err := createVrfListener("nonexistent-vrf-12345", 0)
+	if err == nil {
+		t.Skip("Expected error when BINDTODEVICE fails, but got success. System may not support VRFs or the VRF might exist.")
+	}
+	if !contains(err.Error(), "bind") && !contains(err.Error(), "VRF") {
+		t.Logf("Got error (which is expected): %v", err)
+	}
+}
+
+func TestCreateVrfListenerInvalidPort(t *testing.T) {
+	_, err := createVrfListener("", 99999)
+	if err == nil {
+		t.Fatal("Expected error for invalid port")
+	}
+}
+
+func TestCreateVrfListenerSuccess(t *testing.T) {
+	listener, err := createVrfListener("", 0)
+	if err != nil {
+		t.Skipf("Could not create VRF listener (this is expected if not running as root or on unsupported system): %v", err)
+	}
+	if listener == nil {
+		t.Fatal("Expected non-nil listener")
+	}
+	defer listener.Close()
+
+	addr := listener.Addr()
+	if addr == nil {
+		t.Error("Expected non-nil address")
+	}
+	t.Logf("Successfully created VRF listener on %s", addr.String())
+
+	tcpAddr, ok := addr.(*net.TCPAddr)
+	if !ok {
+		t.Errorf("Expected TCPAddr, got %T", addr)
+	} else {
+		if tcpAddr.Port == 0 {
+			t.Error("Expected non-zero port to be assigned")
+		}
+		t.Logf("Listener bound to port %d", tcpAddr.Port)
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||
+		(len(s) > 0 && len(substr) > 0 && containsHelper(s, substr)))
+}
+
+func containsHelper(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}
+
 func TestParseOrigin(t *testing.T) {
 	var test_paths []*gnmipb.Path
 	var err error

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -62,6 +62,7 @@ type TelemetryConfig struct {
 	WithMasterArbitration    *bool
 	WithSaveOnSet            *bool
 	IdleConnDuration         *int
+	GnmiVrf                  *string
 	Vrf                      *string
 	EnableCrl                *bool
 	CrlExpireDuration        *int
@@ -185,7 +186,8 @@ func setupFlags(fs *flag.FlagSet) (*TelemetryConfig, *gnmi.Config, error) {
 		WithMasterArbitration:    fs.Bool("with-master-arbitration", false, "Enables master arbitration policy."),
 		WithSaveOnSet:            fs.Bool("with-save-on-set", false, "Enables save-on-set."),
 		IdleConnDuration:         fs.Int("idle_conn_duration", 5, "Seconds before server closes idle connections"),
-		Vrf:                      fs.String("vrf", "", "VRF name, when zmq_address belong on a VRF, need VRF name to bind ZMQ."),
+		GnmiVrf:                  fs.String("gnmi_vrf", "", "VRF name for gNMI server binding."),
+		Vrf:                      fs.String("vrf", "", "VRF name for ZMQ client binding."),
 		EnableCrl:                fs.Bool("enable_crl", false, "Enable certificate revocation list"),
 		CrlExpireDuration:        fs.Int("crl_expire_duration", 86400, "Certificate revocation list cache expire duration"),
 		ImgDirPath:               fs.String("img_dir", "/tmp/host_tmp", "Directory path where image will be transferred."),
@@ -265,6 +267,7 @@ func setupFlags(fs *flag.FlagSet) (*TelemetryConfig, *gnmi.Config, error) {
 	cfg.Threshold = int(*telemetryCfg.Threshold)
 	cfg.IdleConnDuration = int(*telemetryCfg.IdleConnDuration)
 	cfg.ConfigTableName = *telemetryCfg.ConfigTableName
+	cfg.GnmiVrf = *telemetryCfg.GnmiVrf
 	cfg.Vrf = *telemetryCfg.Vrf
 	cfg.EnableCrl = *telemetryCfg.EnableCrl
 	cfg.CaCertLnk = *telemetryCfg.CaCertLnk

--- a/telemetry/telemetry_test.go
+++ b/telemetry/telemetry_test.go
@@ -59,8 +59,14 @@ func TestRunTelemetry(t *testing.T) {
 
 func TestFlags(t *testing.T) {
 	originalArgs := os.Args
+	originalJwtRefreshInt := gnmi.JwtRefreshInt
+	originalJwtValidInt := gnmi.JwtValidInt
+	originalCrlExpireDuration := gnmi.GetCrlExpireDuration()
 	defer func() {
 		os.Args = originalArgs
+		gnmi.JwtRefreshInt = originalJwtRefreshInt
+		gnmi.JwtValidInt = originalJwtValidInt
+		gnmi.SetCrlExpireDuration(originalCrlExpireDuration)
 	}()
 
 	tests := []struct {
@@ -69,6 +75,8 @@ func TestFlags(t *testing.T) {
 		expectedThreshold int
 		expectedIdleDur   int
 		expectedLogLevel  int
+		expectedGnmiVrf   string
+		expectedVrf       string
 	}{
 		{
 			[]string{"cmd", "-port", "9090", "-threshold", "200", "-idle_conn_duration", "10", "-v", "6", "-noTLS"},
@@ -76,6 +84,8 @@ func TestFlags(t *testing.T) {
 			200,
 			10,
 			6,
+			"",
+			"",
 		},
 		{
 			[]string{"cmd", "-port", "2020", "-threshold", "500", "-idle_conn_duration", "4", "-v", "0", "-insecure"},
@@ -83,6 +93,8 @@ func TestFlags(t *testing.T) {
 			500,
 			4,
 			0,
+			"",
+			"",
 		},
 		{
 			[]string{"cmd", "-port", "5050", "-threshold", "10", "-idle_conn_duration", "3", "-v", "-3", "-noTLS"},
@@ -90,6 +102,17 @@ func TestFlags(t *testing.T) {
 			10,
 			3,
 			2,
+			"",
+			"",
+		},
+		{
+			[]string{"cmd", "-port", "8082", "-threshold", "1", "-idle_conn_duration", "1", "-gnmi_vrf", "mgmt", "-vrf", "mgmt", "-noTLS"},
+			8082,
+			1,
+			1,
+			2,
+			"mgmt",
+			"mgmt",
 		},
 		{
 			[]string{"cmd", "-port", "8081", "-threshold", "1", "-idle_conn_duration", "1"},
@@ -97,6 +120,8 @@ func TestFlags(t *testing.T) {
 			1,
 			1,
 			2,
+			"",
+			"",
 		},
 		{
 			[]string{"cmd", "-port", "8081", "-threshold", "1", "-idle_conn_duration", "1", "-server_crt", "../testdata/certs/testserver.cert"},
@@ -104,6 +129,8 @@ func TestFlags(t *testing.T) {
 			1,
 			1,
 			2,
+			"",
+			"",
 		},
 	}
 
@@ -139,6 +166,14 @@ func TestFlags(t *testing.T) {
 
 		if *config.LogLevel != test.expectedLogLevel {
 			t.Errorf("Expected log_level to be %d, got %d", test.expectedLogLevel, *config.LogLevel)
+		}
+
+		if *config.GnmiVrf != test.expectedGnmiVrf {
+			t.Errorf("Expected gnmi_vrf to be %s, got %s", test.expectedGnmiVrf, *config.GnmiVrf)
+		}
+
+		if *config.Vrf != test.expectedVrf {
+			t.Errorf("Expected vrf to be %s, got %s", test.expectedVrf, *config.Vrf)
 		}
 	}
 }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Operators have requested to allow gNMI server to be bound to a particular VRF.
This change is to allow the binding of gnmi/telemetry to a given VRF.

Fixes https://github.com/sonic-net/sonic-gnmi/issues/504
Fixes https://github.com/sonic-net/sonic-buildimage/issues/23865

Related PRs:
- https://github.com/sonic-net/sonic-buildimage/pull/23867
- https://github.com/sonic-net/sonic-mgmt/pull/20456
- https://github.com/sonic-net/sonic-utilities/pull/4395

#### How I did it
Added `GnmiVrf` to gNMI/Telemetry config which is used to create the gNMI listener bound to the given VRF.

#### How to verify it
- `sonic-mgmt` tests have been added [here](https://github.com/sonic-net/sonic-mgmt/pull/20456) for verifying the changes
- `sonic-buildimage` changes with manual verification steps have been added [here](https://github.com/sonic-net/sonic-buildimage/pull/23867)

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add `GnmiVrf` to gNMI/Telemetry config to bind gNMI listener to a VRF

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->
- [GNMI](https://github.com/spandan-nexthop/sonic-buildimage/blob/spandan-nexthop.vrf-aware-gnmi/src/sonic-yang-models/doc/Configuration.md#gnmi)
- [Telemetry](https://github.com/spandan-nexthop/sonic-buildimage/blob/spandan-nexthop.vrf-aware-gnmi/src/sonic-yang-models/doc/Configuration.md#telemetry)

#### A picture of a cute animal (not mandatory but encouraged)
![beluga-whale](https://github.com/user-attachments/assets/1a75d339-c195-4b53-a1b0-b5d82ee77c90)

