### PR TITLE
Add unit tests for DPU proxy singleton and GetDPUConnection

### DIFF
--- a/pkg/interceptors/dpuproxy/singleton_test.go
+++ b/pkg/interceptors/dpuproxy/singleton_test.go
@@ -1,0 +1,118 @@
+package dpuproxy
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestGetDPUConnection_NilProxy(t *testing.T) {
+	old := defaultProxy
+	defaultProxy = nil
+	defer func() { defaultProxy = old }()
+
+	conn, err := GetDPUConnection(context.Background(), "0")
+	if err == nil {
+		t.Fatal("expected error when defaultProxy is nil")
+	}
+	if conn != nil {
+		t.Fatal("expected nil connection when defaultProxy is nil")
+	}
+	if err.Error() != "DPU proxy not initialized" {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestSetDefaultProxy_And_GetDPUConnection(t *testing.T) {
+	old := defaultProxy
+	defer func() { defaultProxy = old }()
+
+	proxy := NewDPUProxy(nil)
+	SetDefaultProxy(proxy)
+
+	if defaultProxy != proxy {
+		t.Fatal("SetDefaultProxy did not set the singleton")
+	}
+
+	// With nil resolver, GetDPUConnection should return "resolver not available"
+	conn, err := GetDPUConnection(context.Background(), "0")
+	if err == nil {
+		t.Fatal("expected error with nil resolver")
+	}
+	if conn != nil {
+		t.Fatal("expected nil connection with nil resolver")
+	}
+	if err.Error() != "resolver not available" {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestSetDefaultProxy_Nil(t *testing.T) {
+	old := defaultProxy
+	defer func() { defaultProxy = old }()
+
+	SetDefaultProxy(nil)
+	if defaultProxy != nil {
+		t.Fatal("SetDefaultProxy(nil) should set singleton to nil")
+	}
+}
+
+func TestDPUProxy_GetDPUConnection_NilResolver(t *testing.T) {
+	proxy := NewDPUProxy(nil)
+	conn, err := proxy.GetDPUConnection(context.Background(), "0")
+	if err == nil {
+		t.Fatal("expected error with nil resolver")
+	}
+	if conn != nil {
+		t.Fatal("expected nil connection")
+	}
+}
+
+func TestDPUProxy_GetDPUConnection_ResolverError(t *testing.T) {
+	stateClient := &mockRedisClient{data: map[string]map[string]string{}}
+	configClient := &mockRedisClient{data: map[string]map[string]string{}}
+	resolver := NewDPUResolver(stateClient, configClient)
+	proxy := NewDPUProxy(resolver)
+
+	// DPU "99" doesn't exist in mock data, so GetDPUInfo will fail
+	conn, err := proxy.GetDPUConnection(context.Background(), "99")
+	if err == nil {
+		t.Fatal("expected error for non-existent DPU")
+	}
+	if conn != nil {
+		t.Fatal("expected nil connection")
+	}
+}
+
+func TestDPUProxy_GetDPUConnection_Unreachable(t *testing.T) {
+	stateClient := &mockRedisClient{
+		data: map[string]map[string]string{
+			"CHASSIS_MIDPLANE_TABLE|DPU0": {
+				"ip_address": "169.254.200.1",
+				"access":     "False",
+			},
+		},
+	}
+	configClient := &mockRedisClient{
+		data: map[string]map[string]string{},
+	}
+	resolver := NewDPUResolver(stateClient, configClient)
+	proxy := NewDPUProxy(resolver)
+
+	conn, err := proxy.GetDPUConnection(context.Background(), "0")
+	if err == nil {
+		t.Fatal("expected error for unreachable DPU")
+	}
+	if conn != nil {
+		t.Fatal("expected nil connection")
+	}
+	s, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got: %v", err)
+	}
+	if s.Code() != codes.Unavailable {
+		t.Errorf("expected Unavailable, got: %v", s.Code())
+	}
+}


### PR DESCRIPTION
Cover SetDefaultProxy, package-level GetDPUConnection, and method-level GetDPUConnection with tests for nil proxy, nil resolver, resolver error, and unreachable DPU cases. This satisfies diff coverage requirements on release branches.

#### Why I did it

PR [#591](https://github.com/sonic-net/sonic-gnmi/pull/591) added `SetDefaultProxy`, `GetDPUConnection` (package-level), and `(DPUProxy).GetDPUConnection` (method) to `pkg/interceptors/dpuproxy/proxy.go`. These functions had no direct unit tests in the `dpuproxy` package — they were only exercised via gomonkey mocks in `pkg/gnoi/file` tests, which patches them out rather than executing the actual code. This causes diff coverage checks to fail on release branches (e.g., 202511) where `DIFF_COVER_CHECK_THRESHOLD: 80` is enforced.

#### How I did it

Added `singleton_test.go` in `pkg/interceptors/dpuproxy` with tests covering:
- `GetDPUConnection` when `defaultProxy` is nil (returns "DPU proxy not initialized")
- `SetDefaultProxy` sets and clears the singleton correctly
- `SetDefaultProxy` + `GetDPUConnection` end-to-end delegation with nil resolver
- `(DPUProxy).GetDPUConnection` with nil resolver (returns "resolver not available")
- `(DPUProxy).GetDPUConnection` with resolver error (non-existent DPU in Redis)
- `(DPUProxy).GetDPUConnection` with unreachable DPU (returns `codes.Unavailable`)

Coverage for the new functions:
- `SetDefaultProxy`: 100%
- `GetDPUConnection` (package-level): 100%
- `GetDPUConnection` (method): 87.5% (up from 62.5%)
- Overall `dpuproxy` package: 86.7%

#### How to verify it

```bash
make -f pure.mk PACKAGES="pkg/interceptors/dpuproxy" test
```

#### Which release branch to backport (provide reason below if selected)

Cherry-pick to 202511 to unblock [#593](https://github.com/sonic-net/sonic-gnmi/pull/593) which is failing diff coverage.

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog

Add unit tests for DPU proxy singleton accessor and GetDPUConnection to satisfy diff coverage requirements.

#### Link to config_db schema for YANG module changes


#### A picture of a cute animal (not mandatory but encouraged)

