### PR TITLE
Add optional direct CONFIG_DB write support bypassing D-Bus for allow…

### DIFF
--- a/gnmi_server/client_subscribe.go
+++ b/gnmi_server/client_subscribe.go
@@ -163,7 +163,7 @@ func (c *Client) Run(stream gnmipb.GNMI_SubscribeServer, config *Config) (err er
 		dc, err = sdc.NewTranslClient(prefix, paths, ctx, extensions, sdc.TranslWildcardOption{})
 	} else if IsNativeOrigin(origin) {
 		var targetDbName string
-		dc, err = sdc.NewMixedDbClient(paths, prefix, origin, gnmipb.Encoding_JSON_IETF, "", "", &targetDbName)
+		dc, err = sdc.NewMixedDbClient(paths, prefix, origin, gnmipb.Encoding_JSON_IETF, "", "", &targetDbName, false, nil)
 		authTarget = "gnmi_" + targetDbName
 	} else if len(origin) != 0 {
 		return grpc.Errorf(codes.Unimplemented, "Unsupported origin: %s", origin)

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -63,6 +63,8 @@ type TelemetryConfig struct {
 	EnableCrl             *bool
 	CrlExpireDuration     *int
 	ImgDirPath            *string
+	EnableDirectDbWrite   *bool
+	DirectDbWriteTables   *string
 }
 
 func main() {
@@ -178,6 +180,8 @@ func setupFlags(fs *flag.FlagSet) (*TelemetryConfig, *gnmi.Config, error) {
 		EnableCrl:             fs.Bool("enable_crl", false, "Enable certificate revocation list"),
 		CrlExpireDuration:     fs.Int("crl_expire_duration", 86400, "Certificate revocation list cache expire duration"),
 		ImgDirPath:            fs.String("img_dir", "/tmp/host_tmp", "Directory path where image will be transferred."),
+		EnableDirectDbWrite:   fs.Bool("direct_db_write", false, "Enable direct CONFIG_DB write bypassing D-Bus for allowed tables"),
+		DirectDbWriteTables:   fs.String("direct_db_write_tables", "", "Comma-separated table names allowed for direct DB write"),
 	}
 
 	fs.Var(&telemetryCfg.UserAuth, "client_auth", "Client auth mode(s) - none,cert,password")
@@ -259,6 +263,12 @@ func setupFlags(fs *flag.FlagSet) (*TelemetryConfig, *gnmi.Config, error) {
 
 	// Populate the OS-related fields directly on the gnmi.Config struct.
 	cfg.ImgDir = *telemetryCfg.ImgDirPath
+
+	// Populate direct DB write configuration
+	cfg.EnableDirectDbWrite = *telemetryCfg.EnableDirectDbWrite
+	if *telemetryCfg.DirectDbWriteTables != "" {
+		cfg.DirectDbWriteTables = strings.Split(*telemetryCfg.DirectDbWriteTables, ",")
+	}
 
 	return telemetryCfg, cfg, nil
 }


### PR DESCRIPTION
…ed tables

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it


The current CONFIG_DB write path goes through D-Bus to the SONiC Host Service GCU module, which provides YANG validation and safe configuration updates. However, for certain use cases where:
- High-frequency updates are needed
- Tables don't require YANG validation
- Lower latency is critical

This feature allows administrators to configure specific tables that can be written directly to Redis, similar to how APPL_DB writes work.


#### How I did it
This PR adds an optional feature to allow direct CONFIG_DB writes bypassing the D-Bus/GCU (Generic Config Updater) path for specific tables configured at server startup.
#### How to verify it

#### Which release branch to backport (provide reason below if selected)



<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

