### PR TITLE
[SmartSwitch] Support maximum gnmi message size of 125k messages

### DIFF
--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -204,8 +204,8 @@ func setupFlags(fs *flag.FlagSet) (*TelemetryConfig, *gnmi.Config, error) {
 		AuthPolicyEnabled:        fs.Bool("authz_policy_enabled", false, "Enable authz policy. Require insecure flag to be false."),
 		AuthzPolicyFile:          fs.String("authorization_policy_file", "/keys/authorization_policy.json", "Full path name of the JSON authorization policy file."),
 		EnableStreamMultiplexing: fs.Bool("enable_stream_multiplexing", false, "Allow multiple Subscribe RPCs on a single TCP connection via HTTP/2 stream multiplexing"),
-		MaxRecvMsgSize:        fs.Int("max_recv_msg_size", 4096, "Maximum message size in bytes that the server can receive"),
-		MaxSendMsgSize:        fs.Int("max_send_msg_size", 4096, "Maximum message size in bytes that the server can send"),
+		MaxRecvMsgSize:        fs.Int("max_recv_msg_size", 4*1024*1024, "Maximum message size in bytes that the server can receive"),
+		MaxSendMsgSize:        fs.Int("max_send_msg_size", 4*1024*1024, "Maximum message size in bytes that the server can send"),
 	}
 
 	fs.Var(&telemetryCfg.UserAuth, "client_auth", "Client auth mode(s) - none,cert,password")

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -76,6 +76,8 @@ type TelemetryConfig struct {
 	AuthPolicyEnabled        *bool
 	AuthzPolicyFile          *string
 	EnableStreamMultiplexing *bool
+	MaxRecvMsgSize        *int
+	MaxSendMsgSize        *int
 }
 
 func main() {
@@ -202,6 +204,8 @@ func setupFlags(fs *flag.FlagSet) (*TelemetryConfig, *gnmi.Config, error) {
 		AuthPolicyEnabled:        fs.Bool("authz_policy_enabled", false, "Enable authz policy. Require insecure flag to be false."),
 		AuthzPolicyFile:          fs.String("authorization_policy_file", "/keys/authorization_policy.json", "Full path name of the JSON authorization policy file."),
 		EnableStreamMultiplexing: fs.Bool("enable_stream_multiplexing", false, "Allow multiple Subscribe RPCs on a single TCP connection via HTTP/2 stream multiplexing"),
+		MaxRecvMsgSize:        fs.Int("max_recv_msg_size", 4096, "Maximum message size in bytes that the server can receive"),
+		MaxSendMsgSize:        fs.Int("max_send_msg_size", 4096, "Maximum message size in bytes that the server can send"),
 	}
 
 	fs.Var(&telemetryCfg.UserAuth, "client_auth", "Client auth mode(s) - none,cert,password")
@@ -552,6 +556,11 @@ func startGNMIServer(telemetryCfg *TelemetryConfig, cfg *gnmi.Config, serverCont
 
 			gnmi.GenerateJwtSecretKey()
 		}
+
+		commonOpts = append(commonOpts,
+			grpc.MaxRecvMsgSize(*telemetryCfg.MaxRecvMsgSize),
+			grpc.MaxSendMsgSize(*telemetryCfg.MaxSendMsgSize),
+		)
 
 		// Setup interceptor chain (includes DPU proxy with Redis-based routing)
 		var err error

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -79,8 +79,8 @@ type TelemetryConfig struct {
 	AuthPolicyEnabled        *bool
 	AuthzPolicyFile          *string
 	EnableStreamMultiplexing *bool
-	MaxRecvMsgSize        *int
-	MaxSendMsgSize        *int
+	MaxRecvMsgSize           *int
+	MaxSendMsgSize           *int
 }
 
 func main() {
@@ -209,8 +209,8 @@ func setupFlags(fs *flag.FlagSet) (*TelemetryConfig, *gnmi.Config, error) {
 		AuthPolicyEnabled:        fs.Bool("authz_policy_enabled", false, "Enable authz policy. Require insecure flag to be false."),
 		AuthzPolicyFile:          fs.String("authorization_policy_file", "/keys/authorization_policy.json", "Full path name of the JSON authorization policy file."),
 		EnableStreamMultiplexing: fs.Bool("enable_stream_multiplexing", false, "Allow multiple Subscribe RPCs on a single TCP connection via HTTP/2 stream multiplexing"),
-		MaxRecvMsgSize:        fs.Int("max_recv_msg_size", 4*1024*1024, "Maximum message size in bytes that the server can receive"),
-		MaxSendMsgSize:        fs.Int("max_send_msg_size", 4*1024*1024, "Maximum message size in bytes that the server can send"),
+		MaxRecvMsgSize:           fs.Int("max_recv_msg_size", 4*1024*1024, "Maximum message size in bytes that the server can receive"),
+		MaxSendMsgSize:           fs.Int("max_send_msg_size", 4*1024*1024, "Maximum message size in bytes that the server can send"),
 	}
 
 	fs.Var(&telemetryCfg.UserAuth, "client_auth", "Client auth mode(s) - none,cert,password")


### PR DESCRIPTION

### Why I did it
At max DASH scale, a single gNMI call (CA-to-PA, ENI-level object config) can contain up to ~125,000 protobuf messages, which serializes to ~32 MB. sonic-gnmi currently uses gRPC's 4 MB default for `MaxRecvMsgSize`, so these calls are rejected.

### How I did it
| Setting                        | Before                    | After                                 |
| ------------------------------ | ------------------------- | ------------------------------------- |
| gRPC `MaxRecvMsgSize` (server) | 4 MB (gRPC default)       | configurable via `-max_recv_msg_size` |
| gRPC `MaxSendMsgSize` (server) | `math.MaxInt32` (default) | configurable via `-max_send_msg_size` |

Defaults are unchanged; [sonic-buildimage#26679](https://github.com/sonic-net/sonic-buildimage/pull/26679) sets both to 32 MB for SmartSwitch.

### How to verify it
Start telemetry with `-max_recv_msg_size` above 4 MB and send a gNMI message larger than 4 MB; confirm it is accepted.
