### PR TITLE
Fix CHASSIS_STATE_DB errors on non-chassis platforms

### DIFF
--- a/show_client/show_common.go
+++ b/show_client/show_common.go
@@ -19,6 +19,7 @@ const StateDBPortTable = "PORT_TABLE"
 // Database names
 const StateDB = "STATE_DB"
 const ConfigDB = "CONFIG_DB"
+const ChassisStateDB = "CHASSIS_STATE_DB"
 
 const (
 	dbIndex    = 0 // The first index for a query will be the DB

--- a/show_client/system_health_cli.go
+++ b/show_client/system_health_cli.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	sdc "github.com/sonic-net/sonic-gnmi/sonic_data_client"
+	sdcfg "github.com/sonic-net/sonic-gnmi/sonic_db_config"
 
 	log "github.com/golang/glog"
 	"google.golang.org/grpc/codes"
@@ -161,6 +162,26 @@ func getSystemHealthDpu(options sdc.OptionMap) ([]byte, error) {
 
 // Get data from chassis database using GetMapFromQueries
 func getChassisDataDirect(moduleName string) (map[string]interface{}, error) {
+	// Check whether CHASSIS_STATE_DB is present in the runtime database config.
+	// On non-chassis platform, CHASSIS_STATE_DB won't be present in database_config.json.
+	// Check Db exists before querying.
+
+	dbList, err := sdcfg.GetDbList(sdcfg.SONIC_DEFAULT_NAMESPACE)
+	if err != nil {
+		return nil, fmt.Errorf("getChassisDataDirect: failed to get DB list: %w", err)
+	}
+	chassisStateDBPresent := false
+	for _, db := range dbList {
+		if db == "CHASSIS_STATE_DB" {
+			chassisStateDBPresent = true
+			break
+		}
+	}
+	if !chassisStateDBPresent {
+		log.V(2).Infof("getChassisDataDirect: CHASSIS_STATE_DB not present on this platform, skipping")
+		return make(map[string]interface{}), nil
+	}
+
 	var queries [][]string
 	if moduleName != "" && moduleName != "all" {
 		queries = [][]string{

--- a/show_client/system_health_cli.go
+++ b/show_client/system_health_cli.go
@@ -3,9 +3,9 @@ package show_client
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
-	"sync"
 
 	sdc "github.com/sonic-net/sonic-gnmi/sonic_data_client"
 	sdcfg "github.com/sonic-net/sonic-gnmi/sonic_db_config"
@@ -161,42 +161,16 @@ func getSystemHealthDpu(options sdc.OptionMap) ([]byte, error) {
 	return jsonData, nil
 }
 
-// chassisDBCheck caches the one-time detection of whether CHASSIS_STATE_DB is
-// present in the runtime database_config.json. DB presence is a platform-level
-// fact that cannot change without a container restart, so caching with sync.Once
-// for the lifetime of the process. This avoids a repeated CGO
-// boundary crossing (SonicDBConfigGetDbList → C++ vector construction → Go slice
-// copy) on every gNMI GET.
-var chassisDBCheck = struct {
-	once    sync.Once
-	present bool
-	err     error
-}{}
-
 // Get data from chassis database using GetMapFromQueries
 func getChassisDataDirect(moduleName string) (map[string]interface{}, error) {
-	// Detect once whether CHASSIS_STATE_DB is available on this platform.
+	// Check whether CHASSIS_STATE_DB is present in the runtime database config.
 	// On non-chassis platforms, database_config.json strips it at container startup.
-	chassisDBCheck.once.Do(func() {
-		dbList, err := sdcfg.GetDbList(sdcfg.SONIC_DEFAULT_NAMESPACE)
-		if err != nil {
-			chassisDBCheck.err = fmt.Errorf("getChassisDataDirect: failed to get DB list: %w", err)
-			return
-		}
-		for _, db := range dbList {
-			if db == ChassisStateDB {
-				chassisDBCheck.present = true
-				break
-			}
-		}
-		if !chassisDBCheck.present {
-			log.V(2).Infof("getChassisDataDirect: %s not present on this platform, skipping", ChassisStateDB)
-		}
-	})
-	if chassisDBCheck.err != nil {
-		return nil, chassisDBCheck.err
+	dbList, err := sdcfg.GetDbList(sdcfg.SONIC_DEFAULT_NAMESPACE)
+	if err != nil {
+		return nil, fmt.Errorf("getChassisDataDirect: failed to get DB list: %w", err)
 	}
-	if !chassisDBCheck.present {
+	if !slices.Contains(dbList, ChassisStateDB) {
+		log.V(2).Infof("getChassisDataDirect: %s not present on this platform, skipping", ChassisStateDB)
 		return make(map[string]interface{}), nil
 	}
 

--- a/show_client/system_health_cli.go
+++ b/show_client/system_health_cli.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync"
 
 	sdc "github.com/sonic-net/sonic-gnmi/sonic_data_client"
 	sdcfg "github.com/sonic-net/sonic-gnmi/sonic_db_config"
@@ -160,36 +161,53 @@ func getSystemHealthDpu(options sdc.OptionMap) ([]byte, error) {
 	return jsonData, nil
 }
 
+// chassisDBCheck caches the one-time detection of whether CHASSIS_STATE_DB is
+// present in the runtime database_config.json. DB presence is a platform-level
+// fact that cannot change without a container restart, so caching with sync.Once
+// for the lifetime of the process. This avoids a repeated CGO
+// boundary crossing (SonicDBConfigGetDbList → C++ vector construction → Go slice
+// copy) on every gNMI GET.
+var chassisDBCheck = struct {
+	once    sync.Once
+	present bool
+	err     error
+}{}
+
 // Get data from chassis database using GetMapFromQueries
 func getChassisDataDirect(moduleName string) (map[string]interface{}, error) {
-	// Check whether CHASSIS_STATE_DB is present in the runtime database config.
-	// On non-chassis platform, CHASSIS_STATE_DB won't be present in database_config.json.
-	// Check Db exists before querying.
-
-	dbList, err := sdcfg.GetDbList(sdcfg.SONIC_DEFAULT_NAMESPACE)
-	if err != nil {
-		return nil, fmt.Errorf("getChassisDataDirect: failed to get DB list: %w", err)
-	}
-	chassisStateDBPresent := false
-	for _, db := range dbList {
-		if db == "CHASSIS_STATE_DB" {
-			chassisStateDBPresent = true
-			break
+	// Detect once whether CHASSIS_STATE_DB is available on this platform.
+	// On non-chassis platforms, database_config.json strips it at container startup.
+	chassisDBCheck.once.Do(func() {
+		dbList, err := sdcfg.GetDbList(sdcfg.SONIC_DEFAULT_NAMESPACE)
+		if err != nil {
+			chassisDBCheck.err = fmt.Errorf("getChassisDataDirect: failed to get DB list: %w", err)
+			return
 		}
+		for _, db := range dbList {
+			if db == ChassisStateDB {
+				chassisDBCheck.present = true
+				break
+			}
+		}
+		if !chassisDBCheck.present {
+			log.V(2).Infof("getChassisDataDirect: %s not present on this platform, skipping", ChassisStateDB)
+		}
+	})
+	if chassisDBCheck.err != nil {
+		return nil, chassisDBCheck.err
 	}
-	if !chassisStateDBPresent {
-		log.V(2).Infof("getChassisDataDirect: CHASSIS_STATE_DB not present on this platform, skipping")
+	if !chassisDBCheck.present {
 		return make(map[string]interface{}), nil
 	}
 
 	var queries [][]string
 	if moduleName != "" && moduleName != "all" {
 		queries = [][]string{
-			{"CHASSIS_STATE_DB", "DPU_STATE", moduleName},
+			{ChassisStateDB, "DPU_STATE", moduleName},
 		}
 	} else {
 		queries = [][]string{
-			{"CHASSIS_STATE_DB", "DPU_STATE"},
+			{ChassisStateDB, "DPU_STATE"},
 		}
 	}
 

--- a/sonic_data_client/client_test.go
+++ b/sonic_data_client/client_test.go
@@ -833,6 +833,18 @@ func saveAndResetTarget2RedisDb() func() {
 	return func() { Target2RedisDb = orig }
 }
 
+// allRuntimeDbNames returns all DB names from spb.Target_value except OTHERS,
+// suitable for mocking sdcfg.GetDbList in initRedisDbClients tests.
+func allRuntimeDbNames() []string {
+	names := make([]string, 0, len(spb.Target_value))
+	for name := range spb.Target_value {
+		if name != "OTHERS" {
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
 func TestInitRedisDbClients(t *testing.T) {
 	ns := ""
 
@@ -840,10 +852,14 @@ func TestInitRedisDbClients(t *testing.T) {
 		defer saveAndResetTarget2RedisDb()()
 
 		getDbSockCalls := 0
-		patches := gomonkey.ApplyFunc(sdcfg.GetDbAllNamespaces, func() ([]string, error) {
-			return []string{ns}, nil
+		patches := gomonkey.ApplyFunc(sdcfg.GetDbList, func(_ string) ([]string, error) {
+			return allRuntimeDbNames(), nil
 		})
 		defer patches.Reset()
+
+		patches.ApplyFunc(sdcfg.GetDbAllNamespaces, func() ([]string, error) {
+			return []string{ns}, nil
+		})
 
 		patches.ApplyFunc(sdcfg.GetDbSock, func(dbName string, _ string) (string, error) {
 			getDbSockCalls++
@@ -875,10 +891,14 @@ func TestInitRedisDbClients(t *testing.T) {
 	t.Run("AllDbsAvailable", func(t *testing.T) {
 		defer saveAndResetTarget2RedisDb()()
 
-		patches := gomonkey.ApplyFunc(sdcfg.GetDbAllNamespaces, func() ([]string, error) {
-			return []string{ns}, nil
+		patches := gomonkey.ApplyFunc(sdcfg.GetDbList, func(_ string) ([]string, error) {
+			return allRuntimeDbNames(), nil
 		})
 		defer patches.Reset()
+
+		patches.ApplyFunc(sdcfg.GetDbAllNamespaces, func() ([]string, error) {
+			return []string{ns}, nil
+		})
 
 		patches.ApplyFunc(sdcfg.GetDbSock, func(_ string, _ string) (string, error) {
 			return "/var/run/redis/redis.sock", nil
@@ -906,10 +926,14 @@ func TestInitRedisDbClients(t *testing.T) {
 	t.Run("GetDbAllNamespacesFails", func(t *testing.T) {
 		defer saveAndResetTarget2RedisDb()()
 
-		patches := gomonkey.ApplyFunc(sdcfg.GetDbAllNamespaces, func() ([]string, error) {
-			return nil, fmt.Errorf("namespace retrieval failed")
+		patches := gomonkey.ApplyFunc(sdcfg.GetDbList, func(_ string) ([]string, error) {
+			return allRuntimeDbNames(), nil
 		})
 		defer patches.Reset()
+
+		patches.ApplyFunc(sdcfg.GetDbAllNamespaces, func() ([]string, error) {
+			return nil, fmt.Errorf("namespace retrieval failed")
+		})
 
 		initRedisDbClients()
 
@@ -926,10 +950,14 @@ func TestInitRedisDbClients(t *testing.T) {
 			"ASIC_DB":          true,
 		}
 
-		patches := gomonkey.ApplyFunc(sdcfg.GetDbAllNamespaces, func() ([]string, error) {
-			return []string{ns}, nil
+		patches := gomonkey.ApplyFunc(sdcfg.GetDbList, func(_ string) ([]string, error) {
+			return allRuntimeDbNames(), nil
 		})
 		defer patches.Reset()
+
+		patches.ApplyFunc(sdcfg.GetDbAllNamespaces, func() ([]string, error) {
+			return []string{ns}, nil
+		})
 
 		patches.ApplyFunc(sdcfg.GetDbSock, func(dbName string, _ string) (string, error) {
 			if failingDbs[dbName] {
@@ -953,6 +981,79 @@ func TestInitRedisDbClients(t *testing.T) {
 			if _, exists := nsMap[dbName]; !exists {
 				t.Errorf("Expected %s to be initialized despite other DBs failing", dbName)
 			}
+		}
+	})
+
+	t.Run("GetDbListFails", func(t *testing.T) {
+		defer saveAndResetTarget2RedisDb()()
+
+		patches := gomonkey.ApplyFunc(sdcfg.GetDbList, func(_ string) ([]string, error) {
+			return nil, fmt.Errorf("DB list retrieval failed")
+		})
+		defer patches.Reset()
+
+		initRedisDbClients()
+
+		if len(Target2RedisDb) != 0 {
+			t.Errorf("Expected Target2RedisDb to be empty when GetDbList fails, got %d entries", len(Target2RedisDb))
+		}
+	})
+
+	t.Run("GetDbListEmpty", func(t *testing.T) {
+		defer saveAndResetTarget2RedisDb()()
+
+		patches := gomonkey.ApplyFunc(sdcfg.GetDbList, func(_ string) ([]string, error) {
+			return []string{}, nil
+		})
+		defer patches.Reset()
+
+		initRedisDbClients()
+
+		if len(Target2RedisDb) != 0 {
+			t.Errorf("Expected Target2RedisDb to be empty when DB list is empty, got %d entries", len(Target2RedisDb))
+		}
+	})
+
+	t.Run("RuntimeDbSetFilters", func(t *testing.T) {
+		defer saveAndResetTarget2RedisDb()()
+
+		// Return only a subset of DBs — CHASSIS_STATE_DB is absent from runtime config
+		patches := gomonkey.ApplyFunc(sdcfg.GetDbList, func(_ string) ([]string, error) {
+			return []string{"CONFIG_DB", "APPL_DB", "STATE_DB"}, nil
+		})
+		defer patches.Reset()
+
+		patches.ApplyFunc(sdcfg.GetDbAllNamespaces, func() ([]string, error) {
+			return []string{ns}, nil
+		})
+
+		getDbSockCalls := 0
+		patches.ApplyFunc(sdcfg.GetDbSock, func(_ string, _ string) (string, error) {
+			getDbSockCalls++
+			return "/var/run/redis/redis.sock", nil
+		})
+
+		initRedisDbClients()
+
+		nsMap, ok := Target2RedisDb[ns]
+		if !ok {
+			t.Fatal("Expected namespace to exist in Target2RedisDb")
+		}
+		// DBs not in the runtime list should be filtered out
+		for _, dbName := range []string{"CHASSIS_STATE_DB", "ASIC_DB", "COUNTERS_DB"} {
+			if _, exists := nsMap[dbName]; exists {
+				t.Errorf("%s should have been filtered by runtimeDbSet", dbName)
+			}
+		}
+		// DBs in the runtime list should be present
+		for _, dbName := range []string{"CONFIG_DB", "APPL_DB", "STATE_DB"} {
+			if _, exists := nsMap[dbName]; !exists {
+				t.Errorf("Expected %s to be initialized", dbName)
+			}
+		}
+		// GetDbSock should only be called for DBs in the runtime set
+		if getDbSockCalls != 3 {
+			t.Errorf("Expected GetDbSock to be called 3 times, got %d", getDbSockCalls)
 		}
 	})
 }

--- a/sonic_data_client/db_client.go
+++ b/sonic_data_client/db_client.go
@@ -574,6 +574,28 @@ func init() {
 }
 
 func initRedisDbClients() {
+	// Build the set of DBs present in the runtime database_config.json so
+	// we can skip DBs absent on this platform before calling GetDbSock, which would otherwise
+	// log ERR for every missing DB.
+	// Note: GetDbList always returns the default namespace DB list.
+	// This is safe because all namespaces carry the same DB names; they differ only in
+	// socket paths. GetDbList and GetDbAllNamespaces share the same DbInit gate,
+	// so if GetDbList fails GetDbAllNamespaces would fail too;
+	// returning early here avoids redundant failures.
+	runtimeDbList, err := sdcfg.GetDbList(sdcfg.SONIC_DEFAULT_NAMESPACE)
+	if err != nil {
+		log.Errorf("initRedisDbClients: failed to get runtime DB list: %v", err)
+		return
+	}
+	if len(runtimeDbList) == 0 {
+		log.Errorf("initRedisDbClients: runtime DB list is empty, database config may be corrupt")
+		return
+	}
+	runtimeDbSet := make(map[string]bool, len(runtimeDbList))
+	for _, db := range runtimeDbList {
+		runtimeDbSet[db] = true
+	}
+
 	AllNamespaces, err := sdcfg.GetDbAllNamespaces()
 	if err != nil {
 		log.Errorf("init error:  %v", err)
@@ -583,6 +605,13 @@ func initRedisDbClients() {
 		Target2RedisDb[dbNamespace] = make(map[string]*redis.Client)
 		for dbName, dbn := range spb.Target_value {
 			if dbName != "OTHERS" {
+				// Skip DBs not present in the runtime database_config.json.
+				// runtimeDbSet is non-empty here (guaranteed by the early return
+				// above), so a missing key safely returns false in Go.
+				if !runtimeDbSet[dbName] {
+					log.V(2).Infof("initRedisDbClients: skipping %s, not in runtime DB config", dbName)
+					continue
+				}
 				addr, err := sdcfg.GetDbSock(dbName, dbNamespace)
 				if err != nil {
 					log.Warningf("Skipping %s in namespace %s: %v", dbName, dbNamespace, err)

--- a/sonic_data_client/db_client.go
+++ b/sonic_data_client/db_client.go
@@ -591,9 +591,9 @@ func initRedisDbClients() {
 		log.Errorf("initRedisDbClients: runtime DB list is empty, database config may be corrupt")
 		return
 	}
-	runtimeDbSet := make(map[string]bool, len(runtimeDbList))
+	runtimeDbSet := make(map[string]struct{}, len(runtimeDbList))
 	for _, db := range runtimeDbList {
-		runtimeDbSet[db] = true
+		runtimeDbSet[db] = struct{}{}
 	}
 
 	AllNamespaces, err := sdcfg.GetDbAllNamespaces()
@@ -608,7 +608,7 @@ func initRedisDbClients() {
 				// Skip DBs not present in the runtime database_config.json.
 				// runtimeDbSet is non-empty here (guaranteed by the early return
 				// above), so a missing key safely returns false in Go.
-				if !runtimeDbSet[dbName] {
+				if _, ok := runtimeDbSet[dbName]; !ok {
 					log.V(2).Infof("initRedisDbClients: skipping %s, not in runtime DB config", dbName)
 					continue
 				}


### PR DESCRIPTION
Fixes #654

#### What I did
Fixed syslog errors across gnmi container restarts

```bash
ERR gnmi#telemetry: :- getDbInfo: Failed to find CHASSIS_STATE_DB database in : key
ERR gnmi#dialout_client_cli: :- getDbInfo: Failed to find CHASSIS_STATE_DB database in : key
```

#### How I did it
Added check to ensure DB present on the running DB config before attempting to access it. On non-chassis platforms (e.g. single-ASIC), the database container strips the chassis DB entries from database_config.json at startup. Attempting to connect without this guard causes libswsscommon to throw "Failed to find CHASSIS_STATE_DB database in : key" on every process start.

#### How to verify it
Run sonic-mgmt tests that does `config reload` and does log analyzer. Verified tests don't face teardown errors.

```bash
./run_tests.sh -n ptf2-m -d str-marvell-tl7-01 -f ../ansible/testbed.yaml -i ../ansible/lab,../ansible/veos -t t0,any -c hash/test_generic_hash_packet_type.py::test_pkt_type_hash_config_persistence_reload -u
```