### PR TITLE
Skip flaky TestGnsiPathzRotation subtests

### DIFF
--- a/gnmi_server/gnsi_pathz_test.go
+++ b/gnmi_server/gnsi_pathz_test.go
@@ -249,6 +249,7 @@ var pathzRotationTestCases = []struct {
 		desc: "RotatePolicyEmptyUploadRequest",
 		f: func(ctx context.Context, t *testing.T, sc pathz.PathzClient, s *Server) {
 			// 0) Open the streaming RPC.
+			t.Skip("Flaky due to race between server-side revert and test reset after RotateStreamSendError. Tracking: https://github.com/sonic-net/sonic-gnmi/issues/624")
 			stream, err := sc.Rotate(ctx, grpc.EmptyCallOption{})
 			if err != nil {
 				t.Fatal(err.Error())
@@ -276,6 +277,7 @@ var pathzRotationTestCases = []struct {
 	{
 		desc: "RotatePolicyEmptyRequest",
 		f: func(ctx context.Context, t *testing.T, sc pathz.PathzClient, s *Server) {
+			t.Skip("Flaky due to race between server-side revert and test reset after RotateStreamSendError. Tracking: https://github.com/sonic-net/sonic-gnmi/issues/624")
 			stream, err := sc.Rotate(ctx, grpc.EmptyCallOption{})
 			if err != nil {
 				t.Fatal(err.Error())
@@ -295,6 +297,7 @@ var pathzRotationTestCases = []struct {
 	{
 		desc: "RotatePolicyWrongPolicyProto",
 		f: func(ctx context.Context, t *testing.T, sc pathz.PathzClient, s *Server) {
+			t.Skip("Flaky due to race between server-side revert and test reset after RotateStreamSendError. Tracking: https://github.com/sonic-net/sonic-gnmi/issues/624")
 			stream, err := sc.Rotate(ctx, grpc.EmptyCallOption{})
 			if err != nil {
 				t.Fatal(err.Error())
@@ -366,6 +369,7 @@ var pathzRotationTestCases = []struct {
 	{
 		desc: "RotatePolicyNoVersion",
 		f: func(ctx context.Context, t *testing.T, sc pathz.PathzClient, s *Server) {
+			t.Skip("Flaky due to race between server-side revert and test reset after RotateStreamSendError. Tracking: https://github.com/sonic-net/sonic-gnmi/issues/624")
 			stream, err := sc.Rotate(ctx, grpc.EmptyCallOption{})
 			if err != nil {
 				t.Fatal(err.Error())


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Four subtests in TestGnsiPathzRotation intermittently fail due to a race
condition between the server-side Rotate handler reverting the policy
file and the test loop's resetPathzPolicyFile call after the
RotateStreamSendError subtest.

#### How I did it
Skip the affected subtests with a reference to the tracking issue until
the underlying synchronization issue is resolved.

Affected subtests:
- RotatePolicyEmptyRequest
- RotatePolicyEmptyUploadRequest
- RotatePolicyWrongPolicyProto
- RotatePolicyNoVersion
#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

