### PR TITLE
Refactor: Add missing defer Close() to prevent Redis connection leak 

### DIFF
--- a/gnmi_server/gnsi_certz.go
+++ b/gnmi_server/gnsi_certz.go
@@ -1040,7 +1040,7 @@ func writeCredentialsMetadataToDB(tbl, key, fld, val string) error {
 		log.V(0).Info(err.Error())
 		return fmt.Errorf("REDIS is not available: %v", err)
 	}
-	sc.Close()
+	defer sc.Close()
 
 	// Write metadata.
 	path := common_utils.GetKey([]string{credentialsTbl, tbl})


### PR DESCRIPTION
This PR adds a defer Close() call to the Redis connection handling logic in the writeCredentialsMetadataToDB()  to ensure the connection is properly closed