### PR TITLE
Support stream multiplexing

### DIFF
--- a/gnmi_server/client_subscribe.go
+++ b/gnmi_server/client_subscribe.go
@@ -15,11 +15,20 @@ import (
 	"sync/atomic"
 )
 
+// ClientKey is the key used in the server's client map for duplicate detection.
+// When EnableStreamMultiplexing is true, each stream gets a unique StreamID
+// so multiple streams from the same peer coexist. When false, StreamID is 0
+// and the peer address alone identifies the client (legacy behavior).
+type ClientKey struct {
+	PeerAddr string
+	StreamID uint64
+}
+
 // Client contains information about a subscribe client that has connected to the server.
 type Client struct {
 	addr         net.Addr
 	id           uint64 // Unique ID for this client instance
-	useSingleTcp bool   // When true, include unique ID in String() to allow multiple streams per TCP connection
+	enableStreamMultiplexing bool   // When true, include unique stream ID in Id() for multiplexing
 	sendMsg      int64
 	recvMsg      int64
 	errors       int64
@@ -75,13 +84,20 @@ func (c *Client) setConnectionManager(threshold int) {
 	connectionManager.PrepareRedis()
 }
 
-// String returns the target the client is querying.
-// When useSingleTcp is enabled, includes a unique ID to allow multiple streams per TCP connection.
-func (c *Client) String() string {
-	if c.useSingleTcp {
-		return fmt.Sprintf("%s#%d", c.addr.String(), c.id)
+// Key returns the client's key for use in the server's client map.
+// When EnableStreamMultiplexing is true, each stream has a unique StreamID.
+// When false, StreamID is 0 so all streams from the same peer share the same key (legacy behavior).
+func (c *Client) Key() ClientKey {
+	var streamID uint64
+	if c.enableStreamMultiplexing {
+		streamID = c.id
 	}
-	return c.addr.String()
+	return ClientKey{PeerAddr: c.addr.String(), StreamID: streamID}
+}
+
+// String returns a human-readable description of the client for logging.
+func (c *Client) String() string {
+	return fmt.Sprintf("%s#%d", c.addr.String(), c.id)
 }
 
 // Populate SONiC data path from prefix and subscription path.

--- a/gnmi_server/client_subscribe.go
+++ b/gnmi_server/client_subscribe.go
@@ -28,7 +28,7 @@ type ClientKey struct {
 type Client struct {
 	addr                     net.Addr
 	id                       uint64 // Unique ID for this client instance
-	enableStreamMultiplexing bool   // When true, include unique stream ID in Id() for multiplexing
+	enableStreamMultiplexing bool   // When true, include unique stream ID in Key() for multiplexing
 	sendMsg                  int64
 	recvMsg                  int64
 	errors                   int64

--- a/gnmi_server/client_subscribe.go
+++ b/gnmi_server/client_subscribe.go
@@ -12,20 +12,23 @@ import (
 	"io"
 	"net"
 	"sync"
+	"sync/atomic"
 )
 
 // Client contains information about a subscribe client that has connected to the server.
 type Client struct {
-	addr      net.Addr
-	sendMsg   int64
-	recvMsg   int64
-	errors    int64
-	polled    chan struct{}
-	stop      chan struct{}
-	once      chan struct{}
-	mu        sync.RWMutex
-	q         *queue.PriorityQueue
-	subscribe *gnmipb.SubscriptionList
+	addr         net.Addr
+	id           uint64 // Unique ID for this client instance
+	useSingleTcp bool   // When true, include unique ID in String() to allow multiple streams per TCP connection
+	sendMsg      int64
+	recvMsg      int64
+	errors       int64
+	polled       chan struct{}
+	stop         chan struct{}
+	once         chan struct{}
+	mu           sync.RWMutex
+	q            *queue.PriorityQueue
+	subscribe    *gnmipb.SubscriptionList
 	// Wait for all sub go routine to finish
 	w        sync.WaitGroup
 	fatal    bool
@@ -38,12 +41,17 @@ const logLevelDebug int = 7
 const logLevelMax int = logLevelDebug
 
 var connectionManager *ConnectionManager
+var connectionManagerMu sync.Mutex // Protects connectionManager initialization
+
+// Global counter for unique client IDs
+var clientIDCounter uint64
 
 // NewClient returns a new initialized client.
 func NewClient(addr net.Addr) *Client {
 	pq := queue.NewPriorityQueue(1, false)
 	return &Client{
 		addr:     addr,
+		id:       atomic.AddUint64(&clientIDCounter, 1),
 		q:        pq,
 		logLevel: logLevelError,
 	}
@@ -54,6 +62,9 @@ func (c *Client) setLogLevel(lvl int) {
 }
 
 func (c *Client) setConnectionManager(threshold int) {
+	connectionManagerMu.Lock()
+	defer connectionManagerMu.Unlock()
+
 	if connectionManager != nil && threshold == connectionManager.GetThreshold() {
 		return
 	}
@@ -65,7 +76,11 @@ func (c *Client) setConnectionManager(threshold int) {
 }
 
 // String returns the target the client is querying.
+// When useSingleTcp is enabled, includes a unique ID to allow multiple streams per TCP connection.
 func (c *Client) String() string {
+	if c.useSingleTcp {
+		return fmt.Sprintf("%s#%d", c.addr.String(), c.id)
+	}
 	return c.addr.String()
 }
 

--- a/gnmi_server/client_subscribe.go
+++ b/gnmi_server/client_subscribe.go
@@ -26,18 +26,18 @@ type ClientKey struct {
 
 // Client contains information about a subscribe client that has connected to the server.
 type Client struct {
-	addr         net.Addr
-	id           uint64 // Unique ID for this client instance
+	addr                     net.Addr
+	id                       uint64 // Unique ID for this client instance
 	enableStreamMultiplexing bool   // When true, include unique stream ID in Id() for multiplexing
-	sendMsg      int64
-	recvMsg      int64
-	errors       int64
-	polled       chan struct{}
-	stop         chan struct{}
-	once         chan struct{}
-	mu           sync.RWMutex
-	q            *queue.PriorityQueue
-	subscribe    *gnmipb.SubscriptionList
+	sendMsg                  int64
+	recvMsg                  int64
+	errors                   int64
+	polled                   chan struct{}
+	stop                     chan struct{}
+	once                     chan struct{}
+	mu                       sync.RWMutex
+	q                        *queue.PriorityQueue
+	subscribe                *gnmipb.SubscriptionList
 	// Wait for all sub go routine to finish
 	w        sync.WaitGroup
 	fatal    bool

--- a/gnmi_server/connection_manager.go
+++ b/gnmi_server/connection_manager.go
@@ -24,6 +24,8 @@ type ConnectionManager struct {
 }
 
 func (cm *ConnectionManager) GetThreshold() int {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
 	return cm.threshold
 }
 

--- a/gnmi_server/multi_request_tcp_conn_test.go
+++ b/gnmi_server/multi_request_tcp_conn_test.go
@@ -29,12 +29,12 @@ func createServerWithStreamMultiplexing(t *testing.T, port int64) *Server {
 
 	tlsOpts := []grpc.ServerOption{grpc.Creds(credentials.NewTLS(tlsCfg))}
 	cfg := &Config{
-		Port:                port,
-		EnableTranslibWrite: true,
-		EnableNativeWrite:   true,
-		Threshold:           100,
-		ImgDir:              "/tmp",
-		EnableStreamMultiplexing:        true,
+		Port:                     port,
+		EnableTranslibWrite:      true,
+		EnableNativeWrite:        true,
+		Threshold:                100,
+		ImgDir:                   "/tmp",
+		EnableStreamMultiplexing: true,
 	}
 	s, err := NewServer(cfg, tlsOpts, nil)
 	if err != nil {

--- a/gnmi_server/multi_request_tcp_conn_test.go
+++ b/gnmi_server/multi_request_tcp_conn_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"io"
 	"io/ioutil"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -17,7 +16,7 @@ import (
 	"google.golang.org/grpc/credentials"
 )
 
-func createServerWithSingleTcp(t *testing.T, port int64) *Server {
+func createServerWithStreamMultiplexing(t *testing.T, port int64) *Server {
 	t.Helper()
 	certificate, err := testcert.NewCert()
 	if err != nil {
@@ -35,7 +34,7 @@ func createServerWithSingleTcp(t *testing.T, port int64) *Server {
 		EnableNativeWrite:   true,
 		Threshold:           100,
 		ImgDir:              "/tmp",
-		UseSingleTcp:        true,
+		EnableStreamMultiplexing:        true,
 	}
 	s, err := NewServer(cfg, tlsOpts, nil)
 	if err != nil {
@@ -45,7 +44,7 @@ func createServerWithSingleTcp(t *testing.T, port int64) *Server {
 }
 
 func TestMultipleStreamsOnSameTCPConn(t *testing.T) {
-	s := createServerWithSingleTcp(t, 8081)
+	s := createServerWithStreamMultiplexing(t, 8081)
 	go runServer(t, s)
 	defer s.ForceStop()
 
@@ -280,19 +279,12 @@ func TestMultipleStreamsOnSameTCPConn(t *testing.T) {
 	// Verify server state WHILE streams are still active
 	s.cMu.Lock()
 	activeClients := len(s.clients)
-	clientKeys := make([]string, 0, len(s.clients))
+	clientKeys := make([]ClientKey, 0, len(s.clients))
 	uniqueAddrs := make(map[string]bool)
 
 	for clientKey := range s.clients {
 		clientKeys = append(clientKeys, clientKey)
-		// Extract address (before '#')
-		for i, ch := range clientKey {
-			if ch == '#' {
-				addr := clientKey[:i]
-				uniqueAddrs[addr] = true
-				break
-			}
-		}
+		uniqueAddrs[clientKey.PeerAddr] = true
 	}
 	s.cMu.Unlock()
 
@@ -381,7 +373,7 @@ collectLoop:
 }
 
 func TestMixedModeStreamsOnSameTCPConn(t *testing.T) {
-	s := createServerWithSingleTcp(t, 8082)
+	s := createServerWithStreamMultiplexing(t, 8082)
 	go runServer(t, s)
 	defer s.ForceStop()
 
@@ -539,13 +531,11 @@ func TestMixedModeStreamsOnSameTCPConn(t *testing.T) {
 	// Check server state while streams are active
 	s.cMu.Lock()
 	activeClients := len(s.clients)
-	clientKeys := make([]string, 0, len(s.clients))
+	clientKeys := make([]ClientKey, 0, len(s.clients))
 	uniqueAddrs := make(map[string]bool)
 	for clientKey := range s.clients {
 		clientKeys = append(clientKeys, clientKey)
-		if idx := strings.Index(clientKey, "#"); idx >= 0 {
-			uniqueAddrs[clientKey[:idx]] = true
-		}
+		uniqueAddrs[clientKey.PeerAddr] = true
 	}
 	s.cMu.Unlock()
 
@@ -619,10 +609,10 @@ collectLoop:
 	}
 }
 
-// TestMultipleStreamsDuplicateCloseWithoutFlag verifies that when UseSingleTcp is false (default),
+// TestMultipleStreamsDuplicateCloseWithoutFlag verifies that when EnableStreamMultiplexing is false (default),
 // the legacy behavior is preserved: a second Subscribe from the same peer closes the first.
 func TestMultipleStreamsDuplicateCloseWithoutFlag(t *testing.T) {
-	// Use createServer (not createServerWithSingleTcp) — UseSingleTcp defaults to false
+	// Use createServer (not createServerWithStreamMultiplexing) — EnableStreamMultiplexing defaults to false
 	s := createServer(t, 8081)
 	go runServer(t, s)
 	defer s.ForceStop()
@@ -734,5 +724,5 @@ func TestMultipleStreamsDuplicateCloseWithoutFlag(t *testing.T) {
 	}
 
 	stream2.CloseSend()
-	t.Logf("SUCCESS: Legacy duplicate-close behavior works when UseSingleTcp is disabled")
+	t.Logf("SUCCESS: Legacy duplicate-close behavior works when EnableStreamMultiplexing is disabled")
 }

--- a/gnmi_server/multi_request_tcp_conn_test.go
+++ b/gnmi_server/multi_request_tcp_conn_test.go
@@ -1,0 +1,738 @@
+package gnmi
+
+import (
+	"context"
+	"crypto/tls"
+	"io"
+	"io/ioutil"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	pb "github.com/openconfig/gnmi/proto/gnmi"
+	sdcfg "github.com/sonic-net/sonic-gnmi/sonic_db_config"
+	testcert "github.com/sonic-net/sonic-gnmi/testdata/tls"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+)
+
+func createServerWithSingleTcp(t *testing.T, port int64) *Server {
+	t.Helper()
+	certificate, err := testcert.NewCert()
+	if err != nil {
+		t.Fatalf("could not load server key pair: %s", err)
+	}
+	tlsCfg := &tls.Config{
+		ClientAuth:   tls.RequestClientCert,
+		Certificates: []tls.Certificate{certificate},
+	}
+
+	tlsOpts := []grpc.ServerOption{grpc.Creds(credentials.NewTLS(tlsCfg))}
+	cfg := &Config{
+		Port:                port,
+		EnableTranslibWrite: true,
+		EnableNativeWrite:   true,
+		Threshold:           100,
+		ImgDir:              "/tmp",
+		UseSingleTcp:        true,
+	}
+	s, err := NewServer(cfg, tlsOpts, nil)
+	if err != nil {
+		t.Fatalf("Failed to create gNMI server: %v", err)
+	}
+	return s
+}
+
+func TestMultipleStreamsOnSameTCPConn(t *testing.T) {
+	s := createServerWithSingleTcp(t, 8081)
+	go runServer(t, s)
+	defer s.ForceStop()
+
+	ns, _ := sdcfg.GetDbDefaultNamespace()
+
+	// Set up COUNTERS_DB with all required maps (port name, queue, PG, fabric, etc.)
+	prepareDb(t, ns)
+
+	// Set up APPL_DB data
+	applDbClient := getRedisClientN(t, 0, ns)
+	defer applDbClient.Close()
+	applDbClient.FlushDB(context.Background())
+	applDbClient.HSet(context.Background(), "ROUTE_TABLE:0.0.0.0/0", "ifname", "dummy")
+	applDbClient.HSet(context.Background(), "ROUTE_TABLE:0.0.0.0/0", "nexthop", "dummy")
+
+	// Set up STATE_DB data
+	fileName := "../testdata/NEIGH_STATE_TABLE.txt"
+	neighStateTableByte, err := ioutil.ReadFile(fileName)
+	if err != nil {
+		t.Fatalf("read file %v err: %v", fileName, err)
+	}
+	stateDbClient := getRedisClientN(t, 6, ns)
+	defer stateDbClient.Close()
+	stateDbClient.FlushDB(context.Background())
+	mpi_neigh := loadConfig(t, "", neighStateTableByte)
+	loadDB(t, stateDbClient, mpi_neigh)
+
+	time.Sleep(time.Millisecond * 100)
+
+	tlsConfig := &tls.Config{InsecureSkipVerify: true}
+	opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
+	conn, err := grpc.Dial("127.0.0.1:8081", opts...)
+	if err != nil {
+		t.Fatalf("Failed to dial: %v", err)
+	}
+	defer conn.Close()
+
+	gClient := pb.NewGNMIClient(conn)
+	ctx := context.Background()
+
+	stream1, err := gClient.Subscribe(ctx)
+	if err != nil {
+		t.Fatalf("Failed to create Subscribe stream #1: %v", err)
+	}
+
+	stream2, err := gClient.Subscribe(ctx)
+	if err != nil {
+		t.Fatalf("Failed to create Subscribe stream #2: %v", err)
+	}
+
+	stream3, err := gClient.Subscribe(ctx)
+	if err != nil {
+		t.Fatalf("Failed to create Subscribe stream #3: %v", err)
+	}
+
+	responses := make(chan *pb.SubscribeResponse, 100)
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		msgCount := 0
+		for {
+			resp, err := stream1.Recv()
+			if err == io.EOF {
+				t.Logf("Stream1 (STATE_DB): EOF after %d messages", msgCount)
+				return
+			}
+			if err != nil {
+				t.Logf("Stream1 (STATE_DB) recv error after %d messages: %v", msgCount, err)
+				return
+			}
+			msgCount++
+			if resp.GetSyncResponse() {
+				t.Logf("Stream1 (STATE_DB): got sync response (#%d)", msgCount)
+			}
+			if update := resp.GetUpdate(); update != nil {
+				t.Logf("Stream1 (STATE_DB): got update (#%d) with %d updates, prefix target: %s", msgCount, len(update.Update), update.Prefix.GetTarget())
+			}
+			responses <- resp
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		msgCount := 0
+		for {
+			resp, err := stream2.Recv()
+			if err == io.EOF {
+				t.Logf("Stream2 (COUNTERS_DB): EOF after %d messages", msgCount)
+				return
+			}
+			if err != nil {
+				t.Logf("Stream2 (COUNTERS_DB) recv error after %d messages: %v", msgCount, err)
+				return
+			}
+			msgCount++
+			if resp.GetSyncResponse() {
+				t.Logf("Stream2 (COUNTERS_DB): got sync response (#%d)", msgCount)
+			}
+			if update := resp.GetUpdate(); update != nil {
+				t.Logf("Stream2 (COUNTERS_DB): got update (#%d) with %d updates, prefix target: %s", msgCount, len(update.Update), update.Prefix.GetTarget())
+			}
+			responses <- resp
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		msgCount := 0
+		for {
+			resp, err := stream3.Recv()
+			if err == io.EOF {
+				t.Logf("Stream3 (APPL_DB): EOF after %d messages", msgCount)
+				return
+			}
+			if err != nil {
+				t.Logf("Stream3 (APPL_DB) recv error after %d messages: %v", msgCount, err)
+				return
+			}
+			msgCount++
+			if resp.GetSyncResponse() {
+				t.Logf("Stream3 (APPL_DB): got sync response (#%d)", msgCount)
+			}
+			if update := resp.GetUpdate(); update != nil {
+				t.Logf("Stream3 (APPL_DB): got update (#%d) with %d updates, prefix target: %s", msgCount, len(update.Update), update.Prefix.GetTarget())
+			}
+			responses <- resp
+		}
+	}()
+
+	req1 := &pb.SubscribeRequest{
+		Request: &pb.SubscribeRequest_Subscribe{
+			Subscribe: &pb.SubscriptionList{
+				Prefix: &pb.Path{Target: "STATE_DB"},
+				Mode:   pb.SubscriptionList_POLL,
+				Subscription: []*pb.Subscription{
+					{
+						Path: &pb.Path{
+							Elem: []*pb.PathElem{
+								{Name: "NEIGH_STATE_TABLE"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if err := stream1.Send(req1); err != nil {
+		t.Fatalf("Failed to send SubscribeRequest on stream1: %v", err)
+	}
+	t.Logf("Sent SubscribeRequest on stream #1 for STATE_DB")
+
+	req2 := &pb.SubscribeRequest{
+		Request: &pb.SubscribeRequest_Subscribe{
+			Subscribe: &pb.SubscriptionList{
+				Prefix: &pb.Path{Target: "COUNTERS_DB"},
+				Mode:   pb.SubscriptionList_POLL,
+				Subscription: []*pb.Subscription{
+					{
+						Path: &pb.Path{
+							Elem: []*pb.PathElem{
+								{Name: "COUNTERS"},
+								{Name: "Ethernet68"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if err := stream2.Send(req2); err != nil {
+		t.Fatalf("Failed to send SubscribeRequest on stream2: %v", err)
+	}
+	t.Logf("Sent SubscribeRequest on stream #2 for COUNTERS_DB")
+
+	req3 := &pb.SubscribeRequest{
+		Request: &pb.SubscribeRequest_Subscribe{
+			Subscribe: &pb.SubscriptionList{
+				Prefix: &pb.Path{Target: "APPL_DB"},
+				Mode:   pb.SubscriptionList_POLL,
+				Subscription: []*pb.Subscription{
+					{
+						Path: &pb.Path{
+							Elem: []*pb.PathElem{
+								{Name: "ROUTE_TABLE"},
+								{Name: "0.0.0.0/0"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if err := stream3.Send(req3); err != nil {
+		t.Fatalf("Failed to send SubscribeRequest on stream3: %v", err)
+	}
+	t.Logf("Sent SubscribeRequest on stream #3 for APPL_DB")
+
+	// Wait for subscriptions to be registered
+	time.Sleep(time.Millisecond * 200)
+
+	pollReq := &pb.SubscribeRequest{
+		Request: &pb.SubscribeRequest_Poll{
+			Poll: &pb.Poll{},
+		},
+	}
+
+	numPolls := 3
+	for i := 0; i < numPolls; i++ {
+		if err := stream1.Send(pollReq); err != nil {
+			t.Fatalf("Failed to send poll request %d on stream1: %v", i+1, err)
+		}
+		if err := stream2.Send(pollReq); err != nil {
+			t.Fatalf("Failed to send poll request %d on stream2: %v", i+1, err)
+		}
+		if err := stream3.Send(pollReq); err != nil {
+			t.Fatalf("Failed to send poll request %d on stream3: %v", i+1, err)
+		}
+		t.Logf("Sent poll request %d on all 3 streams", i+1)
+		time.Sleep(time.Millisecond * 100)
+	}
+
+	// Wait for responses to arrive
+	time.Sleep(time.Millisecond * 500)
+
+	// Verify server state WHILE streams are still active
+	s.cMu.Lock()
+	activeClients := len(s.clients)
+	clientKeys := make([]string, 0, len(s.clients))
+	uniqueAddrs := make(map[string]bool)
+
+	for clientKey := range s.clients {
+		clientKeys = append(clientKeys, clientKey)
+		// Extract address (before '#')
+		for i, ch := range clientKey {
+			if ch == '#' {
+				addr := clientKey[:i]
+				uniqueAddrs[addr] = true
+				break
+			}
+		}
+	}
+	s.cMu.Unlock()
+
+	t.Logf("Server has %d active client(s): %v", activeClients, clientKeys)
+	t.Logf("Unique TCP addresses: %v", uniqueAddrs)
+
+	// Close send on all streams
+	stream1.CloseSend()
+	stream2.CloseSend()
+	stream3.CloseSend()
+
+	// Wait for receivers to finish
+	go func() {
+		wg.Wait()
+		close(responses)
+	}()
+
+	// Collect responses
+	stateDbResponses := 0
+	countersDbResponses := 0
+	applDbResponses := 0
+	syncMessages := 0
+
+	timeout := time.After(2 * time.Second)
+collectLoop:
+	for {
+		select {
+		case resp, ok := <-responses:
+			if !ok {
+				break collectLoop
+			}
+			if update := resp.GetUpdate(); update != nil {
+				if update.Prefix != nil {
+					switch update.Prefix.Target {
+					case "STATE_DB":
+						stateDbResponses++
+					case "COUNTERS_DB":
+						countersDbResponses++
+					case "APPL_DB":
+						applDbResponses++
+					}
+				}
+			}
+			if resp.GetSyncResponse() {
+				syncMessages++
+			}
+		case <-timeout:
+			t.Logf("Timeout waiting for responses")
+			break collectLoop
+		}
+	}
+
+	t.Logf("Received %d STATE_DB, %d COUNTERS_DB, %d APPL_DB update responses, and %d sync messages",
+		stateDbResponses, countersDbResponses, applDbResponses, syncMessages)
+
+	// Verify we had 3 active clients while streams were running
+	if activeClients != 3 {
+		t.Errorf("Expected 3 active clients (one per stream), got %d", activeClients)
+	}
+
+	// Verify all streams on same TCP connection
+	if len(uniqueAddrs) != 1 {
+		t.Errorf("Expected all streams on 1 TCP connection, got %d unique addresses: %v", len(uniqueAddrs), uniqueAddrs)
+	}
+
+	// Verify responses received
+	expectedUpdates := numPolls
+	expectedSyncs := numPolls
+
+	if stateDbResponses < expectedUpdates {
+		t.Errorf("Expected at least %d STATE_DB update responses (one per poll), got %d", expectedUpdates, stateDbResponses)
+	}
+	if countersDbResponses < expectedUpdates {
+		t.Errorf("Expected at least %d COUNTERS_DB update responses (one per poll), got %d", expectedUpdates, countersDbResponses)
+	}
+	if applDbResponses < expectedUpdates {
+		t.Errorf("Expected at least %d APPL_DB update responses (one per poll), got %d", expectedUpdates, applDbResponses)
+	}
+	if syncMessages < expectedSyncs*3 {
+		t.Errorf("Expected at least %d sync messages (%d per stream), got %d", expectedSyncs*3, expectedSyncs, syncMessages)
+	}
+
+	if stateDbResponses >= expectedUpdates && countersDbResponses >= expectedUpdates && applDbResponses >= expectedUpdates && len(uniqueAddrs) == 1 && activeClients == 3 {
+		t.Logf("SUCCESS: 3 gRPC streams on same TCP connection, all receiving updates!")
+	}
+}
+
+func TestMixedModeStreamsOnSameTCPConn(t *testing.T) {
+	s := createServerWithSingleTcp(t, 8082)
+	go runServer(t, s)
+	defer s.ForceStop()
+
+	ns, _ := sdcfg.GetDbDefaultNamespace()
+
+	// Set up APPL_DB data for POLL stream
+	applDbClient := getRedisClientN(t, 0, ns)
+	defer applDbClient.Close()
+	applDbClient.FlushDB(context.Background())
+	applDbClient.HSet(context.Background(), "ROUTE_TABLE:0.0.0.0/0", "ifname", "eth0")
+	applDbClient.HSet(context.Background(), "ROUTE_TABLE:0.0.0.0/0", "nexthop", "10.0.0.1")
+
+	// Set up STATE_DB data for ON_CHANGE stream
+	stateDbClient := getRedisClientN(t, 6, ns)
+	defer stateDbClient.Close()
+	stateDbClient.FlushDB(context.Background())
+	stateDbClient.HSet(context.Background(), "NEIGH_STATE_TABLE|10.0.0.1", "state", "reachable")
+
+	time.Sleep(time.Millisecond * 100)
+
+	tlsConfig := &tls.Config{InsecureSkipVerify: true}
+	opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
+	conn, err := grpc.Dial("127.0.0.1:8082", opts...)
+	if err != nil {
+		t.Fatalf("Failed to dial: %v", err)
+	}
+	defer conn.Close()
+
+	gClient := pb.NewGNMIClient(conn)
+	ctx := context.Background()
+
+	// Stream 1: POLL mode on APPL_DB
+	pollStream, err := gClient.Subscribe(ctx)
+	if err != nil {
+		t.Fatalf("Failed to create POLL Subscribe stream: %v", err)
+	}
+
+	// Stream 2: ON_CHANGE (STREAM) mode on STATE_DB
+	onChangeStream, err := gClient.Subscribe(ctx)
+	if err != nil {
+		t.Fatalf("Failed to create ON_CHANGE Subscribe stream: %v", err)
+	}
+
+	type taggedResponse struct {
+		streamName string
+		resp       *pb.SubscribeResponse
+	}
+	responses := make(chan taggedResponse, 100)
+	var wg sync.WaitGroup
+
+	// Receiver for POLL stream
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			resp, err := pollStream.Recv()
+			if err == io.EOF {
+				return
+			}
+			if err != nil {
+				t.Logf("POLL stream recv error: %v", err)
+				return
+			}
+			responses <- taggedResponse{streamName: "POLL", resp: resp}
+		}
+	}()
+
+	// Receiver for ON_CHANGE stream
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			resp, err := onChangeStream.Recv()
+			if err == io.EOF {
+				return
+			}
+			if err != nil {
+				t.Logf("ON_CHANGE stream recv error: %v", err)
+				return
+			}
+			responses <- taggedResponse{streamName: "ON_CHANGE", resp: resp}
+		}
+	}()
+
+	// Send POLL subscription request
+	pollReq := &pb.SubscribeRequest{
+		Request: &pb.SubscribeRequest_Subscribe{
+			Subscribe: &pb.SubscriptionList{
+				Prefix: &pb.Path{Target: "APPL_DB"},
+				Mode:   pb.SubscriptionList_POLL,
+				Subscription: []*pb.Subscription{
+					{
+						Path: &pb.Path{
+							Elem: []*pb.PathElem{
+								{Name: "ROUTE_TABLE"},
+								{Name: "0.0.0.0/0"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	if err := pollStream.Send(pollReq); err != nil {
+		t.Fatalf("Failed to send POLL SubscribeRequest: %v", err)
+	}
+	t.Logf("Sent POLL SubscribeRequest on APPL_DB")
+
+	// Send ON_CHANGE subscription request
+	onChangeReq := &pb.SubscribeRequest{
+		Request: &pb.SubscribeRequest_Subscribe{
+			Subscribe: &pb.SubscriptionList{
+				Prefix: &pb.Path{Target: "STATE_DB"},
+				Mode:   pb.SubscriptionList_STREAM,
+				Subscription: []*pb.Subscription{
+					{
+						Path: &pb.Path{
+							Elem: []*pb.PathElem{
+								{Name: "NEIGH_STATE_TABLE"},
+							},
+						},
+						Mode: pb.SubscriptionMode_ON_CHANGE,
+					},
+				},
+			},
+		},
+	}
+	if err := onChangeStream.Send(onChangeReq); err != nil {
+		t.Fatalf("Failed to send ON_CHANGE SubscribeRequest: %v", err)
+	}
+	t.Logf("Sent ON_CHANGE SubscribeRequest on STATE_DB")
+
+	// Wait for subscriptions to be set up and initial sync
+	time.Sleep(time.Millisecond * 500)
+
+	// Send a poll request on the POLL stream
+	pollTrigger := &pb.SubscribeRequest{
+		Request: &pb.SubscribeRequest_Poll{
+			Poll: &pb.Poll{},
+		},
+	}
+	if err := pollStream.Send(pollTrigger); err != nil {
+		t.Fatalf("Failed to send poll trigger: %v", err)
+	}
+	t.Logf("Sent poll trigger on POLL stream")
+
+	// Trigger an ON_CHANGE update by modifying STATE_DB
+	time.Sleep(time.Millisecond * 200)
+	stateDbClient.HSet(context.Background(), "NEIGH_STATE_TABLE|10.0.0.2", "state", "reachable")
+	t.Logf("Triggered STATE_DB change for ON_CHANGE stream")
+
+	// Wait for responses
+	time.Sleep(time.Second * 1)
+
+	// Check server state while streams are active
+	s.cMu.Lock()
+	activeClients := len(s.clients)
+	clientKeys := make([]string, 0, len(s.clients))
+	uniqueAddrs := make(map[string]bool)
+	for clientKey := range s.clients {
+		clientKeys = append(clientKeys, clientKey)
+		if idx := strings.Index(clientKey, "#"); idx >= 0 {
+			uniqueAddrs[clientKey[:idx]] = true
+		}
+	}
+	s.cMu.Unlock()
+
+	t.Logf("Server has %d active client(s): %v", activeClients, clientKeys)
+	t.Logf("Unique TCP addresses: %v", uniqueAddrs)
+
+	// Close streams
+	pollStream.CloseSend()
+	onChangeStream.CloseSend()
+
+	go func() {
+		wg.Wait()
+		close(responses)
+	}()
+
+	// Collect responses
+	pollUpdates := 0
+	onChangeUpdates := 0
+	pollSyncs := 0
+	onChangeSyncs := 0
+
+	timeout := time.After(2 * time.Second)
+collectLoop:
+	for {
+		select {
+		case tagged, ok := <-responses:
+			if !ok {
+				break collectLoop
+			}
+			if tagged.resp.GetSyncResponse() {
+				if tagged.streamName == "POLL" {
+					pollSyncs++
+				} else {
+					onChangeSyncs++
+				}
+			}
+			if update := tagged.resp.GetUpdate(); update != nil {
+				if tagged.streamName == "POLL" {
+					pollUpdates++
+				} else {
+					onChangeUpdates++
+				}
+			}
+		case <-timeout:
+			t.Logf("Timeout waiting for responses")
+			break collectLoop
+		}
+	}
+
+	t.Logf("POLL stream: %d updates, %d syncs", pollUpdates, pollSyncs)
+	t.Logf("ON_CHANGE stream: %d updates, %d syncs", onChangeUpdates, onChangeSyncs)
+
+	// Verify 2 active clients on same TCP connection
+	if activeClients != 2 {
+		t.Errorf("Expected 2 active clients (POLL + ON_CHANGE), got %d", activeClients)
+	}
+	if len(uniqueAddrs) != 1 {
+		t.Errorf("Expected all streams on 1 TCP connection, got %d unique addresses: %v", len(uniqueAddrs), uniqueAddrs)
+	}
+
+	// Verify both streams received data
+	if pollUpdates < 1 {
+		t.Errorf("Expected at least 1 POLL update response, got %d", pollUpdates)
+	}
+	if onChangeUpdates < 1 {
+		t.Errorf("Expected at least 1 ON_CHANGE update response, got %d", onChangeUpdates)
+	}
+
+	if activeClients == 2 && len(uniqueAddrs) == 1 && pollUpdates >= 1 && onChangeUpdates >= 1 {
+		t.Logf("SUCCESS: Mixed POLL + ON_CHANGE streams coexist on same TCP connection!")
+	}
+}
+
+// TestMultipleStreamsDuplicateCloseWithoutFlag verifies that when UseSingleTcp is false (default),
+// the legacy behavior is preserved: a second Subscribe from the same peer closes the first.
+func TestMultipleStreamsDuplicateCloseWithoutFlag(t *testing.T) {
+	// Use createServer (not createServerWithSingleTcp) — UseSingleTcp defaults to false
+	s := createServer(t, 8081)
+	go runServer(t, s)
+	defer s.ForceStop()
+
+	ns, _ := sdcfg.GetDbDefaultNamespace()
+	prepareDb(t, ns)
+
+	time.Sleep(time.Millisecond * 100)
+
+	tlsConfig := &tls.Config{InsecureSkipVerify: true}
+	opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
+	conn, err := grpc.Dial("127.0.0.1:8081", opts...)
+	if err != nil {
+		t.Fatalf("Failed to dial: %v", err)
+	}
+	defer conn.Close()
+
+	gClient := pb.NewGNMIClient(conn)
+	ctx := context.Background()
+
+	// Open first stream
+	stream1, err := gClient.Subscribe(ctx)
+	if err != nil {
+		t.Fatalf("Failed to create Subscribe stream #1: %v", err)
+	}
+
+	req1 := &pb.SubscribeRequest{
+		Request: &pb.SubscribeRequest_Subscribe{
+			Subscribe: &pb.SubscriptionList{
+				Prefix: &pb.Path{Target: "STATE_DB"},
+				Mode:   pb.SubscriptionList_POLL,
+				Subscription: []*pb.Subscription{
+					{
+						Path: &pb.Path{
+							Elem: []*pb.PathElem{
+								{Name: "NEIGH_STATE_TABLE"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	if err := stream1.Send(req1); err != nil {
+		t.Fatalf("Failed to send SubscribeRequest on stream1: %v", err)
+	}
+	t.Logf("Sent SubscribeRequest on stream #1 for STATE_DB")
+
+	// Drain stream1's initial responses (update + sync) so the buffer is empty
+	for {
+		resp, err := stream1.Recv()
+		if err != nil {
+			t.Fatalf("Unexpected error draining stream1: %v", err)
+		}
+		if resp.GetSyncResponse() {
+			t.Logf("Stream1 initial sync received, buffer drained")
+			break
+		}
+	}
+
+	// Verify 1 active client
+	s.cMu.Lock()
+	clientsBefore := len(s.clients)
+	s.cMu.Unlock()
+	t.Logf("Active clients before stream2: %d", clientsBefore)
+
+	if clientsBefore != 1 {
+		t.Errorf("Expected 1 active client before stream2, got %d", clientsBefore)
+	}
+
+	// Open second stream from the same connection — should close the first
+	stream2, err := gClient.Subscribe(ctx)
+	if err != nil {
+		t.Fatalf("Failed to create Subscribe stream #2: %v", err)
+	}
+
+	req2 := &pb.SubscribeRequest{
+		Request: &pb.SubscribeRequest_Subscribe{
+			Subscribe: &pb.SubscriptionList{
+				Prefix: &pb.Path{Target: "STATE_DB"},
+				Mode:   pb.SubscriptionList_POLL,
+				Subscription: []*pb.Subscription{
+					{
+						Path: &pb.Path{
+							Elem: []*pb.PathElem{
+								{Name: "NEIGH_STATE_TABLE"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	if err := stream2.Send(req2); err != nil {
+		t.Fatalf("Failed to send SubscribeRequest on stream2: %v", err)
+	}
+	t.Logf("Sent SubscribeRequest on stream #2 for STATE_DB")
+
+	// Wait for stream2 to be registered and stream1 to be closed
+	time.Sleep(time.Millisecond * 500)
+
+	// Stream1 should have been closed by the duplicate detection.
+	// Buffer is empty (we drained it), so Recv should return an error.
+	_, err = stream1.Recv()
+	if err == nil {
+		t.Errorf("Expected stream1 to be closed by duplicate detection, but Recv succeeded")
+	} else {
+		t.Logf("Stream1 correctly closed: %v", err)
+	}
+
+	stream2.CloseSend()
+	t.Logf("SUCCESS: Legacy duplicate-close behavior works when UseSingleTcp is disabled")
+}

--- a/gnmi_server/server.go
+++ b/gnmi_server/server.go
@@ -233,6 +233,7 @@ type Config struct {
 	PathzPolicy     bool   // Enable gNMI pathz policy.
 	PathzPolicyFile string // Path to gNMI pathz policy file.
 	PathzMetaFile   string // Path to JSON file with pathz metadata.
+	UseSingleTcp    bool   // Allow multiple Subscribe RPCs on a single TCP connection.
 }
 
 // DBusOSBackend is a concrete implementation of OSBackend
@@ -814,21 +815,25 @@ func (s *Server) Subscribe(stream gnmipb.GNMI_SubscribeServer) error {
 	*/
 
 	c := NewClient(pr.Addr)
+	c.useSingleTcp = s.config.UseSingleTcp
 
 	c.setLogLevel(s.config.LogLevel)
 	c.setConnectionManager(s.config.Threshold)
 
 	s.cMu.Lock()
+	log.V(1).Infof("New Subscribe RPC: client %s (peer: %s, total active: %d)", c.String(), pr.Addr, len(s.clients))
 	if oc, ok := s.clients[c.String()]; ok {
 		log.V(2).Infof("Delete duplicate client %s", oc)
 		oc.Close()
 		delete(s.clients, c.String())
 	}
 	s.clients[c.String()] = c
+	log.V(1).Infof("Client %s registered (total active: %d)", c.String(), len(s.clients))
 	s.cMu.Unlock()
 
 	err := c.Run(stream, s.config)
 	s.cMu.Lock()
+	log.V(1).Infof("Client %s completed, removing (total active: %d)", c.String(), len(s.clients)-1)
 	delete(s.clients, c.String())
 	s.cMu.Unlock()
 

--- a/gnmi_server/server.go
+++ b/gnmi_server/server.go
@@ -80,7 +80,7 @@ type Server struct {
 	udsListener   net.Listener
 	config        *Config
 	cMu           sync.Mutex
-	clients       map[string]*Client
+	clients       map[ClientKey]*Client
 	certProviders []certprovider.Provider
 	// SaveStartupConfig points to a function that is called to save changes of
 	// configuration to a file. By default it points to an empty function -
@@ -233,7 +233,7 @@ type Config struct {
 	PathzPolicy     bool   // Enable gNMI pathz policy.
 	PathzPolicyFile string // Path to gNMI pathz policy file.
 	PathzMetaFile   string // Path to JSON file with pathz metadata.
-	UseSingleTcp    bool   // Allow multiple Subscribe RPCs on a single TCP connection.
+	EnableStreamMultiplexing    bool   // Allow multiple Subscribe RPCs on a single TCP connection.
 }
 
 // DBusOSBackend is a concrete implementation of OSBackend
@@ -512,7 +512,7 @@ func NewServer(config *Config, tlsOpts []grpc.ServerOption, commonOpts []grpc.Se
 
 	srv := &Server{
 		config:            config,
-		clients:           map[string]*Client{},
+		clients:           map[ClientKey]*Client{},
 		certProviders:     providers,
 		SaveStartupConfig: saveOnSetDisabled,
 		// ReqFromMaster point to a function that is called to verify if
@@ -815,26 +815,28 @@ func (s *Server) Subscribe(stream gnmipb.GNMI_SubscribeServer) error {
 	*/
 
 	c := NewClient(pr.Addr)
-	c.useSingleTcp = s.config.UseSingleTcp
+	c.enableStreamMultiplexing = s.config.EnableStreamMultiplexing
 
 	c.setLogLevel(s.config.LogLevel)
 	c.setConnectionManager(s.config.Threshold)
 
+	clientKey := c.Key()
+
 	s.cMu.Lock()
 	log.V(1).Infof("New Subscribe RPC: client %s (peer: %s, total active: %d)", c.String(), pr.Addr, len(s.clients))
-	if oc, ok := s.clients[c.String()]; ok {
+	if oc, ok := s.clients[clientKey]; ok {
 		log.V(2).Infof("Delete duplicate client %s", oc)
 		oc.Close()
-		delete(s.clients, c.String())
+		delete(s.clients, clientKey)
 	}
-	s.clients[c.String()] = c
+	s.clients[clientKey] = c
 	log.V(1).Infof("Client %s registered (total active: %d)", c.String(), len(s.clients))
 	s.cMu.Unlock()
 
 	err := c.Run(stream, s.config)
 	s.cMu.Lock()
 	log.V(1).Infof("Client %s completed, removing (total active: %d)", c.String(), len(s.clients)-1)
-	delete(s.clients, c.String())
+	delete(s.clients, clientKey)
 	s.cMu.Unlock()
 
 	log.Flush()

--- a/gnmi_server/server.go
+++ b/gnmi_server/server.go
@@ -217,23 +217,23 @@ type Config struct {
 	ImgDir     string
 	GetOptions func(*Config) ([]grpc.ServerOption, []certprovider.Provider, error)
 	// gnsi.certz mTLS flags
-	CaCertLnk       string // Path to symlink pointing to current CA certificate.
-	SrvCertLnk      string // Path to symlink pointing to current server's certificate.
-	SrvKeyLnk       string // Path to symlink pointing to current server's private key.
-	CaCertFile      string // Path to the first CA certificate.
-	SrvCertFile     string // Path to the first server's certificate.
-	SrvKeyFile      string // Path to the first server's private key.
-	CertCRLConfig   string // Path to the CRL directory. Disable if empty.
-	IntManFile      string // Path to the Integrity Manifest file.
-	CertzMetaFile   string // Path to JSON file with gRPC credential metadata.
-	FedPolicyFile   string // Path to federation policy file.
-	AuthzPolicy     bool   // Enable authz policy.
-	AuthzPolicyFile string // Path to JSON file with authz policies.
-	AuthzMetaFile   string // Path to JSON file with authz metadata.
-	PathzPolicy     bool   // Enable gNMI pathz policy.
-	PathzPolicyFile string // Path to gNMI pathz policy file.
-	PathzMetaFile   string // Path to JSON file with pathz metadata.
-	EnableStreamMultiplexing    bool   // Allow multiple Subscribe RPCs on a single TCP connection.
+	CaCertLnk                string // Path to symlink pointing to current CA certificate.
+	SrvCertLnk               string // Path to symlink pointing to current server's certificate.
+	SrvKeyLnk                string // Path to symlink pointing to current server's private key.
+	CaCertFile               string // Path to the first CA certificate.
+	SrvCertFile              string // Path to the first server's certificate.
+	SrvKeyFile               string // Path to the first server's private key.
+	CertCRLConfig            string // Path to the CRL directory. Disable if empty.
+	IntManFile               string // Path to the Integrity Manifest file.
+	CertzMetaFile            string // Path to JSON file with gRPC credential metadata.
+	FedPolicyFile            string // Path to federation policy file.
+	AuthzPolicy              bool   // Enable authz policy.
+	AuthzPolicyFile          string // Path to JSON file with authz policies.
+	AuthzMetaFile            string // Path to JSON file with authz metadata.
+	PathzPolicy              bool   // Enable gNMI pathz policy.
+	PathzPolicyFile          string // Path to gNMI pathz policy file.
+	PathzMetaFile            string // Path to JSON file with pathz metadata.
+	EnableStreamMultiplexing bool   // Allow multiple Subscribe RPCs on a single TCP connection.
 }
 
 // DBusOSBackend is a concrete implementation of OSBackend

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -2213,9 +2213,11 @@ func TestGnmiGetMultiNs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error Setting up MultiNamespace files with err %T", err)
 	}
+	sdc.ResetRedisClients()
 
 	/* https://www.gopherguides.com/articles/test-cleanup-in-go-1-14*/
 	t.Cleanup(func() {
+		sdc.ResetRedisClients()
 		if err := test_utils.CleanUpMultiNamespace(); err != nil {
 			t.Fatalf("error Cleaning up MultiNamespace files with err %T", err)
 
@@ -4105,9 +4107,11 @@ func TestGnmiSubscribeMultiNs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error Setting up MultiNamespace files with err %T", err)
 	}
+	sdc.ResetRedisClients()
 
 	/* https://www.gopherguides.com/articles/test-cleanup-in-go-1-14*/
 	t.Cleanup(func() {
+		sdc.ResetRedisClients()
 		if err := test_utils.CleanUpMultiNamespace(); err != nil {
 			t.Fatalf("error Cleaning up MultiNamespace files with err %T", err)
 
@@ -5652,9 +5656,11 @@ func TestGNMINativeMultiNamespace(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error Setting up MultiNamespace files with err %T", err)
 	}
+	sdc.ResetRedisClients()
 
 	/* https://www.gopherguides.com/articles/test-cleanup-in-go-1-14*/
 	t.Cleanup(func() {
+		sdc.ResetRedisClients()
 		if err := test_utils.CleanUpMultiNamespace(); err != nil {
 			t.Fatalf("error Cleaning up MultiNamespace files with err %T", err)
 

--- a/sonic_data_client/db_client.go
+++ b/sonic_data_client/db_client.go
@@ -69,6 +69,17 @@ var UseRedisLocalTcpPort bool = false
 // redis client connected to each DB
 var Target2RedisDb = make(map[string]map[string]*redis.Client)
 
+// Ensure useRedisTcpClient is only called once to avoid race conditions
+var useRedisTcpClientOnce sync.Once
+var useRedisTcpClientErr error
+
+// ResetRedisClients resets the useRedisTcpClient sync.Once so Target2RedisDb
+// gets re-populated. Used by multi-namespace tests when namespace config changes.
+func ResetRedisClients() {
+	useRedisTcpClientOnce = sync.Once{}
+	useRedisTcpClientErr = nil
+}
+
 // MinSampleInterval is the lowest sampling interval for streaming subscriptions.
 // Any non-zero value that less than this threshold is considered invalid argument.
 var MinSampleInterval = time.Second
@@ -178,7 +189,12 @@ func NewDbClient(paths []*gnmipb.Path, prefix *gnmipb.Path) (Client, error) {
 
 	// Testing program may ask to use redis local tcp connection
 	if UseRedisLocalTcpPort {
-		useRedisTcpClient()
+		useRedisTcpClientOnce.Do(func() {
+			useRedisTcpClientErr = useRedisTcpClient()
+		})
+		if useRedisTcpClientErr != nil {
+			return nil, useRedisTcpClientErr
+		}
 	}
 
 	client.prefix = prefix

--- a/sonic_data_client/virtual_db_test.go
+++ b/sonic_data_client/virtual_db_test.go
@@ -550,3 +550,28 @@ func TestClearMappings_Resets(t *testing.T) {
 		t.Errorf("expected countersPortNameMap to be cleared")
 	}
 }
+
+func TestResetRedisClients(t *testing.T) {
+	// Verify ResetRedisClients resets the sync.Once and error
+	ResetRedisClients()
+
+	// After reset, the sync.Once should fire again on next NewDbClient call
+	// Exercise the UseRedisLocalTcpPort path
+	origFlag := UseRedisLocalTcpPort
+	UseRedisLocalTcpPort = true
+	defer func() { UseRedisLocalTcpPort = origFlag }()
+
+	sdcfg.Init()
+
+	useRedisTcpClientOnce.Do(func() {
+		useRedisTcpClientErr = fmt.Errorf("mock error")
+	})
+
+	_, err := NewDbClient(nil, nil)
+	if err == nil {
+		t.Errorf("expected error from NewDbClient when useRedisTcpClient fails")
+	}
+
+	// Reset again to clean up for other tests
+	ResetRedisClients()
+}

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -75,6 +75,7 @@ type TelemetryConfig struct {
 	AuthzMetaFile         *string
 	AuthPolicyEnabled     *bool
 	AuthzPolicyFile       *string
+	UseSingleTcp          *bool
 }
 
 func main() {
@@ -200,6 +201,7 @@ func setupFlags(fs *flag.FlagSet) (*TelemetryConfig, *gnmi.Config, error) {
 		AuthzMetaFile:         fs.String("authz_meta", "/keys/authz-version.json", "authz policy metadata JSON file"),
 		AuthPolicyEnabled:     fs.Bool("authz_policy_enabled", false, "Enable authz policy. Require insecure flag to be false."),
 		AuthzPolicyFile:       fs.String("authorization_policy_file", "/keys/authorization_policy.json", "Full path name of the JSON authorization policy file."),
+		UseSingleTcp:          fs.Bool("use_single_tcp", false, "Allow multiple Subscribe RPCs on a single TCP connection"),
 	}
 
 	fs.Var(&telemetryCfg.UserAuth, "client_auth", "Client auth mode(s) - none,cert,password")
@@ -314,6 +316,7 @@ func setupFlags(fs *flag.FlagSet) (*TelemetryConfig, *gnmi.Config, error) {
 	cfg.AuthzMetaFile = string(*telemetryCfg.AuthzMetaFile)
 	cfg.AuthzPolicy = *telemetryCfg.AuthPolicyEnabled && !*telemetryCfg.Insecure
 	cfg.AuthzPolicyFile = string(*telemetryCfg.AuthzPolicyFile)
+	cfg.UseSingleTcp = *telemetryCfg.UseSingleTcp
 	return telemetryCfg, cfg, nil
 }
 

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -75,7 +75,7 @@ type TelemetryConfig struct {
 	AuthzMetaFile         *string
 	AuthPolicyEnabled     *bool
 	AuthzPolicyFile       *string
-	UseSingleTcp          *bool
+	EnableStreamMultiplexing          *bool
 }
 
 func main() {
@@ -201,7 +201,7 @@ func setupFlags(fs *flag.FlagSet) (*TelemetryConfig, *gnmi.Config, error) {
 		AuthzMetaFile:         fs.String("authz_meta", "/keys/authz-version.json", "authz policy metadata JSON file"),
 		AuthPolicyEnabled:     fs.Bool("authz_policy_enabled", false, "Enable authz policy. Require insecure flag to be false."),
 		AuthzPolicyFile:       fs.String("authorization_policy_file", "/keys/authorization_policy.json", "Full path name of the JSON authorization policy file."),
-		UseSingleTcp:          fs.Bool("use_single_tcp", false, "Allow multiple Subscribe RPCs on a single TCP connection"),
+		EnableStreamMultiplexing:          fs.Bool("enable_stream_multiplexing", false, "Allow multiple Subscribe RPCs on a single TCP connection via HTTP/2 stream multiplexing"),
 	}
 
 	fs.Var(&telemetryCfg.UserAuth, "client_auth", "Client auth mode(s) - none,cert,password")
@@ -316,7 +316,7 @@ func setupFlags(fs *flag.FlagSet) (*TelemetryConfig, *gnmi.Config, error) {
 	cfg.AuthzMetaFile = string(*telemetryCfg.AuthzMetaFile)
 	cfg.AuthzPolicy = *telemetryCfg.AuthPolicyEnabled && !*telemetryCfg.Insecure
 	cfg.AuthzPolicyFile = string(*telemetryCfg.AuthzPolicyFile)
-	cfg.UseSingleTcp = *telemetryCfg.UseSingleTcp
+	cfg.EnableStreamMultiplexing = *telemetryCfg.EnableStreamMultiplexing
 	return telemetryCfg, cfg, nil
 }
 

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -39,43 +39,43 @@ const (
 )
 
 type TelemetryConfig struct {
-	UserAuth              gnmi.AuthTypes
-	Port                  *int
-	UnixSocket            *string
-	LogLevel              *int
-	CaCert                *string
-	ServerCert            *string
-	ServerKey             *string
-	ConfigTableName       *string
-	ZmqAddress            *string
-	ZmqPort               *string
-	Insecure              *bool
-	NoTLS                 *bool
-	AllowNoClientCert     *bool
-	JwtRefInt             *uint64
-	JwtValInt             *uint64
-	GnmiTranslibWrite     *bool
-	GnmiNativeWrite       *bool
-	Threshold             *int
-	StreamingThreshold    *int
-	UnaryThreshold        *int
-	WithMasterArbitration *bool
-	WithSaveOnSet         *bool
-	IdleConnDuration      *int
-	Vrf                   *string
-	EnableCrl             *bool
-	CrlExpireDuration     *int
-	CaCertLnk             *string
-	ServerCertLnk         *string
-	ServerKeyLnk          *string
-	CertCRLConfig         *string
-	IntManFile            *string
-	CertzMetaFile         *string
-	ImgDirPath            *string
-	AuthzMetaFile         *string
-	AuthPolicyEnabled     *bool
-	AuthzPolicyFile       *string
-	EnableStreamMultiplexing          *bool
+	UserAuth                 gnmi.AuthTypes
+	Port                     *int
+	UnixSocket               *string
+	LogLevel                 *int
+	CaCert                   *string
+	ServerCert               *string
+	ServerKey                *string
+	ConfigTableName          *string
+	ZmqAddress               *string
+	ZmqPort                  *string
+	Insecure                 *bool
+	NoTLS                    *bool
+	AllowNoClientCert        *bool
+	JwtRefInt                *uint64
+	JwtValInt                *uint64
+	GnmiTranslibWrite        *bool
+	GnmiNativeWrite          *bool
+	Threshold                *int
+	StreamingThreshold       *int
+	UnaryThreshold           *int
+	WithMasterArbitration    *bool
+	WithSaveOnSet            *bool
+	IdleConnDuration         *int
+	Vrf                      *string
+	EnableCrl                *bool
+	CrlExpireDuration        *int
+	CaCertLnk                *string
+	ServerCertLnk            *string
+	ServerKeyLnk             *string
+	CertCRLConfig            *string
+	IntManFile               *string
+	CertzMetaFile            *string
+	ImgDirPath               *string
+	AuthzMetaFile            *string
+	AuthPolicyEnabled        *bool
+	AuthzPolicyFile          *string
+	EnableStreamMultiplexing *bool
 }
 
 func main() {
@@ -167,41 +167,41 @@ func parseOSArgs() ([]string, []string) {
 
 func setupFlags(fs *flag.FlagSet) (*TelemetryConfig, *gnmi.Config, error) {
 	telemetryCfg := &TelemetryConfig{
-		UserAuth:              gnmi.AuthTypes{"password": false, "cert": false, "jwt": false},
-		Port:                  fs.Int("port", -1, "port to listen on"),
-		UnixSocket:            fs.String("unix_socket", "/var/run/gnmi/gnmi.sock", "Unix socket path for local connections without TLS (set to empty to disable)"),
-		LogLevel:              fs.Int("v", 2, "log level of process"),
-		ConfigTableName:       fs.String("config_table_name", "", "Config table name"),
-		ZmqAddress:            fs.String("zmq_address", "", "Orchagent ZMQ address, deprecated, please use zmq_port."),
-		ZmqPort:               fs.String("zmq_port", "", "Orchagent ZMQ port, when not set or empty string telemetry server will switch to Redis based communication channel."),
-		Insecure:              fs.Bool("insecure", false, "Skip providing TLS cert and key, for testing only!"),
-		NoTLS:                 fs.Bool("noTLS", false, "disable TLS, for testing only!"),
-		AllowNoClientCert:     fs.Bool("allow_no_client_auth", false, "When set, telemetry server will request but not require a client certificate."),
-		JwtRefInt:             fs.Uint64("jwt_refresh_int", 900, "Seconds before JWT expiry the token can be refreshed."),
-		JwtValInt:             fs.Uint64("jwt_valid_int", 3600, "Seconds that JWT token is valid for."),
-		GnmiTranslibWrite:     fs.Bool("gnmi_translib_write", gnmi.ENABLE_TRANSLIB_WRITE, "Enable gNMI translib write for management framework"),
-		GnmiNativeWrite:       fs.Bool("gnmi_native_write", gnmi.ENABLE_NATIVE_WRITE, "Enable gNMI native write"),
-		Threshold:             fs.Int("threshold", 100, "max number of client connections"),
-		WithMasterArbitration: fs.Bool("with-master-arbitration", false, "Enables master arbitration policy."),
-		WithSaveOnSet:         fs.Bool("with-save-on-set", false, "Enables save-on-set."),
-		IdleConnDuration:      fs.Int("idle_conn_duration", 5, "Seconds before server closes idle connections"),
-		Vrf:                   fs.String("vrf", "", "VRF name, when zmq_address belong on a VRF, need VRF name to bind ZMQ."),
-		EnableCrl:             fs.Bool("enable_crl", false, "Enable certificate revocation list"),
-		CrlExpireDuration:     fs.Int("crl_expire_duration", 86400, "Certificate revocation list cache expire duration"),
-		ImgDirPath:            fs.String("img_dir", "/tmp/host_tmp", "Directory path where image will be transferred."),
-		CaCert:                fs.String("ca_crt", "", "CA certificate for client certificate validation. Optional."),
-		ServerCert:            fs.String("server_crt", "", "TLS server certificate"),
-		ServerKey:             fs.String("server_key", "", "TLS server private key"),
-		CaCertLnk:             fs.String("ca_cert_lnk", "/keys/ca_cert.lnk", "Path for CA certificate symlink"),
-		ServerCertLnk:         fs.String("server_cert_lnk", "/keys/server_cert.lnk", "Path for Server certificate symlink"),
-		ServerKeyLnk:          fs.String("server_key_lnk", "/keys/server_key.lnk", "Path for Server key symlink"),
-		IntManFile:            fs.String("integrity_manifest_file", "", "Full path name of integrity manifest file."),
-		CertCRLConfig:         fs.String("cert_crl_dir", "/mtls/crl", "Directory for CRL files"),
-		CertzMetaFile:         fs.String("grpc_meta", "/keys/grpc-version.json", "gRPC credentials metadata JSON file"),
-		AuthzMetaFile:         fs.String("authz_meta", "/keys/authz-version.json", "authz policy metadata JSON file"),
-		AuthPolicyEnabled:     fs.Bool("authz_policy_enabled", false, "Enable authz policy. Require insecure flag to be false."),
-		AuthzPolicyFile:       fs.String("authorization_policy_file", "/keys/authorization_policy.json", "Full path name of the JSON authorization policy file."),
-		EnableStreamMultiplexing:          fs.Bool("enable_stream_multiplexing", false, "Allow multiple Subscribe RPCs on a single TCP connection via HTTP/2 stream multiplexing"),
+		UserAuth:                 gnmi.AuthTypes{"password": false, "cert": false, "jwt": false},
+		Port:                     fs.Int("port", -1, "port to listen on"),
+		UnixSocket:               fs.String("unix_socket", "/var/run/gnmi/gnmi.sock", "Unix socket path for local connections without TLS (set to empty to disable)"),
+		LogLevel:                 fs.Int("v", 2, "log level of process"),
+		ConfigTableName:          fs.String("config_table_name", "", "Config table name"),
+		ZmqAddress:               fs.String("zmq_address", "", "Orchagent ZMQ address, deprecated, please use zmq_port."),
+		ZmqPort:                  fs.String("zmq_port", "", "Orchagent ZMQ port, when not set or empty string telemetry server will switch to Redis based communication channel."),
+		Insecure:                 fs.Bool("insecure", false, "Skip providing TLS cert and key, for testing only!"),
+		NoTLS:                    fs.Bool("noTLS", false, "disable TLS, for testing only!"),
+		AllowNoClientCert:        fs.Bool("allow_no_client_auth", false, "When set, telemetry server will request but not require a client certificate."),
+		JwtRefInt:                fs.Uint64("jwt_refresh_int", 900, "Seconds before JWT expiry the token can be refreshed."),
+		JwtValInt:                fs.Uint64("jwt_valid_int", 3600, "Seconds that JWT token is valid for."),
+		GnmiTranslibWrite:        fs.Bool("gnmi_translib_write", gnmi.ENABLE_TRANSLIB_WRITE, "Enable gNMI translib write for management framework"),
+		GnmiNativeWrite:          fs.Bool("gnmi_native_write", gnmi.ENABLE_NATIVE_WRITE, "Enable gNMI native write"),
+		Threshold:                fs.Int("threshold", 100, "max number of client connections"),
+		WithMasterArbitration:    fs.Bool("with-master-arbitration", false, "Enables master arbitration policy."),
+		WithSaveOnSet:            fs.Bool("with-save-on-set", false, "Enables save-on-set."),
+		IdleConnDuration:         fs.Int("idle_conn_duration", 5, "Seconds before server closes idle connections"),
+		Vrf:                      fs.String("vrf", "", "VRF name, when zmq_address belong on a VRF, need VRF name to bind ZMQ."),
+		EnableCrl:                fs.Bool("enable_crl", false, "Enable certificate revocation list"),
+		CrlExpireDuration:        fs.Int("crl_expire_duration", 86400, "Certificate revocation list cache expire duration"),
+		ImgDirPath:               fs.String("img_dir", "/tmp/host_tmp", "Directory path where image will be transferred."),
+		CaCert:                   fs.String("ca_crt", "", "CA certificate for client certificate validation. Optional."),
+		ServerCert:               fs.String("server_crt", "", "TLS server certificate"),
+		ServerKey:                fs.String("server_key", "", "TLS server private key"),
+		CaCertLnk:                fs.String("ca_cert_lnk", "/keys/ca_cert.lnk", "Path for CA certificate symlink"),
+		ServerCertLnk:            fs.String("server_cert_lnk", "/keys/server_cert.lnk", "Path for Server certificate symlink"),
+		ServerKeyLnk:             fs.String("server_key_lnk", "/keys/server_key.lnk", "Path for Server key symlink"),
+		IntManFile:               fs.String("integrity_manifest_file", "", "Full path name of integrity manifest file."),
+		CertCRLConfig:            fs.String("cert_crl_dir", "/mtls/crl", "Directory for CRL files"),
+		CertzMetaFile:            fs.String("grpc_meta", "/keys/grpc-version.json", "gRPC credentials metadata JSON file"),
+		AuthzMetaFile:            fs.String("authz_meta", "/keys/authz-version.json", "authz policy metadata JSON file"),
+		AuthPolicyEnabled:        fs.Bool("authz_policy_enabled", false, "Enable authz policy. Require insecure flag to be false."),
+		AuthzPolicyFile:          fs.String("authorization_policy_file", "/keys/authorization_policy.json", "Full path name of the JSON authorization policy file."),
+		EnableStreamMultiplexing: fs.Bool("enable_stream_multiplexing", false, "Allow multiple Subscribe RPCs on a single TCP connection via HTTP/2 stream multiplexing"),
 	}
 
 	fs.Var(&telemetryCfg.UserAuth, "client_auth", "Client auth mode(s) - none,cert,password")


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Our gRPC server should be able to support several RPCs on a single TCP connection using HTTP/2 multiplexing, which is how gRPC is designed to work.

Check for UseSingleTcp flag to enable this feature. If enabled, we can support multiple rpcs on a single TCP connection regardless of request type (GET, POLL, SUBSCRIBE), target (Any DB), etc.

#### How I did it

Added a unique atomic ID to each Client instance.

#### How to verify it

UT/CI/Manual test

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

