### PR TITLE
Makefile - cleanup of backup_crypto

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ endif
 
 # download and apply patch for gnmi client, which will break advancetls
 # backup crypto and gnxi
-	mkdir backup_crypto
+	mkdir -p backup_crypto
 	cp -r vendor/golang.org/x/crypto/* backup_crypto/
 
 # download and patch crypto and gnxi
@@ -245,6 +245,7 @@ check_memleak: $(DBCONFG) $(ENVFILE)
 clean:
 	$(RM) -r build
 	$(RM) -r vendor
+	$(RM) -r backup_crypto
 
 # File target that generates a diff file if formatting is incorrect
 $(FORMAT_CHECK): $(GO_FILES)


### PR DESCRIPTION
Signed-off-by: miroslav.miklus@pantheon.tech

#### Why I did it
To fix the following issue: 
mkdir backup_crypto mkdir: cannot create directory 'backup_crypto': File exists make[2]: *** [Makefile:99: sonic-gnmi] Error 1 make[2]: Leaving directory '/sonic/src/sonic-gnmi' dh_auto_build: error: make -j1 returned exit code 2

#### How I did it
fix in Makefile

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
updated Makefile

#### Link to config_db schema for YANG module changes

#### A picture of a cute animal (not mandatory but encouraged)
<img width="256"  alt="image" src="https://github.com/user-attachments/assets/2d86c752-8cbe-4e5f-b097-d16c99f60ec0" />
