### PR TITLE
Fix gNOI system service registration in debian package build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -146,7 +146,7 @@ stages:
         sudo dpkg -i python3-swsscommon_1.0.0_amd64.deb
       workingDirectory: $(Pipeline.Workspace)/
       displayName: 'Install libswsscommon package'
-    
+
     - script: |
         sudo apt-get install -y protobuf-compiler
         protoc --version
@@ -164,7 +164,7 @@ stages:
 
         pushd sonic-gnmi
 
-        dpkg-buildpackage -rfakeroot -us -uc -b -j$(nproc) && cp ../*.deb $(Build.ArtifactStagingDirectory)/
+        ENABLE_TRANSLIB_WRITE=y dpkg-buildpackage -rfakeroot -us -uc -b -j$(nproc) && cp ../*.deb $(Build.ArtifactStagingDirectory)/
       displayName: "Build"
 
     - script: |


### PR DESCRIPTION
The gNOI system service was not being registered at runtime because the debian package was built without ENABLE_TRANSLIB_WRITE flag. The service registration in gnmi_server/server.go requires either EnableTranslibWrite or EnableNativeWrite to be true.

Pass ENABLE_TRANSLIB_WRITE=y environment variable to dpkg-buildpackage to ensure the binary is built with the correct build tags, enabling gNOI system service registration.

#### Why I did it
The gNOI system service (gnoi.system.System) was missing from the gRPC server when installing the debian package built by Azure Pipeline. This prevented usage of critical gNOI operations like system reboot, package installation, and other system management functions.

#### How I did it
Added ENABLE_TRANSLIB_WRITE=y environment variable to the dpkg-buildpackage command in azure-pipelines.yml to ensure the telemetry binary is built with the correct build tags that enable gNOI service registration.

#### How to verify it

**Before the change:**
```
admin@str3-7260cx3-acs-14:~$ ./grpcurl -vv -plaintext localhost:50052 list
gnmi.gNMI
gnoi.sonic.Debug
gnoi.sonic_jwt.SonicJwtService
grpc.reflection.v1.ServerReflection
grpc.reflection.v1alpha.ServerReflection
Timing Data: 2.943131ms
  Dial: 1.196391ms
    BlockingDial: 1.183923ms
```

**After the change:**
```
admin@str3-7260cx3-acs-14:~$ ./grpcurl -vv -plaintext localhost:50052 list
gnmi.gNMI
gnoi.containerz.Containerz
gnoi.factory_reset.FactoryReset
gnoi.file.File
gnoi.os.OS
gnoi.sonic.Debug
gnoi.sonic.SonicService
gnoi.sonic_jwt.SonicJwtService
gnoi.system.System
grpc.reflection.v1.ServerReflection
grpc.reflection.v1alpha.ServerReflection
Timing Data: 3.515083ms
  Dial: 1.823255ms
    BlockingDial: 1.802898ms
```

Notice the addition of:
- gnoi.containerz.Containerz
- gnoi.factory_reset.FactoryReset
- gnoi.file.File
- gnoi.os.OS
- gnoi.sonic.SonicService
- **gnoi.system.System** (critical for system operations)

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
Fix missing gNOI system service in telemetry container by enabling ENABLE_TRANSLIB_WRITE during debian package build