### PR TITLE
convert updates_only to suppress_redundant

### DIFF
--- a/sonic_data_client/mixed_db_client.go
+++ b/sonic_data_client/mixed_db_client.go
@@ -1989,7 +1989,7 @@ func (c *MixedDbClient) dbSingleTableKeySubscribe(rsd redisSubData, updateChanne
 // dbTableKeySubscribe subscribes to tables using a table keys.
 // Handles queries like "COUNTERS/Ethernet0" or "COUNTERS/Ethernet*"
 // This function handles both ON_CHANGE and SAMPLE modes. "interval" being 0 is interpreted as ON_CHANGE mode.
-func (c *MixedDbClient) dbTableKeySubscribe(gnmiPath *gnmipb.Path, interval time.Duration, updateOnly bool) {
+func (c *MixedDbClient) dbTableKeySubscribe(gnmiPath *gnmipb.Path, interval time.Duration, suppressRedundant bool) {
 	defer c.w.Done()
 
 	msiAll := make(map[string]interface{})
@@ -2106,7 +2106,7 @@ func (c *MixedDbClient) dbTableKeySubscribe(gnmiPath *gnmipb.Path, interval time
 	signalSync()
 
 	// Clear the payload so that next time it will send only updates
-	if updateOnly {
+	if suppressRedundant {
 		msiAll = make(map[string]interface{})
 	}
 
@@ -2148,7 +2148,7 @@ func (c *MixedDbClient) dbTableKeySubscribe(gnmiPath *gnmipb.Path, interval time
 			}
 
 			// Clear the payload so that next time it will send only updates
-			if updateOnly {
+			if suppressRedundant {
 				msiAll = make(map[string]interface{})
 				log.V(6).Infof("msiAll cleared: %v", len(msiAll))
 			}


### PR DESCRIPTION
#### Why I did it
This flag was incorrectly implemented.

See related part of gNMI spec at https://github.com/openconfig/reference/blob/master/rpc/gnmi/gnmi-specification.md#35152-stream-subscriptions

> Optionally, the suppress_redundant field of the Subscription message may be set for a sampled subscription. In the case that it is set to true, the target SHOULD NOT generate a telemetry update message unless the value of the path being reported on has changed since the last update was generated. Updates MUST only be generated for those individual leaf nodes in the subscription that have changed. 

On the other hand, upadtes_only effectively just means skip the initial sync and then send samples as per usual.

Note this will need changes to sonic-mgmt also, I am holding off on doing that until the gNMIC PR I have raised is merged as this will make things easier. Raising the PR now just to show it is a triaged issue.

#### How I did it
Made the same code flow look at the suppress redundant flag and not updates_only as it behaved in the way it should when the suppress_redundant flag is sent.

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

