### PR TITLE
[ssw][ha] use ProducerStateTable for DASH_HA_ tables. 

### DIFF
--- a/sonic_data_client/client_test.go
+++ b/sonic_data_client/client_test.go
@@ -836,14 +836,19 @@ func TestGetTableDashHA(t *testing.T) {
 
 	// Create ZMQ server and client
 	zmqServer := swsscommon.NewZmqServer("tcp://*:3234")
+	defer swsscommon.DeleteZmqServer(zmqServer)
 	zmqAddress := "tcp://127.0.0.1:3234"
+
+	zmqClient := swsscommon.NewZmqClient(zmqAddress)
+	defer swsscommon.DeleteZmqClient(zmqClient)
 
 	client := MixedDbClient{
 		applDB:      swsscommon.NewDBConnector(APPL_DB_NAME, SWSS_TIMEOUT, false),
 		tableMap:    map[string]swsscommon.ProducerStateTable{},
 		zmqTableMap: map[string]swsscommon.ZmqProducerStateTable{},
-		zmqClient:   swsscommon.NewZmqClient(zmqAddress),
+		zmqClient:   zmqClient,
 	}
+	defer client.Close()
 
 	// Test DASH_ROUTE table - should use ZmqProducerStateTable
 	_ = client.GetTable("DASH_ROUTE")
@@ -871,9 +876,4 @@ func TestGetTableDashHA(t *testing.T) {
 	if _, ok := client.zmqTableMap["DASH_HA_SCOPE_CONFIG_TABLE"]; ok {
 		t.Errorf("DASH_HA_SCOPE_CONFIG_TABLE should not use ZmqProducerStateTable")
 	}
-
-	// Cleanup
-	client.Close()
-	swsscommon.DeleteZmqClient(client.zmqClient)
-	swsscommon.DeleteZmqServer(zmqServer)
 }

--- a/sonic_data_client/mixed_db_client.go
+++ b/sonic_data_client/mixed_db_client.go
@@ -261,6 +261,8 @@ func (c *MixedDbClient) GetTable(table string) swsscommon.ProducerStateTable {
 		return pt
 	}
 
+	// DASH_HA_ tables use ProducerStateTable (not ZMQ) because hamgrd subscribes
+	// via SubscriberStateTable which has rehydration support.
 	if strings.HasPrefix(table, DASH_TABLE_PREFIX) && !strings.HasPrefix(table, DASH_HA_TABLE_PREFIX) && c.zmqClient != nil {
 		log.V(2).Infof("Create ZmqProducerStateTable:  %s", table)
 		zmqTable := swsscommon.NewZmqProducerStateTable(c.applDB, table, c.zmqClient)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Today hamgrd use `SubscribeStateTable` instead of `ZmqConsumerStateTable`. `ZmqConsumerStateTable` doesn't support rehydration. 
https://github.com/sonic-net/sonic-dash-ha/blob/c04969eb024bb8d5b21f78778b8c69aa3c5af2b8/crates/hamgrd/src/actors.rs#L49

sign-off: Jing Zhang zhangjing@microsoft.com

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

