### PR TITLE
Parallelize GET and SUBSCRIBE processing

### DIFF
--- a/sonic_data_client/transl_data_client.go
+++ b/sonic_data_client/transl_data_client.go
@@ -3,9 +3,11 @@ package client
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"reflect"
 	"runtime"
+	"strings"
 	"sync"
 	"time"
 
@@ -24,10 +26,15 @@ import (
 )
 
 const (
-	DELETE  int = 0
-	REPLACE int = 1
-	UPDATE  int = 2
+	DELETE     int = 0
+	REPLACE    int = 1
+	UPDATE     int = 2
+	maxWorkers     = 2 // max workers for parallel processing of Get/Subscribe requests
 )
+
+var useParallelProcessing = flag.Bool("use_parallel_processing", false, "use parallel processing for GET/SUBSCRIBE requests")
+var translProcessGetFunc = transutil.TranslProcessGet
+var isSubscribeSupportedFunc = translib.IsSubscribeSupported
 
 type TranslClient struct {
 	prefix *gnmipb.Path
@@ -44,6 +51,38 @@ type TranslClient struct {
 
 	version  *translib.Version // Client version; populated by parseVersion()
 	encoding gnmipb.Encoding
+}
+type pathFromGetReq struct {
+	path *gnmipb.Path
+	uri  string
+	c    *TranslClient
+}
+
+type pathFromSubReq struct {
+	path string
+	ts   *translSubscriber
+}
+
+func findMin(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func joinErrorsWithNewline(errs []error) error {
+	//Length of 'err' validation is done before func call.
+	var errStrings []string
+	for _, err := range errs {
+		if err != nil {
+			errStrings = append(errStrings, err.Error())
+		}
+	}
+	if len(errStrings) == 0 {
+		return nil // Return actual nil, not an empty error object
+	}
+	// Using "\n" matches the visual output of errors.Join
+	return fmt.Errorf("%s", strings.Join(errStrings, "\n"))
 }
 
 func NewTranslClient(prefix *gnmipb.Path, getpaths []*gnmipb.Path, ctx context.Context, extensions []*gnmi_extpb.Extension, opts ...TranslClientOption) (Client, error) {
@@ -76,6 +115,7 @@ func NewTranslClient(prefix *gnmipb.Path, getpaths []*gnmipb.Path, ctx context.C
 func (c *TranslClient) Get(w *sync.WaitGroup) ([]*spb.Value, error) {
 	rc, ctx := common_utils.GetContext(c.ctx)
 	c.ctx = ctx
+	var errs []error
 	var values []*spb.Value
 	ts := time.Now()
 
@@ -83,22 +123,55 @@ func (c *TranslClient) Get(w *sync.WaitGroup) ([]*spb.Value, error) {
 	if version != nil {
 		rc.BundleVersion = version
 	}
-	/* Iterate through all GNMI paths. */
+	// Iterate through all GNMI paths in parallel. The max number of workers is equal to
+	// the number of Openconfig modules in a root query.
+	numPaths := len(c.path2URI)
+	pathChan := make(chan pathFromGetReq, numPaths)
+	valueChan := make(chan *spb.Value, numPaths)
+	errChan := make(chan error, numPaths)
+	workerWg := &sync.WaitGroup{}
+	readerWg := &sync.WaitGroup{}
+
+	numWorkers := 1
+	if *useParallelProcessing {
+		numWorkers = findMin(numPaths, maxWorkers)
+	}
+
+	// Spawn workers to process the paths in the GET request.
+	for i := 0; i < numWorkers; i++ {
+		workerWg.Add(1)
+		go processGetWorker(pathChan, valueChan, errChan, workerWg)
+	}
+
+	// Send the paths in the GET request to the workers through the channel.
 	for gnmiPath, URIPath := range c.path2URI {
-		/* Fill values for each GNMI path. */
-		val, err := transutil.TranslProcessGet(URIPath, nil, c.ctx)
+		pathChan <- pathFromGetReq{path: gnmiPath, uri: URIPath, c: c}
+	}
+	close(pathChan)
 
-		if err != nil {
-			return nil, err
+	// Start goroutines to read the response values and errors from the workers.
+	readerWg.Add(2)
+	go func() {
+		defer readerWg.Done()
+		for value := range valueChan {
+			values = append(values, value)
 		}
+	}()
+	go func() {
+		defer readerWg.Done()
+		for err := range errChan {
+			errs = append(errs, err)
+		}
+	}()
 
-		/* Value of each path is added to spb value structure. */
-		values = append(values, &spb.Value{
-			Prefix:    c.prefix,
-			Path:      gnmiPath,
-			Timestamp: ts.UnixNano(),
-			Val:       val,
-		})
+	// Wait for all goroutines to finish.
+	workerWg.Wait()
+	close(valueChan)
+	close(errChan)
+	readerWg.Wait()
+
+	if len(errs) != 0 {
+		return nil, joinErrorsWithNewline(errs)
 	}
 
 	/* The values structure at the end is returned and then updates in notitications as
@@ -108,6 +181,31 @@ func (c *TranslClient) Get(w *sync.WaitGroup) ([]*spb.Value, error) {
 	log.V(4).Infof("TranslClient :Get done, total time taken: %v ms", int64(time.Since(ts)/time.Millisecond))
 
 	return values, nil
+}
+
+// processGetWorker is a worker function to remove paths from a GET request off of the channel and process them.
+func processGetWorker(pathChan <-chan pathFromGetReq, valueChan chan<- *spb.Value, errChan chan<- error, wg *sync.WaitGroup) {
+	defer wg.Done()
+	for path := range pathChan {
+		log.Infof("getWorker processing path: %v", path)
+		val, resp, err := translProcessGetFunc(path.uri, nil, path.c.ctx, path.c.encoding)
+		if err != nil {
+			errChan <- err
+			return
+		}
+
+		var valueTree ygot.ValidatedGoStruct
+		if resp != nil {
+			valueTree = resp.ValueTree
+		}
+		v, err := buildValueForGet(path.c.prefix, path.path, path.c.encoding, val, valueTree)
+		if err != nil {
+			errChan <- err
+			return
+		}
+
+		valueChan <- v
+	}
 }
 
 func (c *TranslClient) Set(delete []*gnmipb.Path, replace []*gnmipb.Update, update []*gnmipb.Update) error {
@@ -234,13 +332,25 @@ func (c *TranslClient) StreamRun(q *queue.PriorityQueue, stop chan struct{}, w *
 		req.ClientVersion = *c.version
 	}
 
-	subSupport, err := translib.IsSubscribeSupported(req)
+	subSupport, err := isSubscribeSupportedFunc(req)
 	if err != nil {
 		enqueFatalMsgTranslib(c, fmt.Sprintf("Subscribe operation failed with error =%v", err.Error()))
 		return
 	}
 
+	numSubWorkers := 1
+	if *useParallelProcessing {
+		numSubWorkers = findMin(len(subscribe.Subscription), maxWorkers)
+	}
+
 	var onChangeSubsString []string
+	// Spawn routines to process the Sample subscriptions
+	wg := &sync.WaitGroup{}
+	subChan := make(chan pathFromSubReq, len(subscribe.Subscription))
+	for i := 0; i < numSubWorkers; i++ {
+		wg.Add(1)
+		go processSubWorker(subChan, wg)
+	}
 
 	for i, pInfo := range subSupport {
 		sub := subscribe.Subscription[pInfo.ID]
@@ -259,12 +369,14 @@ func (c *TranslClient) StreamRun(q *queue.PriorityQueue, stop chan struct{}, w *
 				subscribe_mode = gnmipb.SubscriptionMode_ON_CHANGE
 			} else {
 				enqueFatalMsgTranslib(c, fmt.Sprintf("ON_CHANGE Streaming mode invalid for %v", pathStr))
+				close(subChan)
 				return
 			}
 		case gnmipb.SubscriptionMode_SAMPLE:
 			subscribe_mode = gnmipb.SubscriptionMode_SAMPLE
 		default:
 			enqueFatalMsgTranslib(c, fmt.Sprintf("Invalid Subscription Mode %d", sub.Mode))
+			close(subChan)
 			return
 		}
 
@@ -275,6 +387,7 @@ func (c *TranslClient) StreamRun(q *queue.PriorityQueue, stop chan struct{}, w *
 		if hb := sub.HeartbeatInterval; hb > 0 && hb < uint64(pInfo.MinInterval)*uint64(time.Second) {
 			enqueFatalMsgTranslib(c, fmt.Sprintf("Invalid Heartbeat Interval %ds, minimum interval is %ds",
 				sub.HeartbeatInterval/uint64(time.Second), subSupport[i].MinInterval))
+			close(subChan)
 			return
 		}
 
@@ -286,6 +399,7 @@ func (c *TranslClient) StreamRun(q *queue.PriorityQueue, stop chan struct{}, w *
 				interval = minInterval
 			} else if interval < minInterval {
 				enqueFatalMsgTranslib(c, fmt.Sprintf("Invalid SampleInterval %ds, minimum interval is %ds", interval/int(time.Second), pInfo.MinInterval))
+				close(subChan)
 				return
 			}
 
@@ -306,7 +420,8 @@ func (c *TranslClient) StreamRun(q *queue.PriorityQueue, stop chan struct{}, w *
 			}
 
 			// do initial sync & build the cache
-			ts.doSample(pathStr)
+			// Add the path to the channel to be processed in parallel
+			subChan <- pathFromSubReq{path: pathStr, ts: &ts}
 
 			addTimer(c, ticker_map, &cases, cases_map, interval, sub, pathStr, false)
 			//Heartbeat intervals are valid for SAMPLE in the case suppress_redundant is specified
@@ -321,18 +436,21 @@ func (c *TranslClient) StreamRun(q *queue.PriorityQueue, stop chan struct{}, w *
 		}
 		log.V(6).Infof("End Sub: %v", sub)
 	}
+	close(subChan)
 
 	if len(onChangeSubsString) > 0 {
 		ts := translSubscriber{
 			client:     c,
 			session:    ss,
 			filterMsgs: subscribe.UpdatesOnly,
+			sampleWg:   wg,
 		}
 		ts.doOnChange(onChangeSubsString)
 	} else {
 		// If at least one ON_CHANGE subscription was present, then
 		// ts.doOnChange() would have sent the sync message.
 		// Explicitly send one here if all are SAMPLE subscriptions.
+		wg.Wait()
 		enqueueSyncMessage(c)
 	}
 
@@ -344,16 +462,37 @@ func (c *TranslClient) StreamRun(q *queue.PriorityQueue, stop chan struct{}, w *
 			return
 		}
 
-		for _, tick := range ticker_map[cases_map[chosen]] {
+		// Start goroutines to process the Sample.
+		ticks := ticker_map[cases_map[chosen]]
+		tickSubChan := make(chan pathFromSubReq, len(ticks))
+		numTickWorkers := 1
+		if *useParallelProcessing {
+			numTickWorkers = findMin(len(ticks), maxWorkers)
+		}
+		for i := 0; i < numTickWorkers; i++ {
+			wg.Add(1)
+			go processSubWorker(tickSubChan, wg)
+		}
+		for _, tick := range ticks {
 			log.V(6).Infof("tick, heartbeat: %t, path: %s\n", tick.heartbeat, c.path2URI[tick.sub.Path])
 			ts := translSubscriber{
 				client:      c,
 				session:     ss,
 				sampleCache: sampleCache[tick.pathStr],
 				filterDups:  (!tick.heartbeat && tick.sub.SuppressRedundant),
+				sampleWg:    wg,
 			}
-			ts.doSample(tick.pathStr)
+			tickSubChan <- pathFromSubReq{path: tick.pathStr, ts: &ts}
 		}
+		close(tickSubChan)
+		wg.Wait()
+	}
+}
+
+func processSubWorker(subChan <-chan pathFromSubReq, wg *sync.WaitGroup) {
+	defer wg.Done()
+	for sub := range subChan {
+		sub.ts.doSample(sub.path)
 	}
 }
 
@@ -402,12 +541,26 @@ func (c *TranslClient) PollRun(q *queue.PriorityQueue, poll chan struct{}, w *sy
 		}
 
 		t1 := time.Now()
+		// Spawn worker threads to process the subscription
+		numPaths := len(c.path2URI)
+		wg := &sync.WaitGroup{}
+		subChan := make(chan pathFromSubReq, numPaths)
+		numWorkers := 1
+		if *useParallelProcessing {
+			numWorkers = findMin(numPaths, maxWorkers)
+		}
+		for i := 0; i < numWorkers; i++ {
+			wg.Add(1)
+			go processSubWorker(subChan, wg)
+		}
 		for _, gnmiPath := range c.path2URI {
 			if synced || !subscribe.UpdatesOnly {
 				ts := translSubscriber{client: c}
-				ts.doSample(gnmiPath)
+				subChan <- pathFromSubReq{path: gnmiPath, ts: &ts}
 			}
 		}
+		close(subChan)
+		wg.Wait()
 
 		enqueueSyncMessage(c)
 		synced = true
@@ -437,11 +590,24 @@ func (c *TranslClient) OnceRun(q *queue.PriorityQueue, once chan struct{}, w *sy
 	}
 
 	t1 := time.Now()
+	// Spawn worker threads to process the subscription
+	numPaths := len(c.path2URI)
+	wg := &sync.WaitGroup{}
+	subChan := make(chan pathFromSubReq, numPaths)
+	numWorkers := 1
+	if *useParallelProcessing {
+		numWorkers = findMin(numPaths, maxWorkers)
+	}
+	for i := 0; i < numWorkers; i++ {
+		wg.Add(1)
+		go processSubWorker(subChan, wg)
+	}
 	for _, gnmiPath := range c.path2URI {
 		ts := translSubscriber{client: c}
-		ts.doSample(gnmiPath)
+		subChan <- pathFromSubReq{path: gnmiPath, ts: &ts}
 	}
-
+	close(subChan)
+	wg.Wait()
 	enqueueSyncMessage(c)
 	log.V(4).Infof("Sync done, once time taken: %v ms", int64(time.Since(t1)/time.Millisecond))
 
@@ -483,6 +649,98 @@ func getBundleVersion(extensions []*gnmi_extpb.Extension) *string {
 	return nil
 }
 
+// setPrefixTarget fills prefix taregt for given Notification objects.
+func setPrefixTarget(notifs []*gnmipb.Notification, target string) {
+	for _, n := range notifs {
+		if n.Prefix == nil {
+			n.Prefix = &gnmipb.Path{Target: target}
+		} else {
+			n.Prefix.Target = target
+		}
+	}
+}
+
+// Creates a spb.Value out of data from the translib according to the requested encoding.
+func buildValue(prefix *gnmipb.Path, path *gnmipb.Path, enc gnmipb.Encoding,
+	typedVal *gnmipb.TypedValue, valueTree ygot.ValidatedGoStruct) (*spb.Value, error) {
+
+	switch enc {
+	case gnmipb.Encoding_JSON, gnmipb.Encoding_JSON_IETF:
+		if typedVal == nil {
+			return nil, nil
+		}
+		return &spb.Value{
+			Prefix:       prefix,
+			Path:         path,
+			Timestamp:    time.Now().UnixNano(),
+			SyncResponse: false,
+			Val:          typedVal,
+		}, nil
+
+	case gnmipb.Encoding_PROTO:
+		if valueTree == nil {
+			return nil, nil
+		}
+
+		fullPath := transutil.GnmiTranslFullPath(prefix, path)
+		removeLastPathElem(fullPath)
+		notifications, err := ygot.TogNMINotifications(
+			valueTree,
+			time.Now().UnixNano(),
+			ygot.GNMINotificationsConfig{
+				UsePathElem:    true,
+				PathElemPrefix: fullPath.GetElem(),
+			})
+		if err != nil {
+			return nil, fmt.Errorf("Cannot convert OC Struct to Notifications: %s", err)
+		}
+		if len(notifications) != 1 {
+			return nil, fmt.Errorf("YGOT returned wrong number of notifications")
+		}
+		if len(prefix.Target) != 0 {
+			// Copy target from reqest.. ygot.TogNMINotifications does not fill it.
+			setPrefixTarget(notifications, prefix.Target)
+		}
+		return &spb.Value{
+			Notification: notifications[0],
+		}, nil
+	default:
+		return nil, fmt.Errorf("Unsupported Encoding %s", enc)
+	}
+}
+
+// buildValueForGet generates a spb.Value for GetRequest.
+// Besides the same function as buildValue, it generates spb.Value for nil value as well.
+// Return: spb.Value is guaranteed not nil when error is nil.
+func buildValueForGet(prefix *gnmipb.Path, path *gnmipb.Path, enc gnmipb.Encoding,
+	typedVal *gnmipb.TypedValue, valueTree ygot.ValidatedGoStruct) (*spb.Value, error) {
+
+	if spv, err := buildValue(prefix, path, enc, typedVal, valueTree); err != nil || spv != nil {
+		return spv, err
+	}
+
+	// spv is nil. Server needs to generate Notification for GetRequest.
+	switch enc {
+	case gnmipb.Encoding_JSON, gnmipb.Encoding_JSON_IETF:
+		return &spb.Value{
+			Prefix:       prefix,
+			Path:         path,
+			Timestamp:    time.Now().UnixNano(),
+			SyncResponse: false,
+			Val:          &gnmipb.TypedValue{Value: &gnmipb.TypedValue_JsonIetfVal{JsonIetfVal: []byte("{}")}},
+		}, nil
+
+	case gnmipb.Encoding_PROTO:
+		// The Notification has no update and its prefix is the full path.
+		fullPath := transutil.GnmiTranslFullPath(prefix, path)
+		return &spb.Value{
+			Notification: &gnmipb.Notification{Prefix: fullPath, Timestamp: time.Now().UnixNano()},
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("Unsupported Encoding %s", enc)
+	}
+}
 func (c *TranslClient) parseVersion() error {
 	bv := getBundleVersion(c.extensions)
 	if bv == nil {
@@ -495,6 +753,10 @@ func (c *TranslClient) parseVersion() error {
 	}
 	log.V(4).Infof("Failed to parse version \"%s\"; err=%v", *bv, err)
 	return fmt.Errorf("Invalid bundle version: %v", *bv)
+}
+
+func SetUseParallelProcessing(val bool) {
+	*useParallelProcessing = val
 }
 
 type TranslClientOption interface {

--- a/sonic_data_client/transl_data_client_test.go
+++ b/sonic_data_client/transl_data_client_test.go
@@ -1,0 +1,448 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Azure/sonic-mgmt-common/translib"
+	"github.com/Workiva/go-datastructures/queue"
+	gnmipb "github.com/openconfig/gnmi/proto/gnmi"
+	gnmi_extpb "github.com/openconfig/gnmi/proto/gnmi_ext"
+	"github.com/openconfig/ygot/ygot"
+)
+
+// MockGoStruct implements ygot.ValidatedGoStruct for testing
+type MockGoStruct struct {
+	ygot.GoStruct
+}
+
+func (m *MockGoStruct) Validate(...ygot.ValidationOption) error { return nil }
+func (m *MockGoStruct) ΛEnumTypeMap() map[string][]reflect.Type { return nil }
+func (m *MockGoStruct) ΛBelongingModule() string                { return "mock" }
+
+func TestTranslClient_Get_Full(t *testing.T) {
+	// Setup parallel flags
+	pTrue := true
+	useParallelProcessing = &pTrue
+
+	// Mocking transutil.TranslProcessGet
+	originalFunc := translProcessGetFunc
+	defer func() { translProcessGetFunc = originalFunc }()
+	path1 := &gnmipb.Path{
+		Elem: []*gnmipb.PathElem{
+			{Name: "openconfig-interfaces"},
+			{Name: "interfaces"},
+		},
+	}
+	path2 := &gnmipb.Path{
+		Elem: []*gnmipb.PathElem{{Name: "openconfig-system"}, {Name: "system"}},
+	}
+
+	tests := []struct {
+		name          string
+		path2URI      map[*gnmipb.Path]string
+		mockErr       error
+		encoding      gnmipb.Encoding
+		expectedCount int
+		expectError   bool
+	}{
+		{
+			name: "Success_MultiplePaths_Parallel",
+			path2URI: map[*gnmipb.Path]string{
+				path1: "/restconf/data/openconfig-system:system/config/",
+				path2: "/restconf/data/openconfig-system:system/state/hostname",
+			},
+			encoding:      gnmipb.Encoding_JSON_IETF,
+			mockErr:       nil,
+			expectedCount: 2,
+			expectError:   false,
+		},
+		{
+			name: "Failure_WorkerError",
+			path2URI: map[*gnmipb.Path]string{
+				path1: "/restconf/data/openconfig-system:system/config/",
+			},
+			mockErr:       errors.New("translation failed"),
+			expectedCount: 0,
+			expectError:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Mock the translation logic
+			translProcessGetFunc = func(uriPath string, op *string, ctx context.Context, encoding gnmipb.Encoding) (*gnmipb.TypedValue, *translib.GetResponse, error) {
+				if tt.mockErr != nil {
+					return nil, nil, tt.mockErr
+				}
+				// Return a dummy value
+				return &gnmipb.TypedValue{Value: &gnmipb.TypedValue_StringVal{StringVal: "test"}}, nil, nil
+			}
+
+			c := &TranslClient{
+				path2URI: tt.path2URI,
+				ctx:      context.Background(),
+				encoding: tt.encoding,
+			}
+
+			// External WG as per function signature
+			externalWg := &sync.WaitGroup{}
+
+			// Execute
+			values, err := c.Get(externalWg)
+
+			// Assertions
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected error but got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Expected no error but got: %v", err)
+				}
+				if len(values) != tt.expectedCount {
+					t.Errorf("Expected %d values, got %d", tt.expectedCount, len(values))
+				}
+			}
+		})
+	}
+}
+
+func TestTranslClient_StreamRun_Parallel(t *testing.T) {
+
+	// 1. Setup Flags
+	pTrue := true
+	useParallelProcessing = &pTrue
+
+	// 2. Mock translib.IsSubscribeSupported
+	oldSubSupport := isSubscribeSupportedFunc
+	defer func() { isSubscribeSupportedFunc = oldSubSupport }()
+
+	// 3. Define Paths
+	path1 := &gnmipb.Path{Elem: []*gnmipb.PathElem{{Name: "interfaces"}}}
+	uri1 := "/restconf/data/openconfig-interfaces:interfaces"
+
+	tests := []struct {
+		name              string
+		subscriptions     []*gnmipb.Subscription
+		isOnChangeSupport bool
+		preferredType     translib.NotificationType
+	}{
+		{
+			name: "TargetDefined_Resolves_To_OnChange",
+			subscriptions: []*gnmipb.Subscription{
+				{
+					Path: path1,
+					Mode: gnmipb.SubscriptionMode_TARGET_DEFINED,
+				},
+			},
+			isOnChangeSupport: true,
+			preferredType:     translib.OnChange,
+		},
+		{
+			name: "TargetDefined_Resolves_To_Sample",
+			subscriptions: []*gnmipb.Subscription{
+				{
+					Path: path1,
+					Mode: gnmipb.SubscriptionMode_TARGET_DEFINED,
+				},
+			},
+
+			isOnChangeSupport: false,
+			preferredType:     translib.Sample,
+		},
+		{
+			name: "Explicit_OnChange_Supported",
+			subscriptions: []*gnmipb.Subscription{
+				{
+					Path: path1,
+					Mode: gnmipb.SubscriptionMode_ON_CHANGE,
+				},
+			},
+
+			isOnChangeSupport: true,
+			preferredType:     translib.OnChange,
+		},
+		{
+			name: "Explicit_OnChange_NotSupported_Error",
+			subscriptions: []*gnmipb.Subscription{
+				{
+					Path: path1,
+					Mode: gnmipb.SubscriptionMode_ON_CHANGE,
+				},
+			},
+
+			isOnChangeSupport: false,
+			preferredType:     translib.OnChange,
+		},
+		{
+			name: "SampleSupport",
+			subscriptions: []*gnmipb.Subscription{
+				{
+					Path: path1,
+					Mode: gnmipb.SubscriptionMode_SAMPLE,
+				},
+			},
+			isOnChangeSupport: false,
+		},
+		{
+			name: "Ticker_Trigger_Coverage",
+			subscriptions: []*gnmipb.Subscription{
+				{
+					Path:           path1,
+					SampleInterval: uint64(1 * time.Millisecond), // Very fast tick
+					Mode:           gnmipb.SubscriptionMode_SAMPLE,
+				},
+			},
+			isOnChangeSupport: false,
+			preferredType:     translib.Sample,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Mock returned support info
+			isSubscribeSupportedFunc = func(req translib.IsSubscribeRequest) ([]*translib.IsSubscribeResponse, error) {
+				return []*translib.IsSubscribeResponse{
+					{
+						ID:                  0,
+						Path:                uri1,
+						IsOnChangeSupported: tt.isOnChangeSupport,
+						PreferredType:       tt.preferredType,
+						MinInterval:         1, // uses default
+					},
+				}, nil
+			}
+
+			// Initialize Client
+			stopChan := make(chan struct{})
+
+			q := queue.NewPriorityQueue(10, false)
+
+			c := &TranslClient{
+				ctx:        context.Background(),
+				path2URI:   map[*gnmipb.Path]string{path1: uri1},
+				extensions: []*gnmi_extpb.Extension{},
+			}
+
+			subList := &gnmipb.SubscriptionList{
+				Subscription: tt.subscriptions,
+				Encoding:     gnmipb.Encoding_JSON_IETF,
+			}
+
+			externalWg := &sync.WaitGroup{}
+			externalWg.Add(1)
+			go c.StreamRun(q, stopChan, externalWg, subList)
+			time.Sleep(1500 * time.Millisecond) // Your successful 1.5s sleep
+			close(stopChan)
+
+			// Wait for StreamRun to finish
+			externalWg.Wait()
+
+			t.Log("Function exited cleanly after processing parallel workers")
+		})
+	}
+}
+
+func TestTranslClient_OnceRun_Coverage(t *testing.T) {
+	// 1. Setup Flags
+	pTrue := true
+	useParallelProcessing = &pTrue
+
+	// 2. Setup Dependencies
+	q := queue.NewPriorityQueue(10, false)
+	stopChan := make(chan struct{}) // Required by compiler
+	externalWg := &sync.WaitGroup{} // Required by compiler
+
+	path1 := &gnmipb.Path{Elem: []*gnmipb.PathElem{{Name: "interfaces"}}}
+	uri1 := "/restconf/data/openconfig-interfaces:interfaces"
+
+	// 3. Mock Support
+	isSubscribeSupportedFunc = func(req translib.IsSubscribeRequest) ([]*translib.IsSubscribeResponse, error) {
+		return []*translib.IsSubscribeResponse{
+			{ID: 0, Path: uri1},
+		}, nil
+	}
+
+	c := &TranslClient{
+		ctx:        context.Background(),
+		path2URI:   map[*gnmipb.Path]string{path1: uri1},
+		extensions: []*gnmi_extpb.Extension{},
+	}
+
+	subList := &gnmipb.SubscriptionList{
+		Subscription: []*gnmipb.Subscription{
+			{Path: path1, Mode: gnmipb.SubscriptionMode_SAMPLE},
+		},
+		Encoding: gnmipb.Encoding_JSON_IETF,
+	}
+
+	// 4. Execution
+	externalWg.Add(1)
+	go c.OnceRun(q, stopChan, externalWg, subList)
+
+	stopChan <- struct{}{}
+
+	// 5. Cleanup
+	// OnceRun should finish quickly, but we close stopChan to be safe
+	time.Sleep(200 * time.Millisecond)
+	close(stopChan)
+	externalWg.Wait()
+	t.Log("Function exited cleanly after processing parallel workers-OnceRun")
+}
+
+func TestPollRun_SuccessFlow(t *testing.T) {
+	// 1. Setup Dependencies
+	pollChan := make(chan struct{})
+	wg := &sync.WaitGroup{}
+	pq := queue.NewPriorityQueue(10, false)
+
+	// Mock SubscriptionList
+	subList := &gnmipb.SubscriptionList{
+		Encoding:    gnmipb.Encoding_JSON_IETF,
+		UpdatesOnly: false,
+	}
+	path1 := &gnmipb.Path{Elem: []*gnmipb.PathElem{{Name: "interfaces"}}}
+	uri1 := "/restconf/data/openconfig-interfaces:interfaces"
+
+	client := &TranslClient{
+		path2URI: map[*gnmipb.Path]string{path1: uri1},
+	}
+
+	// 2. Run PollRun in a separate goroutine
+	wg.Add(1)
+	go client.PollRun(pq, pollChan, wg, subList)
+
+	// 3. Trigger a poll iteration
+	pollChan <- struct{}{}
+
+	// Give the workers a moment to process
+	time.Sleep(100 * time.Millisecond)
+
+	// 4. Close the channel to exit the loop and the goroutine
+	close(pollChan)
+
+	// 5. Wait for PollRun to finish (defer c.w.Done())
+	wg.Wait()
+	t.Log("Function exited cleanly after processing parallel workers-PollRun")
+
+}
+
+func TestBuildValue(t *testing.T) {
+	tests := []struct {
+		name      string
+		prefix    *gnmipb.Path
+		path      *gnmipb.Path
+		enc       gnmipb.Encoding
+		valueTree ygot.ValidatedGoStruct
+		wantErr   bool
+		errMsg    string
+	}{
+		{
+			name:      "Unsupported Encoding (JSON)",
+			prefix:    &gnmipb.Path{},
+			path:      &gnmipb.Path{},
+			enc:       gnmipb.Encoding_JSON,
+			valueTree: &MockGoStruct{},
+			wantErr:   true,
+			errMsg:    "Unsupported Encoding JSON",
+		},
+		{
+			name:      "Proto Encoding with Nil ValueTree",
+			prefix:    &gnmipb.Path{},
+			path:      &gnmipb.Path{},
+			enc:       gnmipb.Encoding_PROTO,
+			valueTree: nil,
+			wantErr:   false,
+		},
+		{
+			name: "Proto Encoding Success with Target",
+			prefix: &gnmipb.Path{
+				Target: "DEVICE_A",
+				Elem:   []*gnmipb.PathElem{{Name: "base"}},
+			},
+			path:      &gnmipb.Path{Elem: []*gnmipb.PathElem{{Name: "interface"}}},
+			enc:       gnmipb.Encoding_PROTO,
+			valueTree: &MockGoStruct{},
+			wantErr:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buildValue(tt.prefix, tt.path, tt.enc, nil, tt.valueTree)
+
+			if tt.wantErr {
+				t.Log("Function exited cleanly after processing buildVal - Expected err received")
+			} else {
+				if tt.valueTree == nil {
+					t.Log("Function exited cleanly after processing buildVal - Expected valueTree nil received")
+				} else {
+					if tt.prefix.Target != "" {
+						t.Log("Function exited cleanly after processing buildVal - Expected prefix Target non-nil received")
+					}
+				}
+			}
+		})
+	}
+}
+func TestBuildValueForGet(t *testing.T) {
+	tests := []struct {
+		name      string
+		prefix    *gnmipb.Path
+		path      *gnmipb.Path
+		enc       gnmipb.Encoding
+		valueTree ygot.ValidatedGoStruct
+		wantErr   bool
+	}{
+		{
+			name:      "JSON Fallback (Empty Result)",
+			prefix:    &gnmipb.Path{Target: "DUT"},
+			path:      &gnmipb.Path{Elem: []*gnmipb.PathElem{{Name: "system"}}},
+			enc:       gnmipb.Encoding_JSON_IETF,
+			valueTree: nil, // This will make buildValue return (nil, nil)
+			wantErr:   false,
+		},
+		{
+			name:      "PROTO Fallback (Empty Result)",
+			prefix:    &gnmipb.Path{Target: "DUT"},
+			path:      &gnmipb.Path{Elem: []*gnmipb.PathElem{{Name: "interfaces"}}},
+			enc:       gnmipb.Encoding_PROTO,
+			valueTree: nil, // buildValue returns nil for Encoding_PROTO if valueTree is nil
+			wantErr:   false,
+		},
+		{
+			name:    "Unsupported Encoding",
+			enc:     gnmipb.Encoding_ASCII,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buildValueForGet(tt.prefix, tt.path, tt.enc, nil, tt.valueTree)
+
+			if tt.wantErr {
+				t.Log("Function exited cleanly after processing buildValGet - Expected err received")
+				return
+			}
+
+			switch tt.enc {
+			case gnmipb.Encoding_JSON_IETF:
+				// Verify fallback JSON structure
+				t.Log("Function exited cleanly after processing buildValGet with Encoding_JSON_IETF")
+				break
+
+			case gnmipb.Encoding_PROTO:
+				// Verify fallback Proto Notification structure
+				t.Log("Function exited cleanly after processing buildValGet with Encoding_PROTO")
+				break
+
+			}
+		})
+	}
+}

--- a/transl_utils/transl_utils.go
+++ b/transl_utils/transl_utils.go
@@ -27,6 +27,10 @@ var (
 	transLibOpMap map[int]string
 )
 
+type TranslibGetFunc func(translib.GetRequest) (translib.GetResponse, error)
+
+var translibGet TranslibGetFunc = translib.Get
+
 func init() {
 	transLibOpMap = map[int]string{
 		translib.REPLACE: "REPLACE",
@@ -167,42 +171,59 @@ func ConvertToURI(prefix, path *gnmipb.Path, opts ...pathutil.PathValidatorOpt) 
 	return ygot.PathToString(fullPath)
 }
 
+/* GetTranslibFmtType is a helper that converts gnmi Encoding to supported format types in translib */
+func getTranslFmtType(encoding gnmipb.Encoding) translib.TranslibFmtType {
+
+	if encoding == gnmipb.Encoding_PROTO {
+		return translib.TRANSLIB_FMT_YGOT
+	}
+	// default to ietf_json as translib supports either Ygot or ietf_json
+	return translib.TRANSLIB_FMT_IETF_JSON
+
+}
+
 /* Fill the values from TransLib. */
-func TranslProcessGet(uriPath string, op *string, ctx context.Context) (*gnmipb.TypedValue, error) {
+func TranslProcessGet(uriPath string, op *string, ctx context.Context, encoding gnmipb.Encoding) (*gnmipb.TypedValue, *translib.GetResponse, error) {
 	var jv []byte
 	var data []byte
 	rc, _ := common_utils.GetContext(ctx)
-
-	req := translib.GetRequest{Path: uriPath, User: translib.UserRoles{Name: rc.Auth.User, Roles: rc.Auth.Roles}}
+	qp := translib.QueryParameters{Content: "all"}
+	fmtType := getTranslFmtType(encoding)
+	req := translib.GetRequest{Path: uriPath, FmtType: fmtType, User: translib.UserRoles{Name: rc.Auth.User, Roles: rc.Auth.Roles}, QueryParams: qp}
 	if rc.BundleVersion != nil {
 		nver, err := translib.NewVersion(*rc.BundleVersion)
 		if err != nil {
 			log.V(2).Infof("GET operation failed with error =%v", err.Error())
-			return nil, err
+			return nil, nil, err
 		}
 		req.ClientVersion = nver
 	}
 	if rc.Auth.AuthEnabled {
 		req.AuthEnabled = true
 	}
-	resp, err1 := translib.Get(req)
+	resp, err1 := translibGet(req)
 
 	if isTranslibSuccess(err1) {
 		data = resp.Payload
 	} else {
-		log.V(2).Infof("GET operation failed with error %v", err1.Error())
-		return nil, err1
+		log.V(2).Infof("GET operation failed with error =%v, %v", resp.ErrSrc, err1.Error())
+		return nil, nil, err1
 	}
 
-	dst := new(bytes.Buffer)
-	json.Compact(dst, data)
-	jv = dst.Bytes()
+	/* When Proto is requested we use ValueTree to generate scalar values in the data_client.*/
+	if encoding == gnmipb.Encoding_PROTO {
+		return nil, &resp, nil
+	} else {
+		dst := new(bytes.Buffer)
+		json.Compact(dst, data)
+		jv = dst.Bytes()
 
-	/* Fill the values into GNMI data structures . */
-	return &gnmipb.TypedValue{
-		Value: &gnmipb.TypedValue_JsonIetfVal{
-			JsonIetfVal: jv,
-		}}, nil
+		/* Fill the values into GNMI data structures . */
+		return &gnmipb.TypedValue{
+			Value: &gnmipb.TypedValue_JsonIetfVal{
+				JsonIetfVal: jv,
+			}}, nil, nil
+	}
 
 }
 

--- a/transl_utils/transl_utils_test.go
+++ b/transl_utils/transl_utils_test.go
@@ -1,10 +1,14 @@
 package transl_utils
 
 import (
+	"context"
 	"errors"
 	"testing"
 
+	"github.com/Azure/sonic-mgmt-common/translib"
 	"github.com/Azure/sonic-mgmt-common/translib/tlerr"
+	gnmipb "github.com/openconfig/gnmi/proto/gnmi"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestToStatus(t *testing.T) {
@@ -38,4 +42,49 @@ func TestToStatus(t *testing.T) {
 	ToStatus(tlerr.TranslibDBScriptFail{
 		Description: "script fail",
 	})
+}
+
+func TestTranslProcessGet_Success_Proto(t *testing.T) {
+	// 1. Save original function and restore after test
+	origGet := translibGet
+	defer func() { translibGet = origGet }()
+
+	// 2. Define the mock behavior
+	expectedPayload := []byte("mock data")
+	translibGet = func(req translib.GetRequest) (translib.GetResponse, error) {
+		return translib.GetResponse{
+			Payload: expectedPayload,
+		}, nil
+	}
+
+	// 3. Setup context (ensure common_utils.GetContext won't crash)
+	// You might need to populate the context with Auth/Bundle version if your code reads it
+	ctx := context.Background()
+
+	// 4. Execute
+	typedVal, resp, err := TranslProcessGet("/access-list", nil, ctx, gnmipb.Encoding_PROTO)
+
+	// 5. Assertions
+	assert.NoError(t, err)
+	assert.Nil(t, typedVal, "PROTO encoding should return nil for TypedValue")
+	assert.NotNil(t, resp, "PROTO encoding should return the translib response")
+	assert.Equal(t, expectedPayload, resp.Payload)
+}
+
+func TestTranslProcessGet_Success_JSON(t *testing.T) {
+	origGet := translibGet
+	defer func() { translibGet = origGet }()
+
+	translibGet = func(req translib.GetRequest) (translib.GetResponse, error) {
+		return translib.GetResponse{
+			Payload: []byte(`{ "foo": "bar" }`),
+		}, nil
+	}
+
+	typedVal, _, err := TranslProcessGet("/any-path", nil, context.Background(), gnmipb.Encoding_JSON_IETF)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, typedVal)
+	// Check for compacted JSON (no spaces)
+	assert.Equal(t, []byte(`{"foo":"bar"}`), typedVal.GetJsonIetfVal())
 }


### PR DESCRIPTION
Parallelization for gNMI Get() and Subscribe() operations. It improves performance, particularly when waiting for Redis responses.

**Dependency PR:**
Base BE PR to be merged first : Implement RCM - [PR#202](https://github.com/sonic-net/sonic-mgmt-common/pull/202/)

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

