### PR TITLE
[gNOI Debug] Improve validation for command arguments

### DIFF
--- a/pkg/gnoi/debug/validate.go
+++ b/pkg/gnoi/debug/validate.go
@@ -107,11 +107,11 @@ func validateStatement(statement *syntax.Stmt, whitelist []string) error {
 			return fmt.Errorf("%w: empty call", ErrRejected)
 		}
 
-		// Every Word must be a literal (no param/cmd/arith/brace/glob/...).
-		for i, w := range call.Args {
-			lit := w.Lit()
-			if lit == "" {
-				return fmt.Errorf("%w: word %d is not a plain literal (contains expansions/substs/globs)", ErrRejected, i)
+		// Check that every word only consists of word parts with safe node types
+		for _, word := range call.Args {
+			err := validateWordParts(word, word.Parts)
+			if err != nil {
+				return err
 			}
 		}
 
@@ -180,6 +180,39 @@ func walkForDangerousNodeTypes(node syntax.Node) bool {
 	})
 
 	return unsafe
+}
+
+// Helper to determine whether a set of word parts contains any potentially dangerous constructs.
+// Allowed word part types are:
+//   - Lit: Represents a literal, will not be affected by expansion
+//   - SglQuoted: Represents a string enclosed in single quotes, will not be affected by expansion
+//   - DblQuoted: Represents word parts enclosed in double quotes, may be affected by expansion (requiring recursive validation)
+func validateWordParts(word *syntax.Word, wordParts []syntax.WordPart) error {
+	for _, part := range wordParts {
+		switch partType := part.(type) {
+		case *syntax.Lit:
+			continue
+		case *syntax.SglQuoted:
+			continue
+		case *syntax.DblQuoted:
+			subParts := part.(*syntax.DblQuoted).Parts
+			err := validateWordParts(word, subParts)
+			if err != nil {
+				return err
+			}
+			continue
+		default:
+			var wordString strings.Builder
+			var wordPartString strings.Builder
+			printer := syntax.NewPrinter()
+			printer.Print(&wordString, word)
+			printer.Print(&wordPartString, part)
+
+			return fmt.Errorf("%w: '%s' contained in '%s' is invalid type: %s", ErrRejected, wordPartString.String(), wordString.String(), partType)
+		}
+	}
+
+	return nil
 }
 
 // Helper which ports the slices.Contains functionality for string slices to this version of Go.

--- a/pkg/gnoi/debug/validate_test.go
+++ b/pkg/gnoi/debug/validate_test.go
@@ -13,6 +13,7 @@ var exampleWhitelist = []string{
 	"tar",
 	"sleep",
 	"grep",
+	"awk",
 }
 
 func TestValidateAndExtract(t *testing.T) {
@@ -36,6 +37,13 @@ func TestValidateAndExtract(t *testing.T) {
 			allow:        true,
 			expectedCmd:  "ls",
 			expectedArgs: []string{"-la", "/tmp"},
+		},
+		{
+			name:         "grep pipeline",
+			input:        "ls -la | grep \"filename.txt\"",
+			allow:        true,
+			expectedCmd:  "ls",
+			expectedArgs: []string{"-la", "|", "grep", "\"filename.txt\""},
 		},
 		{
 			name:  "command substitution",
@@ -182,8 +190,8 @@ func TestValidateAndExtract(t *testing.T) {
 			allow: false,
 		},
 		{
-			name:  "pipeline with malicious quoted arg",
-			input: "ls | grep '; rm -rf /'",
+			name:  "awk with malicious command",
+			input: "awk BEGIN\\ \\{\\ cmd\\ =\\ \\\"ip\\ link\\\"\\;\\ while\\ \\(\\ \\(\\ cmd\\ \\|\\ getline\\ result\\ \\)\\ \\>\\ 0\\ \\)\\ \\{\\ print\\ result\\ \\}\\;\\ close\\(cmd\\)\\;\\ \\}",
 			allow: false,
 		},
 		{


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Commands containing single or double quotes would refuse to run, despite the contents themselves being safe, due to failing validation (as the word part validation expected ONLY Literals). This change introduces more comprehensive validation to account for these situations.

#### How I did it

Word part validation now leverages a helper function, which includes support for single and double quoted word parts. Additionally, for double quoted word parts in particular, all word parts contained within are fed through the validation helper recursively, such that there isn't the possibility of enclosing dangerous node types within double quotes to bypass this validation.

#### How to verify it

Unit tests have been added for both safe and unsafe double quoted cases.
Additionally, the following manual testing has been performed:

##### Previous Behaviour
The following safe command does not pass validation, when it should:
```
>>> client = sonic_debug_client.DebugContainerClient("10.250.0.101", 8080, use_ssl = False)
No private key specified - mTLS will not be available
>>> client.run_command("ls -la")
total 126313
drwxr-xr-x 1 admin admin      4096 Nov 10 23:42 .
drwxr-xr-x 1 root  root       4096 Nov  6 02:57 ..
-rw------- 1 admin admin       426 Dec  4 04:54 .bash_history
-rw-r--r-- 1 admin admin       220 Jun  6  2025 .bash_logout
-rw-r--r-- 1 admin admin      3526 Jun  6  2025 .bashrc
-rw-r--r-- 1 admin admin 129317225 Nov 10 23:42 docker-sonic-gnmi.gz
-rw-r--r-- 1 admin admin       807 Jun  6  2025 .profile
-rw-r--r-- 1 admin admin         0 Nov  6 05:47 .sudo_as_admin_successful
0
>>> client.run_command("ls -la | grep \"profile\"")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/mattsoulsby/debug-service/.venv/lib/python3.11/site-packages/sonic_debug_client/client.py", line 22, in wrapper
    result = func(self, *args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/mattsoulsby/debug-service/.venv/lib/python3.11/site-packages/sonic_debug_client/client.py", line 133, in run_command
    for response in responses:
  File "/home/mattsoulsby/debug-service/.venv/lib/python3.11/site-packages/grpc/_channel.py", line 543, in __next__
    return self._next()
           ^^^^^^^^^^^^
  File "/home/mattsoulsby/debug-service/.venv/lib/python3.11/site-packages/grpc/_channel.py", line 972, in _next
    raise self
grpc._channel._MultiThreadedRendezvous: <_MultiThreadedRendezvous of RPC that terminated with:
        status = StatusCode.PERMISSION_DENIED
        details = "command failed validation: command rejected by policy: word 1 is not a plain literal (contains expansions/substs/globs)"
        debug_error_string = "UNKNOWN:Error received from peer  {grpc_status:7, grpc_message:"command failed validation: command rejected by policy: word 1 is not a plain literal (contains expansions/substs/globs)"}"
>
>>>

```

##### New Behaviour
The command now passes validation:
```
Python 3.11.12 (main, May 17 2025, 13:48:36) [Clang 20.1.4 ] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import sonic_debug_client
>>> client = sonic_debug_client.DebugContainerClient("10.250.0.101", 8080, use_ssl = False)
No private key specified - mTLS will not be available
>>> client.run_command('ls -la | grep "boot"')
drwxr--r--   2 root root 4096 Nov  6 05:08 boot
lrwxrwxrwx   1 root root   32 Nov  6 02:56 initrd.img -> boot/initrd.img-6.1.0-29-2-amd64
lrwxrwxrwx   1 root root   32 Nov  6 02:56 initrd.img.old -> boot/initrd.img-6.1.0-29-2-amd64
lrwxrwxrwx   1 root root   29 Nov  6 02:56 vmlinuz -> boot/vmlinuz-6.1.0-29-2-amd64
lrwxrwxrwx   1 root root   29 Nov  6 02:56 vmlinuz.old -> boot/vmlinuz-6.1.0-29-2-amd64
0
>>>
```

Additionally, unsafe commands are still caught:
```
>>> client.run_command('ls -la | grep "$(rm -rf /)"')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/mattsoulsby/debug-service/.venv/lib/python3.11/site-packages/sonic_debug_client/client.py", line 22, in wrapper
    result = func(self, *args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/mattsoulsby/debug-service/.venv/lib/python3.11/site-packages/sonic_debug_client/client.py", line 133, in run_command
    for response in responses:
  File "/home/mattsoulsby/debug-service/.venv/lib/python3.11/site-packages/grpc/_channel.py", line 543, in __next__
    return self._next()
           ^^^^^^^^^^^^
  File "/home/mattsoulsby/debug-service/.venv/lib/python3.11/site-packages/grpc/_channel.py", line 972, in _next
    raise self
grpc._channel._MultiThreadedRendezvous: <_MultiThreadedRendezvous of RPC that terminated with:
        status = StatusCode.PERMISSION_DENIED
        details = "command failed validation: command rejected by policy: `ls -la | grep "$(rm -rf /)"` contains unsafe statements"
        debug_error_string = "UNKNOWN:Error received from peer  {grpc_message:"command failed validation: command rejected by policy: `ls -la | grep \"$(rm -rf /)\"` contains unsafe statements", grpc_status:7}"
>
>>>

```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

