### PR TITLE
Validate certs before reloading server and add support for CREATE events

### DIFF
--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -295,7 +295,7 @@ func iNotifyCertMonitoring(watcher *fsnotify.Watcher, telemetryCfg *TelemetryCon
 					filepath.Ext(event.Name) == ".cer" || filepath.Ext(event.Name) == ".pem" ||
 					filepath.Ext(event.Name) == ".key") {
 					log.V(1).Infof("Inotify watcher has received event: %v", event)
-					if event.Op&(fsnotify.CloseWrite|fsnotify.MovedTo|fsnotify.Create) != 0 { {
+					if event.Op&(fsnotify.CloseWrite|fsnotify.MovedTo|fsnotify.Create) != 0 {
 						log.V(1).Infof("Cert File has been modified: %s", event.Name)
 
 						// Validate cert/key pair before signaling reload
@@ -310,7 +310,7 @@ func iNotifyCertMonitoring(watcher *fsnotify.Watcher, telemetryCfg *TelemetryCon
 						done <- true
 						return
 					}
-					if event.Op&(fsnotify.Remove|fsnotify.Rename) != 0 { {
+					if event.Op&(fsnotify.Remove|fsnotify.Rename) != 0 {
 						log.V(1).Infof("Cert file has been deleted: %s", event.Name)
 						serverControlSignal <- ServerRestart   // let server know that a remove/rename event occurred
 						if atomic.LoadInt32(certLoaded) == 1 { // Should continue monitoring if certs are not present

--- a/telemetry/telemetry_test.go
+++ b/telemetry/telemetry_test.go
@@ -1309,7 +1309,7 @@ func TestINotifyCertMonitoringCertValidationFails(t *testing.T) {
 	tempDir := t.TempDir()
 	tempCert := filepath.Join(tempDir, "temp.crt")
 	tempKey := filepath.Join(tempDir, "temp.key")
-	
+
 	err = saveCertKeyPair(tempCert, tempKey)
 	if err != nil {
 		t.Fatalf("Failed to create temp cert/key pair: %v", err)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

35638131

Stop reloading of server when cert pairs are not valid. When we listen to file events, we try and validate the pair, and only if the pair is valid we reload the server.

This prevents issues where only one pair of the certs is rotated, and we try and reload the server on partial rotated certs. 

Also support CREATE events for symlink changes.

#### How I did it

Add verification check before reloading

#### How to verify it

UT

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

