### PR TITLE
Add OS.Verify and OS.Activate to DPU proxy forwardable methods

### DIFF
--- a/pkg/interceptors/dpuproxy/proxy.go
+++ b/pkg/interceptors/dpuproxy/proxy.go
@@ -62,6 +62,16 @@ var defaultForwardableMethods = []ForwardableMethod{
 		Description: "Install package on DPU",
 		Mode:        ForwardToDPU,
 	},
+	{
+		FullMethod:  "/gnoi.os.OS/Verify",
+		Description: "Verify current OS version on DPU",
+		Mode:        ForwardToDPU,
+	},
+	{
+		FullMethod:  "/gnoi.os.OS/Activate",
+		Description: "Activate OS version on DPU",
+		Mode:        ForwardToDPU,
+	},
 	// gRPC reflection methods needed for grpcurl to work with DPU headers
 	{
 		FullMethod:  "/grpc.reflection.v1.ServerReflection/ServerReflectionInfo",


### PR DESCRIPTION
### Description
The SmartSwitch DPU upgrade workflow (see [upgrade HLD](https://github.com/sonic-net/SONiC/blob/master/doc/smart-switch/upgrade/dpu-upgrade-hld.md)) requires verifying the OS version on individual DPUs after upgrade (Phase 3: Verify). 

`OS.Verify` and `OS.Activate` RPCs are already implemented in sonic-gnmi (`gnmi_server/gnoi_os.go`, `pkg/gnoi/os/os.go`) but are **not registered** in the DPU proxy's forwardable methods list (`pkg/interceptors/dpuproxy/proxy.go`). This means requests with DPU metadata headers (`x-sonic-ss-target-type: dpu`) are rejected with an error.

This PR adds both RPCs as `ForwardToDPU` entries so external clients can:
- `OS.Verify` — check the running SONiC version on a specific DPU after upgrade
- `OS.Activate` — set the next-boot image on a specific DPU

### Motivation
- Upgrade test (sonic-mgmt PR #24005, now merged) stages images on DPUs then reboots the NPU. Post-reboot verification currently only checks liveness (`System.Time`) but not the actual running version.
- Related sonic-mgmt follow-up: sonic-net/sonic-mgmt#24246

### How I verified it
Code review — the change adds entries to a declarative registry. The forwarding mechanism is already tested in `proxy_test.go`.

### Type of change
- [x] Bug fix (missing proxy registration for existing RPCs)
