### PR TITLE
Fix concurrent read and writes for global virtual db maps

### DIFF
--- a/gnmi_server/cli_helpers_test.go
+++ b/gnmi_server/cli_helpers_test.go
@@ -60,6 +60,7 @@ func FlushDataSet(t *testing.T, dbNum int) {
 }
 
 func AddDataSet(t *testing.T, dbNum int, fileName string) {
+	sdc.ClearMappings()
 	ns, _ := sdcfg.GetDbDefaultNamespace()
 	rclient := getRedisClientN(t, dbNum, ns)
 	defer rclient.Close()

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -935,6 +935,7 @@ func prepareStateDb(t *testing.T, namespace string) {
 }
 
 func prepareDb(t *testing.T, namespace string) {
+	sdc.ClearMappings()
 	rclient := getRedisClient(t, namespace)
 	defer rclient.Close()
 	rclient.FlushDB(context.Background())
@@ -1187,6 +1188,7 @@ func prepareDb(t *testing.T, namespace string) {
 }
 
 func prepareDbTranslib(t *testing.T) {
+	sdc.ClearMappings()
 	ns, _ := sdcfg.GetDbDefaultNamespace()
 	rclient := getRedisClient(t, ns)
 	rclient.FlushDB(context.Background())
@@ -5563,6 +5565,7 @@ func TestGNMINative(t *testing.T) {
 	go runServer(t, s)
 	defer s.Stop()
 	ns, _ := sdcfg.GetDbDefaultNamespace()
+	sdc.ClearMappings()
 	initFullConfigDb(t, ns)
 	initFullCountersDb(t, ns)
 

--- a/gnmi_server/virtual_db_test.go
+++ b/gnmi_server/virtual_db_test.go
@@ -1,0 +1,147 @@
+package gnmi
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+	sdc "github.com/sonic-net/sonic-gnmi/sonic_data_client"
+)
+
+func TestVirtualDbSyncOnce(t *testing.T) {
+	tests := []struct {
+		desc     string
+		initFunc func() error
+	}{
+		{"countersPortNameMap", sdc.InitCountersPortNameMap},
+		{"countersQueueNameMap", sdc.InitCountersQueueNameMap},
+		{"countersPGNameMap", sdc.InitCountersPGNameMap},
+		{"countersFabricPortNameMap", sdc.InitCountersFabricPortNameMap},
+		{"countersSidMap", sdc.InitCountersSidMap},
+		{"countersAclRuleMap", sdc.InitCountersAclRuleMap},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			sdc.ClearMappings()
+
+			var callCount int64
+			mock := gomonkey.ApplyFunc(sdc.GetCountersMap, func(tableName string) (map[string]string, error) {
+				atomic.AddInt64(&callCount, 1)
+				return map[string]string{"test_key": "test_oid"}, nil
+			})
+			if tt.desc == "countersFabricPortNameMap" {
+				mock = gomonkey.ApplyFunc(sdc.GetFabricCountersMap, func(tableName string) (map[string]string, error) {
+					atomic.AddInt64(&callCount, 1)
+					return map[string]string{"test_key": "test_oid"}, nil
+				})
+			}
+			defer mock.Reset()
+
+			for i := 0; i < 10; i++ {
+				tt.initFunc()
+			}
+			if c := atomic.LoadInt64(&callCount); c != 1 {
+				t.Errorf("expected underlying fetch called once, got %d", c)
+			}
+		})
+	}
+
+	t.Run("aliasMap", func(t *testing.T) {
+		sdc.ClearMappings()
+
+		var callCount int64
+		mock := gomonkey.ApplyFunc(sdc.GetAliasMap, func() (map[string]string, map[string]string, map[string]string, error) {
+			atomic.AddInt64(&callCount, 1)
+			return map[string]string{"Eth1": "Ethernet0"},
+				map[string]string{"Ethernet0": "Eth1"},
+				map[string]string{"Ethernet0": ""},
+				nil
+		})
+		defer mock.Reset()
+
+		for i := 0; i < 10; i++ {
+			sdc.AliasToPortNameMap()
+			sdc.PortToAliasNameMap()
+		}
+		if c := atomic.LoadInt64(&callCount); c != 1 {
+			t.Errorf("expected underlying fetch called once, got %d", c)
+		}
+	})
+}
+
+func TestVirtualDbSyncOnceConcurrent(t *testing.T) {
+	tests := []struct {
+		desc     string
+		initFunc func() error
+	}{
+		{"countersPortNameMap", sdc.InitCountersPortNameMap},
+		{"countersQueueNameMap", sdc.InitCountersQueueNameMap},
+		{"countersPGNameMap", sdc.InitCountersPGNameMap},
+		{"countersFabricPortNameMap", sdc.InitCountersFabricPortNameMap},
+		{"countersSidMap", sdc.InitCountersSidMap},
+		{"countersAclRuleMap", sdc.InitCountersAclRuleMap},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			sdc.ClearMappings()
+
+			var callCount int64
+			mock := gomonkey.ApplyFunc(sdc.GetCountersMap, func(tableName string) (map[string]string, error) {
+				atomic.AddInt64(&callCount, 1)
+				return map[string]string{"test_key": "test_oid"}, nil
+			})
+			if tt.desc == "countersFabricPortNameMap" {
+				mock = gomonkey.ApplyFunc(sdc.GetFabricCountersMap, func(tableName string) (map[string]string, error) {
+					atomic.AddInt64(&callCount, 1)
+					return map[string]string{"test_key": "test_oid"}, nil
+				})
+			}
+			defer mock.Reset()
+
+			var wg sync.WaitGroup
+			for i := 0; i < 100; i++ {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					tt.initFunc()
+				}()
+			}
+			wg.Wait()
+
+			if c := atomic.LoadInt64(&callCount); c != 1 {
+				t.Errorf("expected underlying fetch called once across 100 goroutines, got %d", c)
+			}
+		})
+	}
+
+	t.Run("aliasMap", func(t *testing.T) {
+		sdc.ClearMappings()
+
+		var callCount int64
+		mock := gomonkey.ApplyFunc(sdc.GetAliasMap, func() (map[string]string, map[string]string, map[string]string, error) {
+			atomic.AddInt64(&callCount, 1)
+			return map[string]string{"Eth1": "Ethernet0"},
+				map[string]string{"Ethernet0": "Eth1"},
+				map[string]string{"Ethernet0": ""},
+				nil
+		})
+		defer mock.Reset()
+
+		var wg sync.WaitGroup
+		for i := 0; i < 100; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				sdc.AliasToPortNameMap()
+			}()
+		}
+		wg.Wait()
+
+		if c := atomic.LoadInt64(&callCount); c != 1 {
+			t.Errorf("expected underlying fetch called once across 100 goroutines, got %d", c)
+		}
+	})
+}

--- a/sonic_data_client/virtual_db.go
+++ b/sonic_data_client/virtual_db.go
@@ -66,13 +66,13 @@ var (
 	countersDebugNameSwitchStatMap = make(map[string]string)
 
 	// sync.Once guards for each init function
-	initCountersPortNameMapOnce      sync.Once
-	initCountersQueueNameMapOnce     sync.Once
-	initCountersPGNameMapOnce        sync.Once
-	initCountersSidMapOnce           sync.Once
-	initCountersAclRuleMapOnce       sync.Once
-	initAliasMapOnce                 sync.Once
-	initCountersPfcwdNameMapOnce     sync.Once
+	initCountersPortNameMapOnce       sync.Once
+	initCountersQueueNameMapOnce      sync.Once
+	initCountersPGNameMapOnce         sync.Once
+	initCountersSidMapOnce            sync.Once
+	initCountersAclRuleMapOnce        sync.Once
+	initAliasMapOnce                  sync.Once
+	initCountersPfcwdNameMapOnce      sync.Once
 	initCountersFabricPortNameMapOnce sync.Once
 
 	// path2TFuncTbl is used to populate trie tree which is reponsible
@@ -197,7 +197,6 @@ func GetCountersQueueTypeMap() (map[string]string, error) {
 	}
 	return countersQueueTypeMap, nil
 }
-
 
 func initCountersPortNameMap() error {
 	var initErr error
@@ -1173,7 +1172,6 @@ func InitCountersPGNameMap() error         { return initCountersPGNameMap() }
 func InitCountersSidMap() error            { return initCountersSidMap() }
 func InitCountersAclRuleMap() error        { return initCountersAclRuleMap() }
 func InitCountersFabricPortNameMap() error { return initCountersFabricPortNameMap() }
-
 
 // Populate real data paths from paths like
 // [COUNTERS_DB PERIODIC_WATERMARKS Ethernet* PriorityGroups] or

--- a/sonic_data_client/virtual_db.go
+++ b/sonic_data_client/virtual_db.go
@@ -75,6 +75,8 @@ var (
 	initCountersPfcwdNameMapOnce      sync.Once
 	initCountersFabricPortNameMapOnce sync.Once
 
+	// Mutex to protect ClearMappings from racing with init functions
+	clearMappingsMu sync.RWMutex
 	// path2TFuncTbl is used to populate trie tree which is reponsible
 	// for virtual path to real data path translation
 	pathTransFuncTbl = []pathTransFunc{
@@ -136,6 +138,8 @@ func (t *Trie) v2rTriePopulate() {
 }
 
 func initCountersQueueNameMap() error {
+	clearMappingsMu.RLock()
+	defer clearMappingsMu.RUnlock()
 	var initErr error
 	initCountersQueueNameMapOnce.Do(func() {
 		var err error
@@ -148,6 +152,8 @@ func initCountersQueueNameMap() error {
 }
 
 func initCountersPGNameMap() error {
+	clearMappingsMu.RLock()
+	defer clearMappingsMu.RUnlock()
 	var initErr error
 	initCountersPGNameMapOnce.Do(func() {
 		pgOidMap, err := GetCountersMap("COUNTERS_PG_NAME_MAP")
@@ -197,6 +203,8 @@ func GetCountersQueueTypeMap() (map[string]string, error) {
 }
 
 func initCountersPortNameMap() error {
+	clearMappingsMu.RLock()
+	defer clearMappingsMu.RUnlock()
 	var initErr error
 	initCountersPortNameMapOnce.Do(func() {
 		var err error
@@ -209,6 +217,8 @@ func initCountersPortNameMap() error {
 }
 
 func initCountersSidMap() error {
+	clearMappingsMu.RLock()
+	defer clearMappingsMu.RUnlock()
 	var initErr error
 	initCountersSidMapOnce.Do(func() {
 		var err error
@@ -221,6 +231,8 @@ func initCountersSidMap() error {
 }
 
 func initCountersAclRuleMap() error {
+	clearMappingsMu.RLock()
+	defer clearMappingsMu.RUnlock()
 	var initErr error
 	initCountersAclRuleMapOnce.Do(func() {
 		var err error
@@ -235,6 +247,8 @@ func initCountersAclRuleMap() error {
 }
 
 func initAliasMap() error {
+	clearMappingsMu.RLock()
+	defer clearMappingsMu.RUnlock()
 	var initErr error
 	initAliasMapOnce.Do(func() {
 		var err error
@@ -247,6 +261,8 @@ func initAliasMap() error {
 }
 
 func initCountersPfcwdNameMap() error {
+	clearMappingsMu.RLock()
+	defer clearMappingsMu.RUnlock()
 	var initErr error
 	initCountersPfcwdNameMapOnce.Do(func() {
 		var err error
@@ -259,6 +275,8 @@ func initCountersPfcwdNameMap() error {
 }
 
 func initCountersFabricPortNameMap() error {
+	clearMappingsMu.RLock()
+	defer clearMappingsMu.RUnlock()
 	var initErr error
 	initCountersFabricPortNameMapOnce.Do(func() {
 		var err error
@@ -1121,6 +1139,9 @@ func ClearMappings() {
 	if value != "1" {
 		return
 	}
+	clearMappingsMu.Lock()
+	defer clearMappingsMu.Unlock()
+
 	counterMaps := []map[string]string{
 		countersPortNameMap,
 		alias2nameMap,

--- a/sonic_data_client/virtual_db.go
+++ b/sonic_data_client/virtual_db.go
@@ -176,11 +176,9 @@ func GetCountersQueueTypeMap() (map[string]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	if len(countersQueueNameMap) == 0 {
-		err = initCountersQueueNameMap()
-		if err != nil {
-			return nil, err
-		}
+	err = initCountersQueueNameMap()
+	if err != nil {
+		return nil, err
 	}
 	countersQueueTypeMap := make(map[string]string)
 	for queue, oid := range countersQueueNameMap {

--- a/sonic_data_client/virtual_db.go
+++ b/sonic_data_client/virtual_db.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 
 	sdcfg "github.com/sonic-net/sonic-gnmi/sonic_db_config"
 
@@ -63,6 +64,16 @@ var (
 
 	// SONiC Switch ID to Switch Stat packet integrity drop counters
 	countersDebugNameSwitchStatMap = make(map[string]string)
+
+	// sync.Once guards for each init function
+	initCountersPortNameMapOnce      sync.Once
+	initCountersQueueNameMapOnce     sync.Once
+	initCountersPGNameMapOnce        sync.Once
+	initCountersSidMapOnce           sync.Once
+	initCountersAclRuleMapOnce       sync.Once
+	initAliasMapOnce                 sync.Once
+	initCountersPfcwdNameMapOnce     sync.Once
+	initCountersFabricPortNameMapOnce sync.Once
 
 	// path2TFuncTbl is used to populate trie tree which is reponsible
 	// for virtual path to real data path translation
@@ -125,106 +136,141 @@ func (t *Trie) v2rTriePopulate() {
 }
 
 func initCountersQueueNameMap() error {
-	var err error
-	if len(countersQueueNameMap) == 0 {
-		countersQueueNameMap, err = getCountersMap("COUNTERS_QUEUE_NAME_MAP")
+	var initErr error
+	initCountersQueueNameMapOnce.Do(func() {
+		var err error
+		countersQueueNameMap, err = GetCountersMap("COUNTERS_QUEUE_NAME_MAP")
 		if err != nil {
-			return err
+			initErr = err
 		}
-	}
-	return nil
+	})
+	return initErr
 }
 
 func initCountersPGNameMap() error {
-	if len(countersPGNameMap) == 0 {
-		pgOidMap, err := getCountersMap("COUNTERS_PG_NAME_MAP")
+	var initErr error
+	initCountersPGNameMapOnce.Do(func() {
+		pgOidMap, err := GetCountersMap("COUNTERS_PG_NAME_MAP")
 		if err != nil {
-			return err
+			initErr = err
+			return
 		}
 		for pg, oid := range pgOidMap {
 			// pg is in format of "Ethernet64:7"
 			pg_parts := strings.Split(pg, ":")
 			if len(pg_parts) != 2 {
-				return fmt.Errorf("invalid pg name %v", pg)
+				initErr = fmt.Errorf("invalid pg name %v", pg)
+				return
 			}
 			if _, ok := countersPGNameMap[pg_parts[0]]; !ok {
 				countersPGNameMap[pg_parts[0]] = make(map[string]string)
 			}
 			countersPGNameMap[pg_parts[0]][pg_parts[1]] = oid
 		}
-	}
-	return nil
+	})
+	return initErr
 }
 
-func initCountersPortNameMap() error {
-	var err error
-	if len(countersPortNameMap) == 0 {
-		countersPortNameMap, err = getCountersMap("COUNTERS_PORT_NAME_MAP")
+func GetCountersQueueTypeMap() (map[string]string, error) {
+	oidTypeMap, err := GetCountersMap("COUNTERS_QUEUE_TYPE_MAP")
+	if err != nil {
+		return nil, err
+	}
+	if len(countersQueueNameMap) == 0 {
+		err = initCountersQueueNameMap()
 		if err != nil {
-			return err
+			return nil, err
 		}
 	}
-	return nil
+	countersQueueTypeMap := make(map[string]string)
+	for queue, oid := range countersQueueNameMap {
+		if qtype, ok := oidTypeMap[oid]; ok {
+			if qtype == "SAI_QUEUE_TYPE_UNICAST" {
+				countersQueueTypeMap[queue] = "UC"
+			} else if qtype == "SAI_QUEUE_TYPE_MULTICAST" {
+				countersQueueTypeMap[queue] = "MC"
+			} else {
+				log.V(1).Infof("Invalid queue type %s for queue %s", qtype, queue)
+				countersQueueTypeMap[queue] = "Unknown"
+			}
+		}
+	}
+	return countersQueueTypeMap, nil
+}
+
+
+func initCountersPortNameMap() error {
+	var initErr error
+	initCountersPortNameMapOnce.Do(func() {
+		var err error
+		countersPortNameMap, err = GetCountersMap("COUNTERS_PORT_NAME_MAP")
+		if err != nil {
+			initErr = err
+		}
+	})
+	return initErr
 }
 
 func initCountersSidMap() error {
-	var err error
-	if len(countersSidMap) == 0 {
-		countersSidMap, err = getCountersMap("COUNTERS_SRV6_NAME_MAP")
+	var initErr error
+	initCountersSidMapOnce.Do(func() {
+		var err error
+		countersSidMap, err = GetCountersMap("COUNTERS_SRV6_NAME_MAP")
 		if err != nil {
-			return err
+			initErr = err
 		}
-	}
-	return nil
+	})
+	return initErr
 }
 
 func initCountersAclRuleMap() error {
-	var err error
-	if len(countersAclRuleMap) == 0 {
+	var initErr error
+	initCountersAclRuleMapOnce.Do(func() {
+		var err error
 		// ACL_COUNTER_RULE_MAP is a hash in COUNTERS_DB:
 		//   "DATAACL:RULE_1" -> "oid:0x9000000000711"
-		countersAclRuleMap, err = getCountersMap("ACL_COUNTER_RULE_MAP")
+		countersAclRuleMap, err = GetCountersMap("ACL_COUNTER_RULE_MAP")
 		if err != nil {
-			return err
+			initErr = err
 		}
-	}
-	return nil
+	})
+	return initErr
 }
 
 func initAliasMap() error {
-	var err error
-	if len(alias2nameMap) == 0 {
-		alias2nameMap, name2aliasMap, port2namespaceMap, err = getAliasMap()
+	var initErr error
+	initAliasMapOnce.Do(func() {
+		var err error
+		alias2nameMap, name2aliasMap, port2namespaceMap, err = GetAliasMap()
 		if err != nil {
-			return err
+			initErr = err
 		}
-	}
-	return nil
+	})
+	return initErr
 }
 
 func initCountersPfcwdNameMap() error {
-	var err error
-	if len(countersPfcwdNameMap) == 0 {
+	var initErr error
+	initCountersPfcwdNameMapOnce.Do(func() {
+		var err error
 		countersPfcwdNameMap, err = GetPfcwdMap()
 		if err != nil {
-			return err
+			initErr = err
 		}
-	}
-	return nil
+	})
+	return initErr
 }
 
 func initCountersFabricPortNameMap() error {
-	var err error
-	// Reset map for Unit test to ensure that counters db is updated
-	// after changing from single to multi-asic config
-	value := os.Getenv("UNIT_TEST")
-	if len(countersFabricPortNameMap) == 0 || value == "1" {
-		countersFabricPortNameMap, err = getFabricCountersMap("COUNTERS_FABRIC_PORT_NAME_MAP")
+	var initErr error
+	initCountersFabricPortNameMapOnce.Do(func() {
+		var err error
+		countersFabricPortNameMap, err = GetFabricCountersMap("COUNTERS_FABRIC_PORT_NAME_MAP")
 		if err != nil {
-			return err
+			initErr = err
 		}
-	}
-	return nil
+	})
+	return initErr
 }
 
 func initDebugNameSwitchStatMap() error {
@@ -349,7 +395,7 @@ func GetPfcwdMap() (map[string]map[string]string, error) {
 }
 
 // Get the mapping between sonic interface name and vendor alias and sonic-interface to namespace map
-func getAliasMap() (map[string]string, map[string]string, map[string]string, error) {
+func GetAliasMap() (map[string]string, map[string]string, map[string]string, error) {
 	var alias2name_map = make(map[string]string)
 	var name2alias_map = make(map[string]string)
 	var port2namespace_map = make(map[string]string)
@@ -400,7 +446,7 @@ func addmap(a map[string]string, b map[string]string) {
 
 // Get the mapping between objects in counters DB, Ex. port name to oid in "COUNTERS_PORT_NAME_MAP" table.
 // Aussuming static port name to oid map in COUNTERS table
-func getCountersMap(tableName string) (map[string]string, error) {
+func GetCountersMap(tableName string) (map[string]string, error) {
 	counter_map := make(map[string]string)
 	dbName := "COUNTERS_DB"
 	redis_client_map, err := GetRedisClientsForDb(dbName)
@@ -421,7 +467,7 @@ func getCountersMap(tableName string) (map[string]string, error) {
 
 // Get the mapping between objects in counters DB, Ex. port name to oid in "COUNTERS_FABRIC_PORT_NAME_MAP" table.
 // Aussuming static port name to oid map in COUNTERS table
-func getFabricCountersMap(tableName string) (map[string]string, error) {
+func GetFabricCountersMap(tableName string) (map[string]string, error) {
 	counter_map := make(map[string]string)
 	dbName := "COUNTERS_DB"
 	redis_client_map, err := GetRedisClientsForDb(dbName)
@@ -1090,6 +1136,16 @@ func ClearMappings() {
 			delete(counterMap, entry)
 		}
 	}
+
+	// Reset sync.Once guards so the next call re-initializes.
+	initCountersPortNameMapOnce = sync.Once{}
+	initCountersQueueNameMapOnce = sync.Once{}
+	initCountersPGNameMapOnce = sync.Once{}
+	initCountersSidMapOnce = sync.Once{}
+	initCountersAclRuleMapOnce = sync.Once{}
+	initAliasMapOnce = sync.Once{}
+	initCountersPfcwdNameMapOnce = sync.Once{}
+	initCountersFabricPortNameMapOnce = sync.Once{}
 }
 
 func AliasToPortNameMap() map[string]string {
@@ -1099,6 +1155,25 @@ func AliasToPortNameMap() map[string]string {
 	}
 	return output
 }
+
+func PortToAliasNameMap() map[string]string {
+	// Ensure alias map is initialized
+	initAliasMap()
+
+	output := make(map[string]string, len(name2aliasMap))
+	for portName, alias := range name2aliasMap {
+		output[portName] = alias
+	}
+	return output
+}
+
+func InitCountersPortNameMap() error       { return initCountersPortNameMap() }
+func InitCountersQueueNameMap() error      { return initCountersQueueNameMap() }
+func InitCountersPGNameMap() error         { return initCountersPGNameMap() }
+func InitCountersSidMap() error            { return initCountersSidMap() }
+func InitCountersAclRuleMap() error        { return initCountersAclRuleMap() }
+func InitCountersFabricPortNameMap() error { return initCountersFabricPortNameMap() }
+
 
 // Populate real data paths from paths like
 // [COUNTERS_DB PERIODIC_WATERMARKS Ethernet* PriorityGroups] or


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

There is a potential race condition where two goroutines may enter the Init function for a map and they both read that the map is empty and try to modify the map at the same time.

Use sync.Once instead of checking for empty map as this is an atomic operation such that our initialization of these global maps will be thread safe.

```
telemetry fatal error: concurrent map writes
telemetry fatal error: concurrent map read and map write
telemetry
telemetry goroutine 30 [running]:
telemetry runtime.fatal({0x12cbd58
telemetry ?, 0x0?})
telemetry #011/usr/lib/go-1.19/src/runtime/panic.go:1066 +0x5d fp=0xc000bc29a0 sp=0xc000bc2970 pc=0x4f4b1d
telemetry runtime.mapassign_faststr(0x11435a0, 0xc0008683c0, {0xc0005d35c0, 0xb})
telemetry #011/usr/lib/go-1.19/src/runtime/map_faststr.go:212 +0x56 fp=0xc000bc2a10 sp=0xc000bc29a0 pc=0x4d04b6
telemetry github.com/sonic-net/sonic-gnmi/sonic_data_client.initCountersPGNameMap()
telemetry #011/sonic/src/sonic-gnmi/sonic_data_client/virtual_db.go:128 +0x15e fp=0xc000bc2af0 sp=0xc000bc2a10 pc=
telemetry 0xe25ebe
telemetry github.com/sonic-net/sonic-gnmi/sonic_data_client.populateDbtablePath(0xc000bc31e8, 0xc00047e080, 0xc000bc2f70)
telemetry #011/sonic/src/sonic-gnmi/sonic_data_client/db_client.go:664 +0x297 fp=0xc000bc2f58 sp=0xc000bc2af0 pc=0xe09637
telemetry github.com/sonic-net/sonic-gnmi/sonic_data_client.PopulateTablePaths(0x11fe880?, 0xc00047e080)
telemetry #011/sonic/src/sonic-gnmi/sonic_data_client/show_client.go:140 +0xaa fp=0xc000bc30d0 sp=0xc000bc2f58 pc=0xe1c76a
telemetry github.com/sonic-net/sonic-gnmi/show_client/common.CreateTablePathsFromQueries({0xc000576078?, 0x1, 0xc000908040
telemetry ?})
telemetry #011/sonic/src/sonic-gnmi/show_client/common/db.go:82 +0x215 fp=0xc000bc3270 sp=0xc000bc30d0 pc=0xf0eb55
telemetry github.com/sonic-net/sonic-gnmi/show_client/common.GetMapFromQueries({0xc000576078?, 0x0?, 0x4?})
telemetry #011/sonic/src/sonic-gnmi/show_client/common/db.go:33 +0x25 fp=0xc000bc32d0 sp=
telemetry 0xc000bc3270 pc=0xf0e785
telemetry github.com/sonic-net/sonic-gnmi/show_client.getQueueWatermarksSnapshot({0x0?, 0x0?, 0x12bd992?}, 0x0, {0x12c339f, 0xf})
telemetry #011/sonic/src/sonic-gnmi/show_client/queue_watermark_cli.go:31 +0x151 fp=0xc000bc3490 sp=0xc000bc32d0 pc=0xf5c6f1
telemetry github.com/sonic-net/sonic-gnmi/show_client.getQueueWatermarksCommon(0xe1ce45?, 0xc000aca700?, {
telemetry 0x12c339f, 0xf})
telemetry #011/sonic/src/sonic-gnmi/show_client/queue_watermark_cli.go:76 +0xf1 fp=0xc000bc3518 sp=0xc000bc3490 pc=0xf5d031
telemetry github.com/sonic-net/sonic-gnmi/show_client.getQueueUserWatermarksAll({0x13455b8?, 0xc00084b5f0?, 0x12b5b69?}, 0x4?)
telemetry #011/sonic/src/sonic-gnmi/show_client/queue_watermark_cli.go:108 +0x2a fp=0xc000bc3548 sp=0xc000bc3518 pc=0xf5d50a
telemetry github.com/sonic-net/sonic-gnmi/sonic_data_client.(*ShowClient).Get(0xc000269180, 0x1?)
telemetry #011/sonic/src/sonic-gnmi/sonic_data_client/show_client.go:118 +0x25a fp=0xc000bc3728 sp=0xc000bc3548 pc=0xe1c09a
telemetry github.com/sonic-net/sonic-gnmi/gnmi_server.(*Server).Get(0xc000a360f0, {0x14acee0, 0xc000acd1a0}, 0xc000aca500)
telemetry #011/sonic/src/sonic-gnmi/gnmi_server/server.go:429 +0x6e8 fp=0xc000bc3918 sp=0xc000bc3728 pc=0xf90d68
```

#### How I did it

Use sync.Once to initialize global maps.
