### PR TITLE
Add BUILD.md with containerized local build instructions

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -6,6 +6,8 @@ This guide describes how to build `sonic-gnmi` Debian package in a lightweight c
 
 The build process uses the official SONiC build container (`sonic-slave-bookworm`) and pre-built dependencies from Azure pipeline artifacts. This approach is faster and requires less disk space than a full sonic-buildimage build.
 
+**IMPORTANT:** The steps in this guide are extracted from [`azure-pipelines.yml`](azure-pipelines.yml). If you encounter any discrepancies or need the most up-to-date build process, always refer to `azure-pipelines.yml` as the ultimate source of truth.
+
 ## Prerequisites
 
 - Docker installed and running


### PR DESCRIPTION
Documents the process for building sonic-gnmi .deb package using a lightweight Docker container approach without requiring the full sonic-buildimage build system.

Key sections:
- Step-by-step commands for container setup and dependency installation
- Instructions for downloading dependencies from Azure Pipelines
- Building sonic-mgmt-common and sonic-gnmi with all required flags
- Troubleshooting common build issues
- Deployment instructions for SONiC devices

This approach reduces build complexity and disk space requirements compared to a full sonic-buildimage build.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

