### PR TITLE
azure-pipelines: add nightly scheduled run for flakiness detection

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,6 +17,17 @@ pr:
     - 202???
     - 201???
 
+# Scheduled nightly run on master for flakiness detection.
+# always: true ensures the run fires even when there are no new commits,
+# giving a consistent stream of data points for test analytics.
+schedules:
+- cron: "0 0 * * *"
+  displayName: "Nightly master run"
+  branches:
+    include:
+    - master
+  always: true
+
 variables:
   - name: BUILD_BRANCH
     ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
@@ -25,6 +36,13 @@ variables:
       value: $(Build.SourceBranchName)
   - name: UNIT_TEST_FLAG
     value: 'ENABLE_TRANSLIB_WRITE=y'
+  # Label used in testRunTitle to distinguish scheduled runs from PR/push runs
+  # in Azure DevOps test analytics, making it easier to filter for clean signal.
+  - name: RUN_TYPE
+    ${{ if eq(variables['Build.Reason'], 'Schedule') }}:
+      value: 'Nightly'
+    ${{ else }}:
+      value: 'CI'
 
 resources:
   repositories:
@@ -85,7 +103,7 @@ stages:
         testResultsFiles: '$(System.DefaultWorkingDirectory)/sonic-gnmi/test-results/junit-pure.xml'
         failTaskOnFailedTests: true
         publishRunAttachments: true
-        testRunTitle: 'Pure Package Tests'
+        testRunTitle: '$(RUN_TYPE) - Pure Package Tests'
 
     - task: PublishCodeCoverageResults@1
       displayName: 'Publish Pure Package Coverage'
@@ -150,7 +168,7 @@ stages:
         testResultsFiles: '$(System.DefaultWorkingDirectory)/sonic-gnmi/test-results/junit-memleak-standard.xml'
         failTaskOnFailedTests: true
         publishRunAttachments: true
-        testRunTitle: 'Memory Leak Tests'
+        testRunTitle: '$(RUN_TYPE) - Memory Leak Tests'
 
   # Full integration testing with SONiC dependencies
   - job: build
@@ -234,7 +252,7 @@ stages:
           $(System.DefaultWorkingDirectory)/sonic-gnmi/test-results/junit-integration-dialout.xml
         failTaskOnFailedTests: true
         publishRunAttachments: true
-        testRunTitle: 'Integration Tests'
+        testRunTitle: '$(RUN_TYPE) - Integration Tests'
 
     - publish: $(Build.ArtifactStagingDirectory)/
       artifact: sonic-gnmi


### PR DESCRIPTION
## Problem

Test analytics in Azure DevOps accumulate results mostly from PR runs. PR run failures are ambiguous — a test might fail because the PR broke it, or because it's flaky. Without regular master runs, the analytics can't cleanly identify flaky tests.

With the current volume of master runs (only on merges, a few per day at peak), a test that flakes at 5–10% failure rate can go undetected for days or weeks.

## Solution

Add a nightly scheduled trigger on `master` with `always: true`, so test analytics gets a consistent stream of clean data points independent of merge activity.

- **Scheduled**: midnight UTC daily
- **`always: true`**: fires even with no new commits — critical for consistent data
- **`RUN_TYPE` variable**: tags test run titles as `Nightly` vs `CI` so scheduled and PR/push results can be filtered separately in Azure DevOps test analytics

## Impact

30 clean master data points per month, enough to reliably surface tests failing >10% of the time. Scheduled and PR results remain in the same analytics dashboard but are distinguishable by run title prefix.

Signed-off-by: Dawei Huang <daweihuang@microsoft.com>