### PR TITLE
Makefile: add -gcflags=all=-l to gnmi_server tests for gomonkey compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,7 +222,7 @@ $(ENVFILE):
 check_gotest: $(DBCONFG) $(ENVFILE)
 	sudo CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" $(GO) test -race -coverprofile=coverage-telemetry.txt -covermode=atomic -mod=vendor -v github.com/sonic-net/sonic-gnmi/telemetry
 	sudo CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" $(GO) test -race -coverprofile=coverage-config.txt -covermode=atomic -v github.com/sonic-net/sonic-gnmi/sonic_db_config
-	sudo CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" $(TESTENV) $(GO) test -race -timeout 20m -coverprofile=coverage-gnmi.txt -covermode=atomic -mod=vendor $(BLD_FLAGS) -v github.com/sonic-net/sonic-gnmi/gnmi_server -coverpkg ../...
+	sudo CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" $(TESTENV) $(GO) test -race -timeout 20m -coverprofile=coverage-gnmi.txt -covermode=atomic -mod=vendor $(BLD_FLAGS) -gcflags=all=-l -v github.com/sonic-net/sonic-gnmi/gnmi_server -coverpkg ../...
 ifneq ($(ENABLE_DIALOUT_VALUE),0)
 	sudo CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" $(TESTENV) $(GO) test -coverprofile=coverage-dialout.txt -covermode=atomic -mod=vendor $(BLD_FLAGS) -v github.com/sonic-net/sonic-gnmi/dialout/dialout_client
 endif
@@ -325,14 +325,15 @@ check_gotest_junit: $(DBCONFG) $(ENVFILE)
 			-covermode=atomic -mod=vendor -v $(INTEGRATION_BASIC_PKGS); \
 	fi
 	
-	# Run packages needing special environment
+	# Run packages needing special environment.
+	# -gcflags=all=-l disables inlining, required for gomonkey-based mocks in gnmi_server tests.
 	@if [ -n "$(INTEGRATION_ENV_PKGS)" ]; then \
 		echo "Running environment-dependent integration tests..."; \
 		CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" $(TESTENV) \
 			sudo -E $(shell sudo $(GO) env GOPATH)/bin/gotestsum --junitfile test-results/junit-integration-env.xml \
 			--format testname \
 			-- -race -timeout 20m -coverprofile=test-results/coverage-integration-env.txt \
-			-covermode=atomic -mod=vendor $(BLD_FLAGS) -v $(INTEGRATION_ENV_PKGS); \
+			-covermode=atomic -mod=vendor $(BLD_FLAGS) -gcflags=all=-l -v $(INTEGRATION_ENV_PKGS); \
 	fi
 	
 	# Run dialout package if enabled


### PR DESCRIPTION
## Problem

Tests in `gnmi_server` that use `gomonkey.ApplyFunc()` to mock OS/auth functions (e.g. `user.Lookup`, `UserPwAuth`) silently fail to patch because the binary is built with inlining enabled. gomonkey patches function pointers at the machine-code level and **requires** inlining to be disabled to work correctly.

Without `-gcflags=all=-l`, `ApplyFunc()` patches are no-ops at runtime — the real functions execute instead — causing tests to get real authentication failures:

```
E0305 14:42:56 gnsi_authz.go:66] authentication failed in Rotate RPC: rpc error: code = Unauthenticated desc = Unauthenticated
    gnsi_authz_test.go:60: Unexpected error: rpc error: code = Unauthenticated desc = Unauthenticated
--- FAIL: TestGnsiAuthzRotation/RotateOpenClose
--- FAIL: TestGnsiAuthzRotation/RotateStreamRecvError
... (all 11 subtests fail)
--- FAIL: TestGnsiAuthzRotation
```

This is blocking PR #549 (gNSI Authz frontend implementation) which has failed on every CI run.

## Fix

Add `-gcflags=all=-l` to the `go test` invocations for `gnmi_server` (in `check_gotest`) and `INTEGRATION_ENV_PKGS` (in `check_gotest_junit`). This flag disables inlining so gomonkey can insert its patches at the function entry points.

The flag has no effect on production binaries and does not break any other tests — it only makes the test binary slightly larger and marginally slower to compile.

## References

- [gomonkey docs: build flags requirement](https://github.com/agiledragon/gomonkey#notice)
- PR #549: gNSI Authz (blocked by this issue)