### PR TITLE
Add workflow to detect stuck submodule update PRs

### DIFF
--- a/.github/submodule-watchers.json
+++ b/.github/submodule-watchers.json
@@ -1,0 +1,4 @@
+{
+  "assignees": ["hdwhdw"],
+  "threshold_hours": 96
+}

--- a/.github/workflows/check-submodule-update.yml
+++ b/.github/workflows/check-submodule-update.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   check:
+    if: github.repository_owner == 'sonic-net'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v7

--- a/.github/workflows/check-submodule-update.yml
+++ b/.github/workflows/check-submodule-update.yml
@@ -1,0 +1,55 @@
+name: Check Submodule Update Status
+
+on:
+  schedule:
+    - cron: '0 8 * * 1-5'  # Weekdays 8AM UTC
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const { data } = await github.rest.search.issuesAndPullRequests({
+              q: 'repo:sonic-net/sonic-buildimage is:pr is:open "submodule" "sonic-gnmi" in:title author:mssonicbld'
+            });
+
+            const now = new Date();
+            const THRESHOLD_HOURS = 96;
+
+            for (const pr of data.items) {
+              const ageHours = (now - new Date(pr.created_at)) / 3600000;
+              if (ageHours < THRESHOLD_HOURS) continue;
+
+              const existing = await github.rest.search.issuesAndPullRequests({
+                q: `repo:sonic-net/sonic-gnmi is:issue is:open "buildimage#${pr.number}" in:title`
+              });
+              if (existing.data.total_count > 0) continue;
+
+              const branch = pr.title.match(/\[submodule\]\[(\w+)\]/)?.[1] || 'unknown';
+              const ageDays = Math.floor(ageHours / 24);
+
+              await github.rest.issues.create({
+                owner: 'sonic-net',
+                repo: 'sonic-gnmi',
+                title: `Stuck submodule update: buildimage#${pr.number} (${branch})`,
+                body: [
+                  `The sonic-gnmi submodule update PR in sonic-buildimage has been open for ${ageDays} days.`,
+                  ``,
+                  `**PR:** ${pr.html_url}`,
+                  `**Branch:** ${branch}`,
+                  `**Created:** ${pr.created_at}`,
+                  `**Comments:** ${pr.comments} (likely repeated CI retries)`,
+                  ``,
+                  `This usually means Azure Pipelines is failing to run. Investigate the PR and determine if a rebase, manual CI trigger, or code fix is needed.`,
+                ].join('\n'),
+                labels: ['submodule-stuck'],
+              });
+
+              console.log(`Filed issue for stuck PR #${pr.number} (${branch}, ${ageDays} days old)`);
+            }

--- a/.github/workflows/check-submodule-update.yml
+++ b/.github/workflows/check-submodule-update.yml
@@ -6,6 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  contents: read
   issues: write
 
 jobs:
@@ -13,19 +14,27 @@ jobs:
     if: github.repository_owner == 'sonic-net'
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/submodule-watchers.json
+          sparse-checkout-cone-mode: false
       - uses: actions/github-script@v7
         with:
           script: |
+            const fs = require('fs');
+            const config = JSON.parse(fs.readFileSync('.github/submodule-watchers.json', 'utf8'));
+            const assignees = config.assignees || [];
+            const thresholdHours = config.threshold_hours || 96;
+
             const { data } = await github.rest.search.issuesAndPullRequests({
               q: 'repo:sonic-net/sonic-buildimage is:pr is:open "submodule" "sonic-gnmi" in:title author:mssonicbld'
             });
 
             const now = new Date();
-            const THRESHOLD_HOURS = 96;
 
             for (const pr of data.items) {
               const ageHours = (now - new Date(pr.created_at)) / 3600000;
-              if (ageHours < THRESHOLD_HOURS) continue;
+              if (ageHours < thresholdHours) continue;
 
               const existing = await github.rest.search.issuesAndPullRequests({
                 q: `repo:sonic-net/sonic-gnmi is:issue is:open "buildimage#${pr.number}" in:title`
@@ -50,6 +59,7 @@ jobs:
                   `This usually means Azure Pipelines is failing to run. Investigate the PR and determine if a rebase, manual CI trigger, or code fix is needed.`,
                 ].join('\n'),
                 labels: ['submodule-stuck'],
+                assignees: assignees,
               });
 
               console.log(`Filed issue for stuck PR #${pr.number} (${branch}, ${ageDays} days old)`);


### PR DESCRIPTION
#### Why I did it

The mssonicbld bot creates submodule update PRs in sonic-buildimage automatically, but these PRs can get stuck for days or weeks without anyone noticing (e.g. CI failures, merge conflicts). This delays rollout of merged fixes to the build.

For example, https://github.com/sonic-net/sonic-buildimage/pull/25285 has been open since Jan 31 — over a month — blocking multiple merged commits from reaching the build.

#### How I did it

Added a GitHub Actions workflow (`.github/workflows/check-submodule-update.yml`) that:
- Runs on weekdays at 8AM UTC (and supports manual trigger)
- Searches for open mssonicbld submodule update PRs in sonic-buildimage
- If any PR has been open longer than a configurable threshold (default 96 hours), files an issue in sonic-gnmi with the `submodule-stuck` label
- Avoids duplicate issues by checking for existing open issues referencing the same PR
- Only runs on the sonic-net organization (skipped on forks)

Assignees and threshold are read from `.github/submodule-watchers.json` so the policy can be updated without modifying the workflow.

#### How to verify it

1. Trigger the workflow manually via `workflow_dispatch`
2. Verify it detects the currently stuck PRs (#25285, #25432) and files issues

#### Description for the changelog

Add scheduled workflow to detect and alert on stuck sonic-gnmi submodule update PRs in sonic-buildimage.