### PR TITLE
[202511] Add OS.Verify and OS.Activate to DPU proxy forwardable methods

### DIFF
--- a/pkg/interceptors/dpuproxy/proxy.go
+++ b/pkg/interceptors/dpuproxy/proxy.go
@@ -62,6 +62,16 @@ var defaultForwardableMethods = []ForwardableMethod{
 		Description: "Install package on DPU",
 		Mode:        ForwardToDPU,
 	},
+	{
+		FullMethod:  "/gnoi.os.OS/Verify",
+		Description: "Verify current OS version on DPU",
+		Mode:        ForwardToDPU,
+	},
+	{
+		FullMethod:  "/gnoi.os.OS/Activate",
+		Description: "Activate OS version on DPU",
+		Mode:        ForwardToDPU,
+	},
 	// gRPC reflection methods needed for grpcurl to work with DPU headers
 	{
 		FullMethod:  "/grpc.reflection.v1.ServerReflection/ServerReflectionInfo",


### PR DESCRIPTION
Cherry-pick of #660 to the 202511 branch.

### Description
Add `OS.Verify` and `OS.Activate` to the DPU proxy forwardable methods registry so external clients can verify/activate OS versions on individual DPUs via the NPU proxy.

These RPCs are already implemented (`gnmi_server/gnoi_os.go`, `pkg/gnoi/os/os.go`) but were not registered in `defaultForwardableMethods`, causing requests with DPU metadata headers to be rejected.

See #660 for full context.