### PR TITLE
telemetry: fix auth bypass in noTLS code path

### DIFF
--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -307,8 +307,7 @@ func setupFlags(fs *flag.FlagSet) (*TelemetryConfig, *gnmi.Config, error) {
 		cfg.GetOptions = gnmi.SrvAdvConfig
 	}
 	if *telemetryCfg.CaCert == "" && telemetryCfg.UserAuth.Enabled("cert") {
-		telemetryCfg.UserAuth.Unset("cert")
-		log.V(2).Info("client_auth mode cert requires ca_crt option. Disabling cert mode authentication.")
+		log.Fatalf("--client_auth cert requires --cacert option. Cannot start without CA certificate.")
 	}
 
 	cfg.AuthzMetaFile = string(*telemetryCfg.AuthzMetaFile)
@@ -429,6 +428,9 @@ func startGNMIServer(telemetryCfg *TelemetryConfig, cfg *gnmi.Config, serverCont
 		var certLoaded int32
 		atomic.StoreInt32(&certLoaded, 0) // Not loaded
 
+		// Set application-layer auth regardless of transport (TLS or noTLS)
+		cfg.UserAuth = telemetryCfg.UserAuth
+
 		if !*telemetryCfg.NoTLS {
 			var certificate tls.Certificate
 			var err error
@@ -544,8 +546,6 @@ func startGNMIServer(telemetryCfg *TelemetryConfig, cfg *gnmi.Config, serverCont
 			if *telemetryCfg.IdleConnDuration > 0 { // non inf case
 				commonOpts = append(commonOpts, grpc.KeepaliveParams(keep_alive_params))
 			}
-
-			cfg.UserAuth = telemetryCfg.UserAuth
 
 			gnmi.GenerateJwtSecretKey()
 		}

--- a/telemetry/telemetry_test.go
+++ b/telemetry/telemetry_test.go
@@ -276,7 +276,7 @@ func TestStartGNMIServerNoTLS(t *testing.T) {
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
 	go startGNMIServer(telemetryCfg, cfg, serverControlSignal, stopSignalHandler, wg)
-	stopSignalHandler <- true
+	serverControlSignal <- ServerStop
 	wg.Wait()
 }
 

--- a/telemetry/telemetry_test.go
+++ b/telemetry/telemetry_test.go
@@ -1451,7 +1451,6 @@ func TestFlagsNoPortNoUnixSocket(t *testing.T) {
 	}
 }
 
-
 func TestNoTLSAuthNotBypassed(t *testing.T) {
 	// Regression test for auth bypass in noTLS mode.
 	// Before the fix, cfg.UserAuth was only set inside if !NoTLS{},

--- a/telemetry/telemetry_test.go
+++ b/telemetry/telemetry_test.go
@@ -263,9 +263,14 @@ func TestStartGNMIServerNoTLS(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
+	userAuthSet := make(chan struct{}, 1)
 	patches := gomonkey.ApplyFunc(gnmi.NewServer, func(cfg *gnmi.Config, tlsOpts []grpc.ServerOption, commonOpts []grpc.ServerOption) (*gnmi.Server, error) {
 		if !cfg.UserAuth.Enabled("password") {
 			t.Error("cfg.UserAuth should have password enabled in noTLS mode")
+		}
+		select {
+		case userAuthSet <- struct{}{}:
+		default:
 		}
 		return nil, fmt.Errorf("stop server")
 	})
@@ -276,6 +281,12 @@ func TestStartGNMIServerNoTLS(t *testing.T) {
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
 	go startGNMIServer(telemetryCfg, cfg, serverControlSignal, stopSignalHandler, wg)
+	select {
+	case <-userAuthSet:
+		// cfg.UserAuth was verified in the gnmi.NewServer patch
+	case <-time.After(3 * time.Second):
+		t.Error("startGNMIServer did not call gnmi.NewServer within timeout")
+	}
 	serverControlSignal <- ServerStop
 	wg.Wait()
 }

--- a/telemetry/telemetry_test.go
+++ b/telemetry/telemetry_test.go
@@ -249,6 +249,40 @@ func TestStartGNMIServer(t *testing.T) {
 	}
 }
 
+func TestStartGNMIServerNoTLS(t *testing.T) {
+	// Regression test: cfg.UserAuth must be set in noTLS mode.
+	// Before the fix, UserAuth was only populated inside if !NoTLS{},
+	// so auth was bypassed when --noTLS was active.
+	originalArgs := os.Args
+	defer func() { os.Args = originalArgs }()
+
+	fs := flag.NewFlagSet("testStartGNMIServerNoTLS", flag.ContinueOnError)
+	os.Args = []string{"cmd", "-port", "8080", "-noTLS", "-bind_address", "127.0.0.1", "-client_auth", "password"}
+	telemetryCfg, cfg, err := setupFlags(fs)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	patches := gomonkey.ApplyFunc(gnmi.NewServer, func(cfg *gnmi.Config, tlsOpts []grpc.ServerOption, commonOpts []grpc.ServerOption) (*gnmi.Server, error) {
+		if !cfg.UserAuth.Enabled("password") {
+			t.Error("cfg.UserAuth should have password enabled in noTLS mode")
+		}
+		return nil, fmt.Errorf("stop server")
+	})
+	defer patches.Reset()
+
+	serverControlSignal := make(chan ServerControlValue, 1)
+	stopSignalHandler := make(chan bool, 1)
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		startServer(telemetryCfg, cfg, serverControlSignal, stopSignalHandler)
+	}()
+	stopSignalHandler <- true
+	wg.Wait()
+}
+
 func TestStartGNMIServerGracefulStop(t *testing.T) {
 	testServerCert := "../testdata/certs/testserver.cert"
 	testServerKey := "../testdata/certs/testserver.key"

--- a/telemetry/telemetry_test.go
+++ b/telemetry/telemetry_test.go
@@ -205,6 +205,10 @@ func TestStartGNMIServer(t *testing.T) {
 		return tls.Certificate{}, nil
 	})
 	patches.ApplyFunc(gnmi.NewServer, func(cfg *gnmi.Config, tlsOpts []grpc.ServerOption, commonOpts []grpc.ServerOption) (*gnmi.Server, error) {
+		// Verify cfg.UserAuth is set (regression test for noTLS auth bypass fix)
+		if cfg.UserAuth == nil {
+			t.Error("cfg.UserAuth should not be nil")
+		}
 		return &gnmi.Server{}, nil
 	})
 	patches.ApplyFunc(grpc.Creds, func(credentials.TransportCredentials) grpc.ServerOption {

--- a/telemetry/telemetry_test.go
+++ b/telemetry/telemetry_test.go
@@ -1451,6 +1451,30 @@ func TestFlagsNoPortNoUnixSocket(t *testing.T) {
 	}
 }
 
+
+func TestNoTLSAuthNotBypassed(t *testing.T) {
+	// Regression test for auth bypass in noTLS mode.
+	// Before the fix, cfg.UserAuth was only set inside if !NoTLS{},
+	// so authentication was silently bypassed when --noTLS was active.
+	originalArgs := os.Args
+	defer func() { os.Args = originalArgs }()
+
+	for _, authMode := range []string{"password", "jwt"} {
+		t.Run(authMode, func(t *testing.T) {
+			fs := flag.NewFlagSet("testNoTLSAuthNotBypassed", flag.ContinueOnError)
+			os.Args = []string{"cmd", "-port", "8080", "-noTLS", "-client_auth", authMode}
+
+			_, cfg, err := setupFlags(fs)
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			if !cfg.UserAuth.Enabled(authMode) {
+				t.Errorf("Expected %s auth to be enabled in noTLS mode, but was bypassed", authMode)
+			}
+		})
+	}
+}
+
 func TestMain(m *testing.M) {
 	defer test_utils.MemLeakCheck()
 	m.Run()

--- a/telemetry/telemetry_test.go
+++ b/telemetry/telemetry_test.go
@@ -257,7 +257,7 @@ func TestStartGNMIServerNoTLS(t *testing.T) {
 	defer func() { os.Args = originalArgs }()
 
 	fs := flag.NewFlagSet("testStartGNMIServerNoTLS", flag.ContinueOnError)
-	os.Args = []string{"cmd", "-port", "8080", "-noTLS", "-bind_address", "127.0.0.1", "-client_auth", "password"}
+	os.Args = []string{"cmd", "-port", "8080", "-noTLS", "-client_auth", "password"}
 	telemetryCfg, cfg, err := setupFlags(fs)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
@@ -275,10 +275,7 @@ func TestStartGNMIServerNoTLS(t *testing.T) {
 	stopSignalHandler := make(chan bool, 1)
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		startServer(telemetryCfg, cfg, serverControlSignal, stopSignalHandler)
-	}()
+	go startGNMIServer(telemetryCfg, cfg, serverControlSignal, stopSignalHandler, wg)
 	stopSignalHandler <- true
 	wg.Wait()
 }

--- a/telemetry/telemetry_test.go
+++ b/telemetry/telemetry_test.go
@@ -1455,17 +1455,19 @@ func TestNoTLSAuthNotBypassed(t *testing.T) {
 	// Regression test for auth bypass in noTLS mode.
 	// Before the fix, cfg.UserAuth was only set inside if !NoTLS{},
 	// so authentication was silently bypassed when --noTLS was active.
+	// We verify via telemetryCfg.UserAuth (the source) since cfg.UserAuth
+	// is populated later in the server goroutine, not in setupFlags.
 	originalArgs := os.Args
 	defer func() { os.Args = originalArgs }()
 
 	fs := flag.NewFlagSet("testNoTLSAuthNotBypassed", flag.ContinueOnError)
 	os.Args = []string{"cmd", "-port", "8080", "-noTLS", "-client_auth", "password"}
 
-	_, cfg, err := setupFlags(fs)
+	telemetryCfg, _, err := setupFlags(fs)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	if !cfg.UserAuth.Enabled("password") {
+	if !telemetryCfg.UserAuth.Enabled("password") {
 		t.Error("Expected password auth to be enabled in noTLS mode, but was bypassed")
 	}
 }

--- a/telemetry/telemetry_test.go
+++ b/telemetry/telemetry_test.go
@@ -1459,19 +1459,15 @@ func TestNoTLSAuthNotBypassed(t *testing.T) {
 	originalArgs := os.Args
 	defer func() { os.Args = originalArgs }()
 
-	for _, authMode := range []string{"password", "jwt"} {
-		t.Run(authMode, func(t *testing.T) {
-			fs := flag.NewFlagSet("testNoTLSAuthNotBypassed", flag.ContinueOnError)
-			os.Args = []string{"cmd", "-port", "8080", "-noTLS", "-client_auth", authMode}
+	fs := flag.NewFlagSet("testNoTLSAuthNotBypassed", flag.ContinueOnError)
+	os.Args = []string{"cmd", "-port", "8080", "-noTLS", "-client_auth", "password"}
 
-			_, cfg, err := setupFlags(fs)
-			if err != nil {
-				t.Fatalf("Unexpected error: %v", err)
-			}
-			if !cfg.UserAuth.Enabled(authMode) {
-				t.Errorf("Expected %s auth to be enabled in noTLS mode, but was bypassed", authMode)
-			}
-		})
+	_, cfg, err := setupFlags(fs)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if !cfg.UserAuth.Enabled("password") {
+		t.Error("Expected password auth to be enabled in noTLS mode, but was bypassed")
 	}
 }
 


### PR DESCRIPTION
#### Why I did it

When the gNMI server starts with `--noTLS` (the default when no TLS certificates are configured), application-layer authentication was not being enforced. Two issues:

1. `cfg.UserAuth` was only assigned inside the `if !*telemetryCfg.NoTLS` block, so in the noTLS path it was left at the zero value, causing `authenticate()` to skip all auth checks.

2. When `--client_auth cert` was requested without `--cacert`, the server silently unset cert auth and started with no authentication configured.

#### How I did it

1. Moved `cfg.UserAuth = telemetryCfg.UserAuth` above the TLS setup block so application-layer auth is configured regardless of transport.

2. Changed the cert-without-cacert case from silently unsetting cert auth to `log.Fatalf`, so the server refuses to start with an explicit error rather than degrading to unauthenticated access.

#### How to verify it

On a default image (no certs in ConfigDB), start the gNMI server and attempt an unauthenticated gNMI request — it should now fail with an authentication error rather than returning data.