### PR TITLE
gnmi_server: fix nil-resp panic when CRL fetch fails

### DIFF
--- a/gnmi_server/clientCertAuth.go
+++ b/gnmi_server/clientCertAuth.go
@@ -159,13 +159,14 @@ func ClientCertAuthenAndAuthor(ctx context.Context, serviceConfigTableName strin
 func TryDownload(url string) bool {
 	glog.Infof("Download CRL start: %s", url)
 	resp, err := http.Get(url)
-
-	if resp != nil {
-		defer resp.Body.Close()
-	}
-
-	if err != nil || resp.StatusCode != http.StatusOK {
+	if err != nil {
 		glog.Infof("Download CRL: %s failed: %v", url, err)
+		return false
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		glog.Infof("Download CRL: %s failed: HTTP %d", url, resp.StatusCode)
 		return false
 	}
 


### PR DESCRIPTION
Closes sonic-net/sonic-gnmi#630.

## Problem

`TryDownload` in `gnmi_server/clientCertAuth.go` unconditionally dereferences `resp.StatusCode` after `http.Get(url)`, but `http.Get` returns `(nil, err)` on network-level failures (DNS resolution, connection refused, TLS handshake failure, timeout before response, etc.). Any of these paths panics the gNMI server with `nil pointer dereference`.

```go
resp, err := http.Get(url)

if resp != nil {
    defer resp.Body.Close()
}

if err != nil || resp.StatusCode != http.StatusOK {  // resp may be nil here
```

## Fix

Short-circuit on `err != nil` before touching `resp`, matching the standard Go pattern. Log the HTTP status on non-200 responses instead of a stale `err`. Behavior is otherwise unchanged on the happy path.

## Test

`gofmt -d` clean.