### PR TITLE
Skip flaky TestGnsiCertzServer/Rotate_ConcurrentRPC_ReturnsAborted

### DIFF
--- a/gnmi_server/gnsi_certz_test.go
+++ b/gnmi_server/gnsi_certz_test.go
@@ -1127,6 +1127,7 @@ var gnsiCertzTestCases = []struct {
 		desc:    "Rotate_ConcurrentRPC_ReturnsAborted",
 		timeout: 10 * time.Second, // Set specifically for this case
 		f: func(ctx context.Context, t *testing.T, sc certz.CertzClient, s *Server) {
+			t.Skip("Flaky due to timing sensitivity in concurrent gRPC Rotate streams. Tracking: https://github.com/sonic-net/sonic-gnmi/issues/616")
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 			// 1) Start the first stream to hold the certzMu lock


### PR DESCRIPTION
## Problem

`TestGnsiCertzServer/Rotate_ConcurrentRPC_ReturnsAborted` is flaking again in CI after the attempted fix in #618. The test expects `codes.Aborted` for a concurrent Rotate RPC but gets `codes.DeadlineExceeded` when the internal 5-second context deadline fires before the server returns Aborted.

**Recent failure:** https://dev.azure.com/mssonic/build/_build/results?buildId=1085458&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=996a989a-edd9-5084-d9de-d81350de1bfc&s=6884a131-87da-5381-61f3-d7acc3b91d76

## Root Cause

PR #618 bumped the parent context timeout from 1s to 10s, but the subtest creates its own 5s `context.WithTimeout` at line 1130 which is the actual limiting factor. The fundamental goroutine scheduling race between stream1's lock acquisition and stream2's `TryLock` check is unresolved.

## Fix

Re-skip the test with a reference to the tracking issue until the concurrency logic is fixed with explicit synchronization (e.g., a channel to confirm stream1 has acquired the lock before stream2 connects).

Tracking: #616