### PR TITLE
sonic_data_client: make PollStats stoppable and wire into TestMain

### DIFF
--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -6463,6 +6463,9 @@ func init() {
 
 func TestMain(m *testing.M) {
 	defer test_utils.MemLeakCheck()
+	// Stop the PollStats goroutine started in sonic_data_client's init() so it
+	// cannot race with tests that patch os.OpenFile or os.File methods via gomonkey.
+	sdc.StopPollStats()
 	m.Run()
 }
 

--- a/sonic_data_client/client_test.go
+++ b/sonic_data_client/client_test.go
@@ -1030,6 +1030,9 @@ func TestUseRedisTcpClient(t *testing.T) {
 
 func TestMain(m *testing.M) {
 	defer test_utils.MemLeakCheck()
+	// Stop the PollStats goroutine started in init() so it cannot race with
+	// tests that patch os.OpenFile or os.File methods via gomonkey.
+	StopPollStats()
 	m.Run()
 }
 

--- a/sonic_data_client/non_db_client.go
+++ b/sonic_data_client/non_db_client.go
@@ -58,8 +58,10 @@ func InvalidateVersionFileStash() {
 }
 
 var (
-	clientTrie *Trie
-	statsR     statsRing
+	clientTrie    *Trie
+	statsR        statsRing
+	pollStatsDone = make(chan struct{})
+	pollStatsOnce sync.Once
 
 	versionFileStash sonicVersionYmlStash
 
@@ -343,8 +345,21 @@ func WriteStatsToBuffer(stat *linuxproc.Stat) {
 	statsR.mu.Unlock()
 }
 
+// StopPollStats stops the background PollStats goroutine. Safe to call multiple
+// times. Intended for use in test teardown (e.g. TestMain) to prevent the
+// goroutine from leaking across test cases and racing on os.File pointers.
+func StopPollStats() {
+	pollStatsOnce.Do(func() { close(pollStatsDone) })
+}
+
 func PollStats() {
 	for {
+		select {
+		case <-pollStatsDone:
+			return
+		default:
+		}
+
 		stat, err := linuxproc.ReadStat("/proc/stat")
 		if err != nil {
 			log.V(2).Infof("stat read fail")
@@ -352,9 +367,13 @@ func PollStats() {
 		}
 
 		WriteStatsToBuffer(stat)
-		time.Sleep(time.Millisecond * 100)
-	}
 
+		select {
+		case <-pollStatsDone:
+			return
+		case <-time.After(time.Millisecond * 100):
+		}
+	}
 }
 
 func init() {


### PR DESCRIPTION
## Problem

`PollStats()` is started in `sonic_data_client`'s `init()` and never stopped. The goroutine leaks across test boundaries in both `gnmi_server` and `sonic_data_client` test packages.

When tests use gomonkey to patch `os.OpenFile` or `os.File` methods, the still-running `PollStats` goroutine calls `linuxproc.ReadStat("/proc/stat")` which goes through `os.OpenFile`, hits the mock, and receives a zero-value `*os.File{}`. Calling `Stat()` on that causes a nil pointer dereference:

```
panic: runtime error: invalid memory address or nil pointer dereference
goroutine in PollStats() → linuxproc.ReadStat → os.ReadFile → os.(*File).Stat
```

Also observed as a DATA RACE in CI build `20260305.14`.

## Fix

**`sonic_data_client/non_db_client.go`**
- Add `pollStatsDone chan struct{}` + `sync.Once`
- Add exported `StopPollStats()` — safe to call multiple times
- `PollStats()` selects on done channel each iteration and exits when closed
- Use `select { case <-time.After(...) }` instead of `time.Sleep` for immediate shutdown response

**`gnmi_server/server_test.go`** and **`sonic_data_client/client_test.go`**
- Call `StopPollStats()` in `TestMain` before running tests in both packages

## Notes

- `StopPollStats()` is intentionally test-only — production code never calls it
- Calling it multiple times is safe (`sync.Once`)
- This is a prerequisite for PR #604 (`-gcflags=all=-l`): once gomonkey patches are effective, this goroutine would otherwise race and crash the test binary