### PR TITLE
Fix DBUS connection leak causing "maximum pending replies" error

### DIFF
--- a/sonic_service_client/dbus_client.go
+++ b/sonic_service_client/dbus_client.go
@@ -88,6 +88,7 @@ func DbusApi(busName string, busPath string, intName string, timeout int, args .
 		common_utils.IncCounter(common_utils.DBUS_FAIL)
 		return nil, err
 	}
+	defer conn.Close()
 
 	ch := make(chan *dbus.Call, 1)
 	obj := conn.Object(busName, dbus.ObjectPath(busPath))


### PR DESCRIPTION
Each call to DbusApi() creates a new DBUS SystemBus connection but never closes it. This causes connection accumulation and eventually hits the DBUS daemon's pending reply limit, resulting in the error: "The maximum number of pending replies per connection has been reached"

Add defer conn.Close() to ensure connections are properly cleaned up after each DBUS call completes or times out.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

