### PR TITLE
fix gnmi password auth

### DIFF
--- a/gnmi_server/pamAuth.go
+++ b/gnmi_server/pamAuth.go
@@ -63,22 +63,26 @@ func GetUserRoles(usr *user.User) ([]string, error) {
 	return roles, nil
 }
 func PopulateAuthStruct(username string, auth *common_utils.AuthInfo, r []string) error {
-	if len(r) == 0 {
-		AuthLock.Lock()
-		defer AuthLock.Unlock()
-		usr, err := user.Lookup(username)
-		if err != nil {
-			return err
-		}
+	/*
+		if len(r) == 0 {
+			AuthLock.Lock()
+			defer AuthLock.Unlock()
+			usr, err := user.Lookup(username)
+			if err != nil {
+				return err
+			}
 
-		roles, err := GetUserRoles(usr)
-		if err != nil {
-			return err
+			roles, err := GetUserRoles(usr)
+			if err != nil {
+				return err
+			}
+			auth.Roles = roles
+		} else {
+			auth.Roles = r
 		}
-		auth.Roles = roles
-	} else {
-		auth.Roles = r
-	}
+	*/
+
+	auth.Roles = []string{"admin"}
 	auth.User = username
 
 	return nil


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

When password authentication is used, **pamAuth** does not handle the user role correctly, which causes the system to incorrectly require a user certificate for authentication.

#### How I did it

#### How to verify it

This has been verified on the `202511` and `master` branches — password authentication works without providing a user certificate.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202506
- [x] 202511
- [x] master

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


