### PR TITLE
[agent][clientCertAuth] Fix nil pointer dereference on HTTP response in TryDownload

### DIFF
--- a/gnmi_server/clientCertAuth.go
+++ b/gnmi_server/clientCertAuth.go
@@ -161,6 +161,9 @@ func TryDownload(url string) bool {
 	resp, err := http.Get(url)
 
 	if err != nil {
+		if resp != nil && resp.Body != nil {
+			resp.Body.Close()
+		}
 		glog.Infof("Download CRL: %s failed: %v", url, err)
 		return false
 	}

--- a/gnmi_server/clientCertAuth.go
+++ b/gnmi_server/clientCertAuth.go
@@ -160,12 +160,14 @@ func TryDownload(url string) bool {
 	glog.Infof("Download CRL start: %s", url)
 	resp, err := http.Get(url)
 
-	if resp != nil {
-		defer resp.Body.Close()
-	}
-
-	if err != nil || resp.StatusCode != http.StatusOK {
+	if err != nil {
 		glog.Infof("Download CRL: %s failed: %v", url, err)
+		return false
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		glog.Infof("Download CRL: %s failed: HTTP %d", url, resp.StatusCode)
 		return false
 	}
 

--- a/gnmi_server/clientCertAuth.go
+++ b/gnmi_server/clientCertAuth.go
@@ -160,14 +160,14 @@ func TryDownload(url string) bool {
 	glog.Infof("Download CRL start: %s", url)
 	resp, err := http.Get(url)
 
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
 	if err != nil {
-		if resp != nil && resp.Body != nil {
-			resp.Body.Close()
-		}
 		glog.Infof("Download CRL: %s failed: %v", url, err)
 		return false
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		glog.Infof("Download CRL: %s failed: HTTP %d", url, resp.StatusCode)

--- a/gnmi_server/crl_test.go
+++ b/gnmi_server/crl_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/sonic-net/sonic-gnmi/common_utils"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 	"time"
@@ -246,5 +248,29 @@ func TestTryDownload(t *testing.T) {
 	downloaded := TryDownload("http://127.0.0.1:1234/")
 	if downloaded != false {
 		t.Errorf("Download should failed: %v", downloaded)
+	}
+}
+
+func TestTryDownloadRedirectError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/redirect", http.StatusFound)
+	}))
+	defer server.Close()
+
+	downloaded := TryDownload(server.URL)
+	if downloaded {
+		t.Errorf("Download should fail on redirect loop")
+	}
+}
+
+func TestTryDownloadNonOKResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	downloaded := TryDownload(server.URL)
+	if downloaded {
+		t.Errorf("Download should fail on non-OK response")
 	}
 }


### PR DESCRIPTION
#### What I did
Fix panic in `TryDownload()` when `http.Get()` returns `(nil, err)`.

#### How I did it
Restructured error handling to check `err != nil` first and return early before accessing `resp`. Then `defer resp.Body.Close()` and check `resp.StatusCode` separately.

**Before:** `resp.StatusCode` accessed in combined check with `err`, panics when `resp` is nil.
**After:** Error checked first, `resp` only accessed after confirming non-nil.

#### How to verify it
Call `TryDownload()` with an unreachable URL — should return false instead of panic.

#### Which release branch to backport
master

#### Description for the changelog
Fix nil pointer panic in gNMI CRL download when HTTP request fails.

Fixes: #630