### PR TITLE
Support for OC-YANG target for dialout telemetry

### DIFF
--- a/dialout/dialout_client/dialout_client.go
+++ b/dialout/dialout_client/dialout_client.go
@@ -9,9 +9,7 @@ import (
 	"github.com/go-redis/redis"
 	log "github.com/golang/glog"
 	gpb "github.com/openconfig/gnmi/proto/gnmi"
-	gnmi_extpb "github.com/openconfig/gnmi/proto/gnmi_ext"
 	"github.com/openconfig/ygot/ygot"
-	gnmi "github.com/sonic-net/sonic-gnmi/gnmi_server"
 	spb "github.com/sonic-net/sonic-gnmi/proto"
 	sdc "github.com/sonic-net/sonic-gnmi/sonic_data_client"
 	sdcfg "github.com/sonic-net/sonic-gnmi/sonic_db_config"
@@ -186,48 +184,21 @@ func (cs *clientSubscription) NewInstance(ctx context.Context) error {
 		return fmt.Errorf("Destination group %v doesn't exist", cs.destGroupName)
 	}
 
-	// Extract origin and target from prefix and paths
-	origin := cs.prefix.GetOrigin()
 	target := cs.prefix.GetTarget()
-
-	// Parse origin from paths if not set in prefix
-	if o, err := gnmi.ParseOrigin(cs.paths); err != nil {
-		return err // origin conflict within paths
-	} else if len(origin) == 0 {
-		origin = o // Use origin from paths if not given in prefix
-	} else if len(o) != 0 && o != origin {
-		return fmt.Errorf("Origin conflict between prefix and paths")
+	if target == "" {
+		return fmt.Errorf("Empty target data not supported yet")
 	}
-
-	log.V(2).Infof("origin=%q, target=%q for %v", origin, target, cs.name)
 
 	// Connection to system data source
 	var dc sdc.Client
 	var err error
-	var extensions []*gnmi_extpb.Extension // No extensions for dialout client
-
-	// Handle origin-based and target-based routing
-	if origin == "openconfig" {
-		dc, err = sdc.NewTranslClient(cs.prefix, cs.paths, ctx, extensions, sdc.TranslWildcardOption{})
-	} else if gnmi.IsNativeOrigin(origin) {
-		// Native origin (sonic-db) - use MixedDbClient
-		var targetDbName string
-		dc, err = sdc.NewMixedDbClient(cs.paths, cs.prefix, origin, gpb.Encoding_JSON_IETF, "", "", &targetDbName)
-	} else if len(origin) != 0 {
-		return fmt.Errorf("Unsupported origin: %s", origin)
-	} else if target == "" {
-		return fmt.Errorf("Empty target data not supported")
-	} else if target == "OTHERS" {
+	if target == "OTHERS" {
 		dc, err = sdc.NewNonDbClient(cs.paths, cs.prefix)
-	} else if targetDbName, ok, _, _ := sdc.IsTargetDb(target); ok {
-		dc, err = sdc.NewDbClient(cs.paths, cs.prefix)
-		log.V(2).Infof("Using DbClient for target database: %s", targetDbName)
+	} else if target == "OC_YANG" {
+		dc, err = sdc.NewTranslClient(cs.prefix, cs.paths, ctx, nil, sdc.TranslWildcardOption{})
 	} else {
-		// For any other target or no target match, create new Transl Client
-		// This handles cases like "OC_YANG" or other unrecognized targets as OpenConfig
-		dc, err = sdc.NewTranslClient(cs.prefix, cs.paths, ctx, extensions, sdc.TranslWildcardOption{})
+		dc, err = sdc.NewDbClient(cs.paths, cs.prefix)
 	}
-
 	if err != nil {
 		log.V(1).Infof("Connection to DB for %v failed: %v", *cs, err)
 		return fmt.Errorf("Connection to DB for %v failed: %v", *cs, err)

--- a/dialout/dialout_client/dialout_client_test.go
+++ b/dialout/dialout_client/dialout_client_test.go
@@ -582,7 +582,7 @@ func TestNewInstanceOCYang(t *testing.T) {
 	if err != nil {
 		// Check if it's a connection/DB error (expected in test environment)
 		if !strings.Contains(err.Error(), "Connection to DB") &&
-		   !strings.Contains(err.Error(), "Destination group") {
+			!strings.Contains(err.Error(), "Destination group") {
 			t.Logf("NewInstance returned error (expected in test env): %v", err)
 		} else {
 			t.Logf("NewInstance returned expected error: %v", err)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Dialout telemetry doesn't work with OC Yang target

#### How I did it
Add support for target OC_YANG

https://github.com/sonic-net/sonic-buildimage/pull/24982

#### How to verify it
Test telemetry subscription for OC Yang with dialout

```
127.0.0.1:6379[4]> hgetall "TELEMETRY_CLIENT|Global"
1) "retry_interval"
2) "5"
3) "unidirectional"
4) "true"
5) "encoding"
6) "JSON_IETF"
127.0.0.1:6379[4]> hgetall "TELEMETRY_CLIENT|DestinationGroup_MyCollector"
1) "dst_addr"
2) "172.26.228.175:9000"
127.0.0.1:6379[4]>
127.0.0.1:6379[4]> hgetall "TELEMETRY_CLIENT|Subscription_SensorGroup1"
 1) "path_target"
 2) "OC_YANG"
 3) "paths"
 4) "/openconfig-system:system/config/hostname,/openconfig-platform:components/component[name=Ethernet228]/state/oper-status"
 5) "report_type"
 6) "periodic"
 7) "dst_group"
 8) "MyCollector"
 9) "report_interval"
10) "30000"
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

