### PR TITLE
sonic_data_client: don't recreate ticker on every update

### DIFF
--- a/sonic_data_client/mixed_db_client.go
+++ b/sonic_data_client/mixed_db_client.go
@@ -2066,13 +2066,10 @@ func (c *MixedDbClient) dbTableKeySubscribe(gnmiPath *gnmipb.Path, interval time
 	// Listen on updates from tables.
 	// Depending on the interval, send the updates every interval or on change only.
 	intervalTicker := make(<-chan time.Time)
+	if interval > 0 {
+		intervalTicker = GetIntervalTicker()(interval)
+	}
 	for {
-
-		// The interval ticker ticks only when the interval is non-zero.
-		// Otherwise (e.g. on-change mode) it would never tick.
-		if interval > 0 {
-			intervalTicker = GetIntervalTicker()(interval)
-		}
 
 		select {
 		case updatedTable := <-updateChannel:
@@ -2102,7 +2099,7 @@ func (c *MixedDbClient) dbTableKeySubscribe(gnmiPath *gnmipb.Path, interval time
 				msiAll = make(map[string]interface{})
 				log.V(6).Infof("msiAll cleared: %v", len(msiAll))
 			}
-
+			intervalTicker = GetIntervalTicker()(interval)
 		case <-c.channel:
 			log.V(1).Infof("Stopping dbTableKeySubscribe routine for %v ", c.pathG2S)
 			return


### PR DESCRIPTION
Every update to the updateChannel caused the ticker to be recreated. In theory, this could result in the ticket never being fired if updates continue to come down the channel.

#### Why I did it
The subscription behaviour was incorrect, a stream SAMPLE subscription expects a sample to be provide every `sample_interval`. This was not the case

#### How I did it
Moved the ticker to outside of the for loop so that it is not reset everytime an update comes in.

#### How to verify it
manually verified that the timestamps on SAMPLE responses are now set correctly. Previously some responses would never come after the initial sync due to the notification churn in the system constantly restarting the ticker.

Added sonic-mgmt tests which fail without this change and pass with it: https://github.com/sonic-net/sonic-mgmt/pull/21739

#### Description for the changelog
don't recreate stream SAMPLE ticker on every notification update


