### PR TITLE
Add OS.Verify and OS.Activate DPU proxy forwarding

### DIFF
--- a/pkg/interceptors/dpuproxy/proxy.go
+++ b/pkg/interceptors/dpuproxy/proxy.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/golang/glog"
 	gnoi_file_pb "github.com/openconfig/gnoi/file"
+	gnoi_os_pb "github.com/openconfig/gnoi/os"
 	system "github.com/openconfig/gnoi/system"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -60,6 +61,16 @@ var defaultForwardableMethods = []ForwardableMethod{
 	{
 		FullMethod:  "/gnoi.system.System/SetPackage",
 		Description: "Install package on DPU",
+		Mode:        ForwardToDPU,
+	},
+	{
+		FullMethod:  "/gnoi.os.OS/Verify",
+		Description: "Verify current OS version on DPU",
+		Mode:        ForwardToDPU,
+	},
+	{
+		FullMethod:  "/gnoi.os.OS/Activate",
+		Description: "Activate OS version on DPU",
 		Mode:        ForwardToDPU,
 	},
 	// gRPC reflection methods needed for grpcurl to work with DPU headers
@@ -248,6 +259,46 @@ func (p *DPUProxy) forwardTimeRequest(ctx context.Context, conn *grpc.ClientConn
 	}
 
 	glog.Infof("[DPUProxy] Successfully forwarded Time request to DPU, response: %v", resp)
+	return resp, nil
+}
+
+// forwardOSVerifyRequest forwards a gNOI OS.Verify request to the DPU.
+func (p *DPUProxy) forwardOSVerifyRequest(ctx context.Context, conn *grpc.ClientConn, req interface{}) (interface{}, error) {
+	verifyReq, ok := req.(*gnoi_os_pb.VerifyRequest)
+	if !ok {
+		glog.Errorf("[DPUProxy] Invalid request type for OS.Verify method: %T", req)
+		return nil, status.Errorf(codes.Internal,
+			"invalid request type for OS.Verify: expected *os.VerifyRequest, got %T", req)
+	}
+
+	client := gnoi_os_pb.NewOSClient(conn)
+	resp, err := client.Verify(ctx, verifyReq)
+	if err != nil {
+		glog.Errorf("[DPUProxy] Error forwarding OS.Verify request to DPU: %v", err)
+		return nil, err
+	}
+
+	glog.Infof("[DPUProxy] Successfully forwarded OS.Verify to DPU, version: %v", resp.GetVersion())
+	return resp, nil
+}
+
+// forwardOSActivateRequest forwards a gNOI OS.Activate request to the DPU.
+func (p *DPUProxy) forwardOSActivateRequest(ctx context.Context, conn *grpc.ClientConn, req interface{}) (interface{}, error) {
+	activateReq, ok := req.(*gnoi_os_pb.ActivateRequest)
+	if !ok {
+		glog.Errorf("[DPUProxy] Invalid request type for OS.Activate method: %T", req)
+		return nil, status.Errorf(codes.Internal,
+			"invalid request type for OS.Activate: expected *os.ActivateRequest, got %T", req)
+	}
+
+	client := gnoi_os_pb.NewOSClient(conn)
+	resp, err := client.Activate(ctx, activateReq)
+	if err != nil {
+		glog.Errorf("[DPUProxy] Error forwarding OS.Activate request to DPU: %v", err)
+		return nil, err
+	}
+
+	glog.Infof("[DPUProxy] Successfully forwarded OS.Activate to DPU")
 	return resp, nil
 }
 
@@ -477,6 +528,10 @@ func (p *DPUProxy) UnaryInterceptor() grpc.UnaryServerInterceptor {
 					switch info.FullMethod {
 					case "/gnoi.system.System/Time":
 						return p.forwardTimeRequest(ctx, conn, req)
+					case "/gnoi.os.OS/Verify":
+						return p.forwardOSVerifyRequest(ctx, conn, req)
+					case "/gnoi.os.OS/Activate":
+						return p.forwardOSActivateRequest(ctx, conn, req)
 					default:
 						// This shouldn't happen due to getForwardingMode check, but handle gracefully
 						glog.Errorf("[DPUProxy] Unknown forwardable method: %s", info.FullMethod)


### PR DESCRIPTION
### Description
Register `OS.Verify` and `OS.Activate` in the DPU proxy forwardable methods **and** implement the actual unary forwarding handlers.

PR #660 only added the registry entries but missed the forwarding handlers — requests hit the `default` case in the unary switch and returned:
```
Unimplemented: forwarding for method /gnoi.os.OS/Verify not yet implemented
```

This PR adds:
1. Registry entries for `OS.Verify` and `OS.Activate` (ForwardToDPU mode)
2. `forwardOSVerifyRequest()` — creates OS client, forwards Verify RPC to DPU
3. `forwardOSActivateRequest()` — creates OS client, forwards Activate RPC to DPU

Supersedes #660.

### Motivation
SmartSwitch upgrade verification (Phase 3) needs to confirm DPUs are running the expected OS version after upgrade via `OS.Verify` through the NPU proxy.

### How I verified it
Tested on 202511 SmartSwitch — the Unimplemented error is returned without this fix.