### PR TITLE
Decouple diff-cover enforcement from integration test job

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -158,7 +158,7 @@ stages:
 
   # Full integration testing with SONiC dependencies
   - job: IntegrationTest
-    displayName: "Integration Test"
+    displayName: "Integration Tests"
     timeoutInMinutes: 60
 
     pool:
@@ -244,7 +244,7 @@ stages:
       displayName: 'Publish integration coverage artifact'
       condition: always()
 
-  - job: DiffCoverageCheck
+  - job: build
     displayName: "Diff Coverage Check"
     dependsOn: [PureCIJob, IntegrationTest]
     condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -245,7 +245,7 @@ stages:
       condition: always()
 
   - job: build
-    displayName: "Diff Coverage Check"
+    displayName: "build"
     dependsOn: [PureCIJob, IntegrationTest]
     condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
     timeoutInMinutes: 10

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -157,8 +157,8 @@ stages:
         testRunTitle: 'Memory Leak Tests'
 
   # Full integration testing with SONiC dependencies
-  - job: build
-    displayName: "build"
+  - job: IntegrationTest
+    displayName: "Integration Test"
     timeoutInMinutes: 60
 
     pool:
@@ -246,7 +246,7 @@ stages:
 
   - job: DiffCoverageCheck
     displayName: "Diff Coverage Check"
-    dependsOn: [PureCIJob, build]
+    dependsOn: [PureCIJob, IntegrationTest]
     condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
     timeoutInMinutes: 10
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,8 +25,6 @@ variables:
       value: $(Build.SourceBranchName)
   - name: UNIT_TEST_FLAG
     value: 'ENABLE_TRANSLIB_WRITE=y'
-  - name: DIFF_COVER_THRESHOLD
-    value: 80
 
 resources:
   repositories:
@@ -166,11 +164,6 @@ stages:
       name: sonicso1ES-amd64
       vmImage: ubuntu-22.04
 
-    variables:
-      DIFF_COVER_CHECK_THRESHOLD: 80
-      DIFF_COVER_ENABLE: 'true'
-      DIFF_COVER_WORKING_DIRECTORY: $(System.DefaultWorkingDirectory)/sonic-gnmi
-
     container:
       image: sonicdev-microsoft.azurecr.io:443/sonic-slave-bookworm:latest
 
@@ -250,8 +243,16 @@ stages:
     dependsOn: [PureCIJob, build]
     condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
     timeoutInMinutes: 10
+
     pool:
       vmImage: ubuntu-22.04
+
+    variables:
+      DIFF_COVER_ENABLE: 'true'
+      DIFF_COVER_CHECK_THRESHOLD: 80
+      DIFF_COVER_WORKING_DIRECTORY: $(System.DefaultWorkingDirectory)
+      DIFF_COVER_COVERAGE_FILES: '$(Pipeline.Workspace)/coverage-integration/coverage.xml $(Pipeline.Workspace)/coverage-pure/coverage-pure.xml'
+
     steps:
     - checkout: self
       clean: true
@@ -262,17 +263,6 @@ stages:
 
     - download: current
       artifact: coverage-integration
-
-    - bash: |
-        set -euo pipefail
-        pip3 install --quiet diff-cover
-        diff-cover \
-          $(Pipeline.Workspace)/coverage-integration/coverage.xml \
-          $(Pipeline.Workspace)/coverage-pure/coverage-pure.xml \
-          --compare-branch origin/$(BUILD_BRANCH) \
-          --src-roots . \
-          --fail-under $(DIFF_COVER_THRESHOLD)
-      displayName: 'Run diff-cover'
 
 - stage: BuildAmd64
   dependsOn: []


### PR DESCRIPTION
#### Why I did it

The `build` job previously served double duty: running integration tests and hosting the diff-cover wrapper hook. This coupled the job displayName to the wrapper's GitHub check name (`coverage.{DefinitionName}.{displayName}`), preventing any renaming without breaking branch protection rules.

#### How I did it

- Moved `DIFF_COVER_ENABLE`, `DIFF_COVER_CHECK_THRESHOLD`, and related variables from the integration test job to a dedicated lightweight job that only downloads coverage artifacts and hosts the wrapper decorator.
- Renamed the integration test job from `build` to `IntegrationTest` with displayName "Integration Tests".
- Kept the diff-cover job's displayName as `build` to preserve the existing wrapper check name (`coverage.sonic-net.sonic-gnmi.build`) and avoid branch protection changes.
- Removed the native `diff-cover --fail-under` step since the wrapper handles threshold enforcement via GitHub checks.
- Removed the unused global `DIFF_COVER_THRESHOLD` variable.
- Added `DIFF_COVER_COVERAGE_FILES` to explicitly point the wrapper at both pure and integration coverage XML artifacts.

#### How to verify it

1. The wrapper's GitHub check `coverage.sonic-net.sonic-gnmi.build` still appears and enforces the 80% threshold.
2. The integration test job now shows as "Integration Tests" in the pipeline UI.
3. All existing branch protection rules continue to work without admin changes.

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog

Decouple diff-cover wrapper hook from integration test job, allowing the test job to be renamed independently.

#### Link to config_db schema for YANG module changes

N/A

#### A picture of a cute animal (not mandatory but encouraged)
