### PR TITLE
Fix concurrent read and writes for global virtual db maps

### DIFF
--- a/gnmi_server/cli_helpers_test.go
+++ b/gnmi_server/cli_helpers_test.go
@@ -60,6 +60,7 @@ func FlushDataSet(t *testing.T, dbNum int) {
 }
 
 func AddDataSet(t *testing.T, dbNum int, fileName string) {
+	sdc.ClearMappings()
 	ns, _ := sdcfg.GetDbDefaultNamespace()
 	rclient := getRedisClientN(t, dbNum, ns)
 	defer rclient.Close()

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -935,6 +935,7 @@ func prepareStateDb(t *testing.T, namespace string) {
 }
 
 func prepareDb(t *testing.T, namespace string) {
+	sdc.ClearMappings()
 	rclient := getRedisClient(t, namespace)
 	defer rclient.Close()
 	rclient.FlushDB(context.Background())

--- a/gnmi_server/virtual_db_test.go
+++ b/gnmi_server/virtual_db_test.go
@@ -1,6 +1,7 @@
 package gnmi
 
 import (
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -67,6 +68,55 @@ func TestVirtualDbSyncOnce(t *testing.T) {
 		if c := atomic.LoadInt64(&callCount); c != 1 {
 			t.Errorf("expected underlying fetch called once, got %d", c)
 		}
+	})
+}
+
+func TestVirtualDbSyncOnceError(t *testing.T) {
+	tests := []struct {
+		desc     string
+		initFunc func() error
+	}{
+		{"countersPortNameMap", sdc.InitCountersPortNameMap},
+		{"countersQueueNameMap", sdc.InitCountersQueueNameMap},
+		{"countersPGNameMap", sdc.InitCountersPGNameMap},
+		{"countersFabricPortNameMap", sdc.InitCountersFabricPortNameMap},
+		{"countersSidMap", sdc.InitCountersSidMap},
+		{"countersAclRuleMap", sdc.InitCountersAclRuleMap},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			sdc.ClearMappings()
+
+			mockErr := fmt.Errorf("mock redis error")
+			mock := gomonkey.ApplyFunc(sdc.GetCountersMap, func(tableName string) (map[string]string, error) {
+				return nil, mockErr
+			})
+			if tt.desc == "countersFabricPortNameMap" {
+				mock = gomonkey.ApplyFunc(sdc.GetFabricCountersMap, func(tableName string) (map[string]string, error) {
+					return nil, mockErr
+				})
+			}
+			defer mock.Reset()
+
+			err := tt.initFunc()
+			if err == nil {
+				t.Errorf("expected error, got nil")
+			}
+		})
+	}
+
+	t.Run("aliasMap", func(t *testing.T) {
+		sdc.ClearMappings()
+
+		mockErr := fmt.Errorf("mock redis error")
+		mock := gomonkey.ApplyFunc(sdc.GetAliasMap, func() (map[string]string, map[string]string, map[string]string, error) {
+			return nil, nil, nil, mockErr
+		})
+		defer mock.Reset()
+
+		// AliasToPortNameMap calls initAliasMap internally
+		sdc.AliasToPortNameMap()
 	})
 }
 

--- a/gnmi_server/virtual_db_test.go
+++ b/gnmi_server/virtual_db_test.go
@@ -1,0 +1,146 @@
+package gnmi
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+	sdc "github.com/sonic-net/sonic-gnmi/sonic_data_client"
+)
+
+func TestVirtualDbSyncOnce(t *testing.T) {
+	tests := []struct {
+		desc     string
+		initFunc func() error
+	}{
+		{"countersPortNameMap", sdc.InitCountersPortNameMap},
+		{"countersQueueNameMap", sdc.InitCountersQueueNameMap},
+		{"countersPGNameMap", sdc.InitCountersPGNameMap},
+		{"countersFabricPortNameMap", sdc.InitCountersFabricPortNameMap},
+		{"countersSidMap", sdc.InitCountersSidMap},
+		{"countersAclRuleMap", sdc.InitCountersAclRuleMap},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			sdc.ClearMappings()
+
+			var callCount int64
+			mock := gomonkey.ApplyFunc(sdc.GetCountersMap, func(tableName string) (map[string]string, error) {
+				atomic.AddInt64(&callCount, 1)
+				return map[string]string{"test_key": "test_oid"}, nil
+			})
+			if tt.desc == "countersFabricPortNameMap" {
+				mock = gomonkey.ApplyFunc(sdc.GetFabricCountersMap, func(tableName string) (map[string]string, error) {
+					atomic.AddInt64(&callCount, 1)
+					return map[string]string{"test_key": "test_oid"}, nil
+				})
+			}
+			defer mock.Reset()
+
+			for i := 0; i < 10; i++ {
+				tt.initFunc()
+			}
+			if c := atomic.LoadInt64(&callCount); c != 1 {
+				t.Errorf("expected underlying fetch called once, got %d", c)
+			}
+		})
+	}
+
+	t.Run("aliasMap", func(t *testing.T) {
+		sdc.ClearMappings()
+
+		var callCount int64
+		mock := gomonkey.ApplyFunc(sdc.GetAliasMap, func() (map[string]string, map[string]string, map[string]string, error) {
+			atomic.AddInt64(&callCount, 1)
+			return map[string]string{"Eth1": "Ethernet0"},
+				map[string]string{"Ethernet0": "Eth1"},
+				map[string]string{"Ethernet0": ""},
+				nil
+		})
+		defer mock.Reset()
+
+		for i := 0; i < 10; i++ {
+			sdc.AliasToPortNameMap()
+		}
+		if c := atomic.LoadInt64(&callCount); c != 1 {
+			t.Errorf("expected underlying fetch called once, got %d", c)
+		}
+	})
+}
+
+func TestVirtualDbSyncOnceConcurrent(t *testing.T) {
+	tests := []struct {
+		desc     string
+		initFunc func() error
+	}{
+		{"countersPortNameMap", sdc.InitCountersPortNameMap},
+		{"countersQueueNameMap", sdc.InitCountersQueueNameMap},
+		{"countersPGNameMap", sdc.InitCountersPGNameMap},
+		{"countersFabricPortNameMap", sdc.InitCountersFabricPortNameMap},
+		{"countersSidMap", sdc.InitCountersSidMap},
+		{"countersAclRuleMap", sdc.InitCountersAclRuleMap},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			sdc.ClearMappings()
+
+			var callCount int64
+			mock := gomonkey.ApplyFunc(sdc.GetCountersMap, func(tableName string) (map[string]string, error) {
+				atomic.AddInt64(&callCount, 1)
+				return map[string]string{"test_key": "test_oid"}, nil
+			})
+			if tt.desc == "countersFabricPortNameMap" {
+				mock = gomonkey.ApplyFunc(sdc.GetFabricCountersMap, func(tableName string) (map[string]string, error) {
+					atomic.AddInt64(&callCount, 1)
+					return map[string]string{"test_key": "test_oid"}, nil
+				})
+			}
+			defer mock.Reset()
+
+			var wg sync.WaitGroup
+			for i := 0; i < 100; i++ {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					tt.initFunc()
+				}()
+			}
+			wg.Wait()
+
+			if c := atomic.LoadInt64(&callCount); c != 1 {
+				t.Errorf("expected underlying fetch called once across 100 goroutines, got %d", c)
+			}
+		})
+	}
+
+	t.Run("aliasMap", func(t *testing.T) {
+		sdc.ClearMappings()
+
+		var callCount int64
+		mock := gomonkey.ApplyFunc(sdc.GetAliasMap, func() (map[string]string, map[string]string, map[string]string, error) {
+			atomic.AddInt64(&callCount, 1)
+			return map[string]string{"Eth1": "Ethernet0"},
+				map[string]string{"Ethernet0": "Eth1"},
+				map[string]string{"Ethernet0": ""},
+				nil
+		})
+		defer mock.Reset()
+
+		var wg sync.WaitGroup
+		for i := 0; i < 100; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				sdc.AliasToPortNameMap()
+			}()
+		}
+		wg.Wait()
+
+		if c := atomic.LoadInt64(&callCount); c != 1 {
+			t.Errorf("expected underlying fetch called once across 100 goroutines, got %d", c)
+		}
+	})
+}

--- a/sonic_data_client/virtual_db.go
+++ b/sonic_data_client/virtual_db.go
@@ -78,6 +78,7 @@ var (
 	// Mutex to protect ClearMappings from racing with init functions
 	clearMappingsMu sync.RWMutex
 
+
 	// path2TFuncTbl is used to populate trie tree which is reponsible
 	// for virtual path to real data path translation
 	pathTransFuncTbl = []pathTransFunc{
@@ -126,6 +127,15 @@ var (
 	}
 )
 
+// Function variables for map fetching. Init functions call these instead of
+// the concrete implementations, allowing tests to inject errors.
+var (
+	getCountersMapFn       = func(t string) (map[string]string, error) { return GetCountersMap(t) }
+	getAliasMapFn          = func() (map[string]string, map[string]string, map[string]string, error) { return GetAliasMap() }
+	getFabricCountersMapFn = func(t string) (map[string]string, error) { return GetFabricCountersMap(t) }
+	getPfcwdMapFn          = func() (map[string]map[string]string, error) { return GetPfcwdMap() }
+)
+
 func (t *Trie) v2rTriePopulate() {
 	for _, pt := range pathTransFuncTbl {
 		n := t.Add(pt.path, pt.transFunc)
@@ -144,7 +154,7 @@ func initCountersQueueNameMap() error {
 	var initErr error
 	initCountersQueueNameMapOnce.Do(func() {
 		var err error
-		countersQueueNameMap, err = GetCountersMap("COUNTERS_QUEUE_NAME_MAP")
+		countersQueueNameMap, err = getCountersMapFn("COUNTERS_QUEUE_NAME_MAP")
 		if err != nil {
 			initErr = err
 		}
@@ -157,7 +167,7 @@ func initCountersPGNameMap() error {
 	defer clearMappingsMu.RUnlock()
 	var initErr error
 	initCountersPGNameMapOnce.Do(func() {
-		pgOidMap, err := GetCountersMap("COUNTERS_PG_NAME_MAP")
+		pgOidMap, err := getCountersMapFn("COUNTERS_PG_NAME_MAP")
 		if err != nil {
 			initErr = err
 			return
@@ -184,7 +194,7 @@ func initCountersPortNameMap() error {
 	var initErr error
 	initCountersPortNameMapOnce.Do(func() {
 		var err error
-		countersPortNameMap, err = GetCountersMap("COUNTERS_PORT_NAME_MAP")
+		countersPortNameMap, err = getCountersMapFn("COUNTERS_PORT_NAME_MAP")
 		if err != nil {
 			initErr = err
 		}
@@ -198,7 +208,7 @@ func initCountersSidMap() error {
 	var initErr error
 	initCountersSidMapOnce.Do(func() {
 		var err error
-		countersSidMap, err = GetCountersMap("COUNTERS_SRV6_NAME_MAP")
+		countersSidMap, err = getCountersMapFn("COUNTERS_SRV6_NAME_MAP")
 		if err != nil {
 			initErr = err
 		}
@@ -214,7 +224,7 @@ func initCountersAclRuleMap() error {
 		var err error
 		// ACL_COUNTER_RULE_MAP is a hash in COUNTERS_DB:
 		//   "DATAACL:RULE_1" -> "oid:0x9000000000711"
-		countersAclRuleMap, err = GetCountersMap("ACL_COUNTER_RULE_MAP")
+		countersAclRuleMap, err = getCountersMapFn("ACL_COUNTER_RULE_MAP")
 		if err != nil {
 			initErr = err
 		}
@@ -228,7 +238,7 @@ func initAliasMap() error {
 	var initErr error
 	initAliasMapOnce.Do(func() {
 		var err error
-		alias2nameMap, name2aliasMap, port2namespaceMap, err = GetAliasMap()
+		alias2nameMap, name2aliasMap, port2namespaceMap, err = getAliasMapFn()
 		if err != nil {
 			initErr = err
 		}
@@ -242,7 +252,7 @@ func initCountersPfcwdNameMap() error {
 	var initErr error
 	initCountersPfcwdNameMapOnce.Do(func() {
 		var err error
-		countersPfcwdNameMap, err = GetPfcwdMap()
+		countersPfcwdNameMap, err = getPfcwdMapFn()
 		if err != nil {
 			initErr = err
 		}
@@ -256,7 +266,7 @@ func initCountersFabricPortNameMap() error {
 	var initErr error
 	initCountersFabricPortNameMapOnce.Do(func() {
 		var err error
-		countersFabricPortNameMap, err = GetFabricCountersMap("COUNTERS_FABRIC_PORT_NAME_MAP")
+		countersFabricPortNameMap, err = getFabricCountersMapFn("COUNTERS_FABRIC_PORT_NAME_MAP")
 		if err != nil {
 			initErr = err
 		}

--- a/sonic_data_client/virtual_db.go
+++ b/sonic_data_client/virtual_db.go
@@ -1126,25 +1126,6 @@ func getPortNamespace(port string) (string, error) {
 	return namespace, nil
 }
 
-func ClearMappings() {
-	value := os.Getenv("UNIT_TEST")
-	if value != "1" {
-		return
-	}
-	counterMaps := []map[string]string{
-		countersPortNameMap,
-		alias2nameMap,
-		countersFabricPortNameMap,
-		countersQueueNameMap,
-		countersAclRuleMap,
-	}
-	for _, counterMap := range counterMaps {
-		for entry := range counterMap {
-			delete(counterMap, entry)
-		}
-	}
-}
-
 func AliasToPortNameMap() map[string]string {
 	// Ensure alias map is initialized
 	initAliasMap()

--- a/sonic_data_client/virtual_db.go
+++ b/sonic_data_client/virtual_db.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 
 	sdcfg "github.com/sonic-net/sonic-gnmi/sonic_db_config"
 
@@ -63,6 +64,19 @@ var (
 
 	// SONiC Switch ID to Switch Stat packet integrity drop counters
 	countersDebugNameSwitchStatMap = make(map[string]string)
+
+	// sync.Once guards for each init function
+	initCountersPortNameMapOnce       sync.Once
+	initCountersQueueNameMapOnce      sync.Once
+	initCountersPGNameMapOnce         sync.Once
+	initCountersSidMapOnce            sync.Once
+	initCountersAclRuleMapOnce        sync.Once
+	initAliasMapOnce                  sync.Once
+	initCountersPfcwdNameMapOnce      sync.Once
+	initCountersFabricPortNameMapOnce sync.Once
+
+	// Mutex to protect ClearMappings from racing with init functions
+	clearMappingsMu sync.RWMutex
 
 	// path2TFuncTbl is used to populate trie tree which is reponsible
 	// for virtual path to real data path translation
@@ -125,106 +139,129 @@ func (t *Trie) v2rTriePopulate() {
 }
 
 func initCountersQueueNameMap() error {
-	var err error
-	if len(countersQueueNameMap) == 0 {
-		countersQueueNameMap, err = getCountersMap("COUNTERS_QUEUE_NAME_MAP")
+	clearMappingsMu.RLock()
+	defer clearMappingsMu.RUnlock()
+	var initErr error
+	initCountersQueueNameMapOnce.Do(func() {
+		var err error
+		countersQueueNameMap, err = GetCountersMap("COUNTERS_QUEUE_NAME_MAP")
 		if err != nil {
-			return err
+			initErr = err
 		}
-	}
-	return nil
+	})
+	return initErr
 }
 
 func initCountersPGNameMap() error {
-	if len(countersPGNameMap) == 0 {
-		pgOidMap, err := getCountersMap("COUNTERS_PG_NAME_MAP")
+	clearMappingsMu.RLock()
+	defer clearMappingsMu.RUnlock()
+	var initErr error
+	initCountersPGNameMapOnce.Do(func() {
+		pgOidMap, err := GetCountersMap("COUNTERS_PG_NAME_MAP")
 		if err != nil {
-			return err
+			initErr = err
+			return
 		}
 		for pg, oid := range pgOidMap {
 			// pg is in format of "Ethernet64:7"
 			pg_parts := strings.Split(pg, ":")
 			if len(pg_parts) != 2 {
-				return fmt.Errorf("invalid pg name %v", pg)
+				initErr = fmt.Errorf("invalid pg name %v", pg)
+				return
 			}
 			if _, ok := countersPGNameMap[pg_parts[0]]; !ok {
 				countersPGNameMap[pg_parts[0]] = make(map[string]string)
 			}
 			countersPGNameMap[pg_parts[0]][pg_parts[1]] = oid
 		}
-	}
-	return nil
+	})
+	return initErr
 }
 
 func initCountersPortNameMap() error {
-	var err error
-	if len(countersPortNameMap) == 0 {
-		countersPortNameMap, err = getCountersMap("COUNTERS_PORT_NAME_MAP")
+	clearMappingsMu.RLock()
+	defer clearMappingsMu.RUnlock()
+	var initErr error
+	initCountersPortNameMapOnce.Do(func() {
+		var err error
+		countersPortNameMap, err = GetCountersMap("COUNTERS_PORT_NAME_MAP")
 		if err != nil {
-			return err
+			initErr = err
 		}
-	}
-	return nil
+	})
+	return initErr
 }
 
 func initCountersSidMap() error {
-	var err error
-	if len(countersSidMap) == 0 {
-		countersSidMap, err = getCountersMap("COUNTERS_SRV6_NAME_MAP")
+	clearMappingsMu.RLock()
+	defer clearMappingsMu.RUnlock()
+	var initErr error
+	initCountersSidMapOnce.Do(func() {
+		var err error
+		countersSidMap, err = GetCountersMap("COUNTERS_SRV6_NAME_MAP")
 		if err != nil {
-			return err
+			initErr = err
 		}
-	}
-	return nil
+	})
+	return initErr
 }
 
 func initCountersAclRuleMap() error {
-	var err error
-	if len(countersAclRuleMap) == 0 {
+	clearMappingsMu.RLock()
+	defer clearMappingsMu.RUnlock()
+	var initErr error
+	initCountersAclRuleMapOnce.Do(func() {
+		var err error
 		// ACL_COUNTER_RULE_MAP is a hash in COUNTERS_DB:
 		//   "DATAACL:RULE_1" -> "oid:0x9000000000711"
-		countersAclRuleMap, err = getCountersMap("ACL_COUNTER_RULE_MAP")
+		countersAclRuleMap, err = GetCountersMap("ACL_COUNTER_RULE_MAP")
 		if err != nil {
-			return err
+			initErr = err
 		}
-	}
-	return nil
+	})
+	return initErr
 }
 
 func initAliasMap() error {
-	var err error
-	if len(alias2nameMap) == 0 {
-		alias2nameMap, name2aliasMap, port2namespaceMap, err = getAliasMap()
+	clearMappingsMu.RLock()
+	defer clearMappingsMu.RUnlock()
+	var initErr error
+	initAliasMapOnce.Do(func() {
+		var err error
+		alias2nameMap, name2aliasMap, port2namespaceMap, err = GetAliasMap()
 		if err != nil {
-			return err
+			initErr = err
 		}
-	}
-	return nil
+	})
+	return initErr
 }
 
 func initCountersPfcwdNameMap() error {
-	var err error
-	if len(countersPfcwdNameMap) == 0 {
+	clearMappingsMu.RLock()
+	defer clearMappingsMu.RUnlock()
+	var initErr error
+	initCountersPfcwdNameMapOnce.Do(func() {
+		var err error
 		countersPfcwdNameMap, err = GetPfcwdMap()
 		if err != nil {
-			return err
+			initErr = err
 		}
-	}
-	return nil
+	})
+	return initErr
 }
 
 func initCountersFabricPortNameMap() error {
-	var err error
-	// Reset map for Unit test to ensure that counters db is updated
-	// after changing from single to multi-asic config
-	value := os.Getenv("UNIT_TEST")
-	if len(countersFabricPortNameMap) == 0 || value == "1" {
-		countersFabricPortNameMap, err = getFabricCountersMap("COUNTERS_FABRIC_PORT_NAME_MAP")
+	clearMappingsMu.RLock()
+	defer clearMappingsMu.RUnlock()
+	var initErr error
+	initCountersFabricPortNameMapOnce.Do(func() {
+		var err error
+		countersFabricPortNameMap, err = GetFabricCountersMap("COUNTERS_FABRIC_PORT_NAME_MAP")
 		if err != nil {
-			return err
+			initErr = err
 		}
-	}
-	return nil
+	})
+	return initErr
 }
 
 func initDebugNameSwitchStatMap() error {
@@ -349,7 +386,7 @@ func GetPfcwdMap() (map[string]map[string]string, error) {
 }
 
 // Get the mapping between sonic interface name and vendor alias and sonic-interface to namespace map
-func getAliasMap() (map[string]string, map[string]string, map[string]string, error) {
+func GetAliasMap() (map[string]string, map[string]string, map[string]string, error) {
 	var alias2name_map = make(map[string]string)
 	var name2alias_map = make(map[string]string)
 	var port2namespace_map = make(map[string]string)
@@ -400,7 +437,7 @@ func addmap(a map[string]string, b map[string]string) {
 
 // Get the mapping between objects in counters DB, Ex. port name to oid in "COUNTERS_PORT_NAME_MAP" table.
 // Aussuming static port name to oid map in COUNTERS table
-func getCountersMap(tableName string) (map[string]string, error) {
+func GetCountersMap(tableName string) (map[string]string, error) {
 	counter_map := make(map[string]string)
 	dbName := "COUNTERS_DB"
 	redis_client_map, err := GetRedisClientsForDb(dbName)
@@ -421,7 +458,7 @@ func getCountersMap(tableName string) (map[string]string, error) {
 
 // Get the mapping between objects in counters DB, Ex. port name to oid in "COUNTERS_FABRIC_PORT_NAME_MAP" table.
 // Aussuming static port name to oid map in COUNTERS table
-func getFabricCountersMap(tableName string) (map[string]string, error) {
+func GetFabricCountersMap(tableName string) (map[string]string, error) {
 	counter_map := make(map[string]string)
 	dbName := "COUNTERS_DB"
 	redis_client_map, err := GetRedisClientsForDb(dbName)
@@ -454,6 +491,8 @@ func getFabricCountersMap(tableName string) (map[string]string, error) {
 // Populate real data paths from paths like
 // [COUNTER_DB COUNTERS PORT*] or [COUNTER_DB COUNTERS PORT0]
 func v2rFabricPortStats(paths []string) ([]tablePath, error) {
+	clearMappingsMu.RLock()
+	defer clearMappingsMu.RUnlock()
 	var tblPaths []tablePath
 	if strings.HasSuffix(paths[KeyIdx], "*") { // All Ethernet ports
 		for port, oid := range countersFabricPortNameMap {
@@ -586,6 +625,8 @@ func v2rSwitchPacketIntegrityDrop(paths []string) ([]tablePath, error) {
 // Populate real data paths from paths like
 // [COUNTER_DB COUNTERS Ethernet*] or [COUNTER_DB COUNTERS Ethernet68]
 func v2rEthPortStats(paths []string) ([]tablePath, error) {
+	clearMappingsMu.RLock()
+	defer clearMappingsMu.RUnlock()
 	var tblPaths []tablePath
 	if strings.HasSuffix(paths[KeyIdx], "*") { // All Ethernet ports
 		for port, oid := range countersPortNameMap {
@@ -650,6 +691,8 @@ func v2rEthPortStats(paths []string) ([]tablePath, error) {
 //
 // case of "*" field could be covered in v2rEthPortStats()
 func v2rEthPortFieldStats(paths []string) ([]tablePath, error) {
+	clearMappingsMu.RLock()
+	defer clearMappingsMu.RUnlock()
 	var tblPaths []tablePath
 	if strings.HasSuffix(paths[KeyIdx], "*") {
 		for port, oid := range countersPortNameMap {
@@ -709,6 +752,8 @@ func v2rEthPortFieldStats(paths []string) ([]tablePath, error) {
 // Populate real data paths from paths like
 // [COUNTER_DB COUNTERS Ethernet* Pfcwd] or [COUNTER_DB COUNTERS Ethernet68 Pfcwd]
 func v2rEthPortPfcwdStats(paths []string) ([]tablePath, error) {
+	clearMappingsMu.RLock()
+	defer clearMappingsMu.RUnlock()
 	var tblPaths []tablePath
 	if strings.HasSuffix(paths[KeyIdx], "*") { // Pfcwd on all Ethernet ports
 		for port, pfcqueues := range countersPfcwdNameMap {
@@ -794,6 +839,8 @@ func buildTablePath(namespace, dbName, tableName, tableKey, separator, field, js
 // Populate real data paths from paths like
 // [COUNTERS_DB COUNTERS Ethernet* Queues] or [COUNTERS_DB COUNTERS Ethernet68 Queues]
 func v2rEthPortQueStats(paths []string) ([]tablePath, error) {
+	clearMappingsMu.RLock()
+	defer clearMappingsMu.RUnlock()
 	// paths[DbIdx] = "COUNTERS_DB"
 	separator, _ := GetTableKeySeparator(paths[DbIdx], "")
 	field := "SAI_QUEUE_STAT_SHARED_WATERMARK_BYTES"
@@ -907,6 +954,8 @@ func v2rSRv6SidStats(paths []string) ([]tablePath, error) {
 // [COUNTERS_DB COUNTERS ACL_RULE*] or
 // [COUNTERS_DB COUNTERS ACL_RULE:DATAACL:RULE_1]
 func v2rAclRuleStats(paths []string) ([]tablePath, error) {
+	clearMappingsMu.RLock()
+	defer clearMappingsMu.RUnlock()
 	var tblPaths []tablePath
 
 	// Wildcard: list all ACL rules in the map
@@ -957,6 +1006,8 @@ func v2rAclRuleStats(paths []string) ([]tablePath, error) {
 // [COUNTERS_DB PORT_PHY_ATTR Ethernet*] or [COUNTERS_DB PORT_PHY_ATTR Ethernet68]
 // Unlike v2rEthPortStats, this does NOT apply vendor alias translation.
 func v2rPortPhyAttrStats(paths []string) ([]tablePath, error) {
+	clearMappingsMu.RLock()
+	defer clearMappingsMu.RUnlock()
 	var tblPaths []tablePath
 	if strings.HasSuffix(paths[KeyIdx], "*") { // All Ethernet ports
 		for port, oid := range countersPortNameMap {
@@ -1003,6 +1054,8 @@ func v2rPortPhyAttrStats(paths []string) ([]tablePath, error) {
 // [COUNTERS_DB PORT_PHY_ATTR Ethernet68 phy_rx_signal_detect]
 // Unlike v2rEthPortFieldStats, this does NOT apply vendor alias translation.
 func v2rPortPhyAttrFieldStats(paths []string) ([]tablePath, error) {
+	clearMappingsMu.RLock()
+	defer clearMappingsMu.RUnlock()
 	var tblPaths []tablePath
 	if strings.HasSuffix(paths[KeyIdx], "*") {
 		for port, oid := range countersPortNameMap {
@@ -1093,6 +1146,11 @@ func ClearMappings() {
 }
 
 func AliasToPortNameMap() map[string]string {
+	// Ensure alias map is initialized
+	initAliasMap()
+
+	clearMappingsMu.RLock()
+	defer clearMappingsMu.RUnlock()
 	output := make(map[string]string, len(alias2nameMap))
 	for alias, portName := range alias2nameMap {
 		output[alias] = portName
@@ -1140,6 +1198,45 @@ func v2rEthPortPGPeriodicWMs(paths []string) ([]tablePath, error) {
 	log.V(6).Infof("v2rEthPortPGPeriodicWMs: %v", tblPaths)
 	return tblPaths, nil
 }
+
+func ClearMappings() {
+	value := os.Getenv("UNIT_TEST")
+	if value != "1" {
+		return
+	}
+	clearMappingsMu.Lock()
+	defer clearMappingsMu.Unlock()
+
+	counterMaps := []map[string]string{
+		countersPortNameMap,
+		alias2nameMap,
+		countersFabricPortNameMap,
+		countersQueueNameMap,
+		countersAclRuleMap,
+	}
+	for _, counterMap := range counterMaps {
+		for entry := range counterMap {
+			delete(counterMap, entry)
+		}
+	}
+
+	// Reset sync.Once guards so the next call re-initializes.
+	initCountersPortNameMapOnce = sync.Once{}
+	initCountersQueueNameMapOnce = sync.Once{}
+	initCountersPGNameMapOnce = sync.Once{}
+	initCountersSidMapOnce = sync.Once{}
+	initCountersAclRuleMapOnce = sync.Once{}
+	initAliasMapOnce = sync.Once{}
+	initCountersPfcwdNameMapOnce = sync.Once{}
+	initCountersFabricPortNameMapOnce = sync.Once{}
+}
+
+func InitCountersPortNameMap() error       { return initCountersPortNameMap() }
+func InitCountersQueueNameMap() error      { return initCountersQueueNameMap() }
+func InitCountersPGNameMap() error         { return initCountersPGNameMap() }
+func InitCountersSidMap() error            { return initCountersSidMap() }
+func InitCountersAclRuleMap() error        { return initCountersAclRuleMap() }
+func InitCountersFabricPortNameMap() error { return initCountersFabricPortNameMap() }
 
 func lookupV2R(paths []string) ([]tablePath, error) {
 	n, ok := v2rTrie.Find(paths)

--- a/sonic_data_client/virtual_db.go
+++ b/sonic_data_client/virtual_db.go
@@ -78,7 +78,6 @@ var (
 	// Mutex to protect ClearMappings from racing with init functions
 	clearMappingsMu sync.RWMutex
 
-
 	// path2TFuncTbl is used to populate trie tree which is reponsible
 	// for virtual path to real data path translation
 	pathTransFuncTbl = []pathTransFunc{

--- a/sonic_data_client/virtual_db_test.go
+++ b/sonic_data_client/virtual_db_test.go
@@ -1,7 +1,9 @@
 package client
 
 import (
+	"fmt"
 	"sort"
+	"sync"
 	"testing"
 
 	sdcfg "github.com/sonic-net/sonic-gnmi/sonic_db_config"
@@ -354,5 +356,192 @@ func TestV2rPortPhyAttrFieldStats_SingleMissingNamespace(t *testing.T) {
 	_, err := v2rPortPhyAttrFieldStats(paths)
 	if err == nil {
 		t.Fatal("expected error for port missing namespace, got nil")
+	}
+}
+
+// --------------------------------------------------------------------------
+// Tests for sync.Once error paths and clearMappingsMu.RLock coverage
+// --------------------------------------------------------------------------
+
+// mockError is a helper to swap a function variable, returning a restore func.
+func setupErrorMock(t *testing.T) func() {
+	t.Helper()
+	origCounters := getCountersMapFn
+	origAlias := getAliasMapFn
+	origFabric := getFabricCountersMapFn
+	origPfcwd := getPfcwdMapFn
+
+	mockErr := fmt.Errorf("mock redis error")
+	getCountersMapFn = func(string) (map[string]string, error) { return nil, mockErr }
+	getAliasMapFn = func() (map[string]string, map[string]string, map[string]string, error) {
+		return nil, nil, nil, mockErr
+	}
+	getFabricCountersMapFn = func(string) (map[string]string, error) { return nil, mockErr }
+	getPfcwdMapFn = func() (map[string]map[string]string, error) { return nil, mockErr }
+
+	return func() {
+		getCountersMapFn = origCounters
+		getAliasMapFn = origAlias
+		getFabricCountersMapFn = origFabric
+		getPfcwdMapFn = origPfcwd
+	}
+}
+
+func TestInitFuncsReturnError(t *testing.T) {
+	sdcfg.Init()
+	restore := setupErrorMock(t)
+	defer restore()
+
+	tests := []struct {
+		desc     string
+		initFunc func() error
+		once     *sync.Once
+	}{
+		{"countersQueueNameMap", initCountersQueueNameMap, &initCountersQueueNameMapOnce},
+		{"countersPGNameMap", initCountersPGNameMap, &initCountersPGNameMapOnce},
+		{"countersPortNameMap", initCountersPortNameMap, &initCountersPortNameMapOnce},
+		{"countersSidMap", initCountersSidMap, &initCountersSidMapOnce},
+		{"countersAclRuleMap", initCountersAclRuleMap, &initCountersAclRuleMapOnce},
+		{"aliasMap", initAliasMap, &initAliasMapOnce},
+		{"countersPfcwdNameMap", initCountersPfcwdNameMap, &initCountersPfcwdNameMapOnce},
+		{"countersFabricPortNameMap", initCountersFabricPortNameMap, &initCountersFabricPortNameMapOnce},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			// Reset the sync.Once so it fires again
+			*tt.once = sync.Once{}
+			err := tt.initFunc()
+			if err == nil {
+				t.Errorf("expected error from %s, got nil", tt.desc)
+			}
+		})
+	}
+}
+
+func TestV2rFabricPortStats_EmptyMap(t *testing.T) {
+	sdcfg.Init()
+	origMap := countersFabricPortNameMap
+	countersFabricPortNameMap = map[string]string{}
+	defer func() { countersFabricPortNameMap = origMap }()
+
+	paths := []string{"COUNTERS_DB", "COUNTERS", "PORT*"}
+	tblPaths, err := v2rFabricPortStats(paths)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tblPaths) != 0 {
+		t.Errorf("expected 0 paths, got %d", len(tblPaths))
+	}
+}
+
+func TestV2rEthPortStats_EmptyMap(t *testing.T) {
+	sdcfg.Init()
+	restore := setupPortMaps(t)
+	defer restore()
+	countersPortNameMap = map[string]string{}
+
+	paths := []string{"COUNTERS_DB", "COUNTERS", "Ethernet*"}
+	tblPaths, err := v2rEthPortStats(paths)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tblPaths) != 0 {
+		t.Errorf("expected 0 paths, got %d", len(tblPaths))
+	}
+}
+
+func TestV2rEthPortFieldStats_EmptyMap(t *testing.T) {
+	sdcfg.Init()
+	restore := setupPortMaps(t)
+	defer restore()
+	countersPortNameMap = map[string]string{}
+
+	paths := []string{"COUNTERS_DB", "COUNTERS", "Ethernet*", "SAI_PORT_STAT_IF_IN_OCTETS"}
+	tblPaths, err := v2rEthPortFieldStats(paths)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tblPaths) != 0 {
+		t.Errorf("expected 0 paths, got %d", len(tblPaths))
+	}
+}
+
+func TestV2rEthPortPfcwdStats_EmptyMap(t *testing.T) {
+	sdcfg.Init()
+	origMap := countersPfcwdNameMap
+	countersPfcwdNameMap = make(map[string]map[string]string)
+	defer func() { countersPfcwdNameMap = origMap }()
+
+	paths := []string{"COUNTERS_DB", "COUNTERS", "Ethernet*", "Pfcwd"}
+	tblPaths, err := v2rEthPortPfcwdStats(paths)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tblPaths) != 0 {
+		t.Errorf("expected 0 paths, got %d", len(tblPaths))
+	}
+}
+
+func TestV2rEthPortQueStats_EmptyMap(t *testing.T) {
+	sdcfg.Init()
+	origMap := countersQueueNameMap
+	countersQueueNameMap = map[string]string{}
+	defer func() { countersQueueNameMap = origMap }()
+
+	paths := []string{"COUNTERS_DB", "COUNTERS", "Ethernet*", "Queues"}
+	tblPaths, err := v2rEthPortQueStats(paths)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tblPaths) != 0 {
+		t.Errorf("expected 0 paths, got %d", len(tblPaths))
+	}
+}
+
+func TestV2rAclRuleStats_EmptyMap(t *testing.T) {
+	sdcfg.Init()
+	origMap := countersAclRuleMap
+	countersAclRuleMap = map[string]string{}
+	defer func() { countersAclRuleMap = origMap }()
+
+	paths := []string{"COUNTERS_DB", "COUNTERS", "ACL_RULE*"}
+	tblPaths, err := v2rAclRuleStats(paths)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tblPaths) != 0 {
+		t.Errorf("expected 0 paths, got %d", len(tblPaths))
+	}
+}
+
+func TestAliasToPortNameMap_WithRLock(t *testing.T) {
+	sdcfg.Init()
+	origAlias := alias2nameMap
+	origOnce := initAliasMapOnce
+	alias2nameMap = map[string]string{"Eth0": "Ethernet0"}
+	// Pre-fire the Once so initAliasMap doesn't hit Redis
+	initAliasMapOnce = sync.Once{}
+	initAliasMapOnce.Do(func() {})
+	defer func() {
+		alias2nameMap = origAlias
+		initAliasMapOnce = origOnce
+	}()
+
+	result := AliasToPortNameMap()
+	if result["Eth0"] != "Ethernet0" {
+		t.Errorf("expected Eth0->Ethernet0, got %v", result)
+	}
+}
+
+func TestClearMappings_Resets(t *testing.T) {
+	t.Setenv("UNIT_TEST", "1")
+
+	countersPortNameMap["testport"] = "testoid"
+
+	ClearMappings()
+
+	if _, ok := countersPortNameMap["testport"]; ok {
+		t.Errorf("expected countersPortNameMap to be cleared")
 	}
 }

--- a/sonic_data_client/virtual_db_test.go
+++ b/sonic_data_client/virtual_db_test.go
@@ -537,7 +537,12 @@ func TestAliasToPortNameMap_WithRLock(t *testing.T) {
 func TestClearMappings_Resets(t *testing.T) {
 	t.Setenv("UNIT_TEST", "1")
 
+	origMap := countersPortNameMap
+	if countersPortNameMap == nil {
+		countersPortNameMap = make(map[string]string)
+	}
 	countersPortNameMap["testport"] = "testoid"
+	defer func() { countersPortNameMap = origMap }()
 
 	ClearMappings()
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

There is a potential race condition where two goroutines may enter the Init function for a map and they both read that the map is empty and try to modify the map at the same time.

Use sync.Once instead of checking for empty map as this is an atomic operation such that our initialization of these global maps will be thread safe.

```
telemetry fatal error: concurrent map writes
telemetry fatal error: concurrent map read and map write
telemetry
telemetry goroutine 30 [running]:
telemetry runtime.fatal({0x12cbd58
telemetry ?, 0x0?})
telemetry #011/usr/lib/go-1.19/src/runtime/panic.go:1066 +0x5d fp=0xc000bc29a0 sp=0xc000bc2970 pc=0x4f4b1d
telemetry runtime.mapassign_faststr(0x11435a0, 0xc0008683c0, {0xc0005d35c0, 0xb})
telemetry #011/usr/lib/go-1.19/src/runtime/map_faststr.go:212 +0x56 fp=0xc000bc2a10 sp=0xc000bc29a0 pc=0x4d04b6
telemetry github.com/sonic-net/sonic-gnmi/sonic_data_client.initCountersPGNameMap()
telemetry #011/sonic/src/sonic-gnmi/sonic_data_client/virtual_db.go:128 +0x15e fp=0xc000bc2af0 sp=0xc000bc2a10 pc=
telemetry 0xe25ebe
telemetry github.com/sonic-net/sonic-gnmi/sonic_data_client.populateDbtablePath(0xc000bc31e8, 0xc00047e080, 0xc000bc2f70)
telemetry #011/sonic/src/sonic-gnmi/sonic_data_client/db_client.go:664 +0x297 fp=0xc000bc2f58 sp=0xc000bc2af0 pc=0xe09637
telemetry github.com/sonic-net/sonic-gnmi/sonic_data_client.PopulateTablePaths(0x11fe880?, 0xc00047e080)
telemetry #011/sonic/src/sonic-gnmi/sonic_data_client/show_client.go:140 +0xaa fp=0xc000bc30d0 sp=0xc000bc2f58 pc=0xe1c76a
telemetry github.com/sonic-net/sonic-gnmi/show_client/common.CreateTablePathsFromQueries({0xc000576078?, 0x1, 0xc000908040
telemetry ?})
telemetry #011/sonic/src/sonic-gnmi/show_client/common/db.go:82 +0x215 fp=0xc000bc3270 sp=0xc000bc30d0 pc=0xf0eb55
telemetry github.com/sonic-net/sonic-gnmi/show_client/common.GetMapFromQueries({0xc000576078?, 0x0?, 0x4?})
telemetry #011/sonic/src/sonic-gnmi/show_client/common/db.go:33 +0x25 fp=0xc000bc32d0 sp=
telemetry 0xc000bc3270 pc=0xf0e785
telemetry github.com/sonic-net/sonic-gnmi/show_client.getQueueWatermarksSnapshot({0x0?, 0x0?, 0x12bd992?}, 0x0, {0x12c339f, 0xf})
telemetry #011/sonic/src/sonic-gnmi/show_client/queue_watermark_cli.go:31 +0x151 fp=0xc000bc3490 sp=0xc000bc32d0 pc=0xf5c6f1
telemetry github.com/sonic-net/sonic-gnmi/show_client.getQueueWatermarksCommon(0xe1ce45?, 0xc000aca700?, {
telemetry 0x12c339f, 0xf})
telemetry #011/sonic/src/sonic-gnmi/show_client/queue_watermark_cli.go:76 +0xf1 fp=0xc000bc3518 sp=0xc000bc3490 pc=0xf5d031
telemetry github.com/sonic-net/sonic-gnmi/show_client.getQueueUserWatermarksAll({0x13455b8?, 0xc00084b5f0?, 0x12b5b69?}, 0x4?)
telemetry #011/sonic/src/sonic-gnmi/show_client/queue_watermark_cli.go:108 +0x2a fp=0xc000bc3548 sp=0xc000bc3518 pc=0xf5d50a
telemetry github.com/sonic-net/sonic-gnmi/sonic_data_client.(*ShowClient).Get(0xc000269180, 0x1?)
telemetry #011/sonic/src/sonic-gnmi/sonic_data_client/show_client.go:118 +0x25a fp=0xc000bc3728 sp=0xc000bc3548 pc=0xe1c09a
telemetry github.com/sonic-net/sonic-gnmi/gnmi_server.(*Server).Get(0xc000a360f0, {0x14acee0, 0xc000acd1a0}, 0xc000aca500)
telemetry #011/sonic/src/sonic-gnmi/gnmi_server/server.go:429 +0x6e8 fp=0xc000bc3918 sp=0xc000bc3728 pc=0xf90d68
```

#### How I did it

Use sync.Once to initialize global maps.