### PR TITLE
Add completeness test for DPU proxy ForwardToDPU handlers

### DIFF
--- a/pkg/interceptors/dpuproxy/proxy.go
+++ b/pkg/interceptors/dpuproxy/proxy.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/golang/glog"
 	gnoi_file_pb "github.com/openconfig/gnoi/file"
+	gnoi_os_pb "github.com/openconfig/gnoi/os"
 	system "github.com/openconfig/gnoi/system"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -60,6 +61,16 @@ var defaultForwardableMethods = []ForwardableMethod{
 	{
 		FullMethod:  "/gnoi.system.System/SetPackage",
 		Description: "Install package on DPU",
+		Mode:        ForwardToDPU,
+	},
+	{
+		FullMethod:  "/gnoi.os.OS/Verify",
+		Description: "Verify current OS version on DPU",
+		Mode:        ForwardToDPU,
+	},
+	{
+		FullMethod:  "/gnoi.os.OS/Activate",
+		Description: "Activate OS version on DPU",
 		Mode:        ForwardToDPU,
 	},
 	// gRPC reflection methods needed for grpcurl to work with DPU headers
@@ -248,6 +259,46 @@ func (p *DPUProxy) forwardTimeRequest(ctx context.Context, conn *grpc.ClientConn
 	}
 
 	glog.Infof("[DPUProxy] Successfully forwarded Time request to DPU, response: %v", resp)
+	return resp, nil
+}
+
+// forwardOSVerifyRequest forwards a gNOI OS.Verify request to the DPU.
+func (p *DPUProxy) forwardOSVerifyRequest(ctx context.Context, conn *grpc.ClientConn, req interface{}) (interface{}, error) {
+	verifyReq, ok := req.(*gnoi_os_pb.VerifyRequest)
+	if !ok {
+		glog.Errorf("[DPUProxy] Invalid request type for OS.Verify method: %T", req)
+		return nil, status.Errorf(codes.Internal,
+			"invalid request type for OS.Verify: expected *os.VerifyRequest, got %T", req)
+	}
+
+	client := gnoi_os_pb.NewOSClient(conn)
+	resp, err := client.Verify(ctx, verifyReq)
+	if err != nil {
+		glog.Errorf("[DPUProxy] Error forwarding OS.Verify request to DPU: %v", err)
+		return nil, err
+	}
+
+	glog.Infof("[DPUProxy] Successfully forwarded OS.Verify to DPU, version: %v", resp.GetVersion())
+	return resp, nil
+}
+
+// forwardOSActivateRequest forwards a gNOI OS.Activate request to the DPU.
+func (p *DPUProxy) forwardOSActivateRequest(ctx context.Context, conn *grpc.ClientConn, req interface{}) (interface{}, error) {
+	activateReq, ok := req.(*gnoi_os_pb.ActivateRequest)
+	if !ok {
+		glog.Errorf("[DPUProxy] Invalid request type for OS.Activate method: %T", req)
+		return nil, status.Errorf(codes.Internal,
+			"invalid request type for OS.Activate: expected *os.ActivateRequest, got %T", req)
+	}
+
+	client := gnoi_os_pb.NewOSClient(conn)
+	resp, err := client.Activate(ctx, activateReq)
+	if err != nil {
+		glog.Errorf("[DPUProxy] Error forwarding OS.Activate request to DPU: %v", err)
+		return nil, err
+	}
+
+	glog.Infof("[DPUProxy] Successfully forwarded OS.Activate to DPU")
 	return resp, nil
 }
 
@@ -477,6 +528,10 @@ func (p *DPUProxy) UnaryInterceptor() grpc.UnaryServerInterceptor {
 					switch info.FullMethod {
 					case "/gnoi.system.System/Time":
 						return p.forwardTimeRequest(ctx, conn, req)
+					case "/gnoi.os.OS/Verify":
+						return p.forwardOSVerifyRequest(ctx, conn, req)
+					case "/gnoi.os.OS/Activate":
+						return p.forwardOSActivateRequest(ctx, conn, req)
 					default:
 						// This shouldn't happen due to getForwardingMode check, but handle gracefully
 						glog.Errorf("[DPUProxy] Unknown forwardable method: %s", info.FullMethod)

--- a/pkg/interceptors/dpuproxy/proxy_test.go
+++ b/pkg/interceptors/dpuproxy/proxy_test.go
@@ -388,3 +388,30 @@ func TestDPUProxy_StreamInterceptor_NonForwardableMethod(t *testing.T) {
 		t.Errorf("Expected Unimplemented code, got: %v", st.Code())
 	}
 }
+
+// TestAllForwardToDPUMethodsHaveHandlers validates that every method registered
+// as ForwardToDPU in defaultForwardableMethods has a corresponding forwarding
+// handler implemented.
+func TestAllForwardToDPUMethodsHaveHandlers(t *testing.T) {
+	unaryHandled := map[string]bool{
+		"/gnoi.system.System/Time": true,
+		"/gnoi.os.OS/Verify":       true,
+		"/gnoi.os.OS/Activate":     true,
+	}
+
+	streamHandled := map[string]bool{
+		"/gnoi.file.File/Put":            true,
+		"/gnoi.system.System/SetPackage": true,
+	}
+
+	for _, m := range defaultForwardableMethods {
+		if m.Mode != ForwardToDPU {
+			continue
+		}
+		if !unaryHandled[m.FullMethod] && !streamHandled[m.FullMethod] {
+			t.Errorf("ForwardToDPU method %s (%s) has no forwarding handler — "+
+				"add a case to UnaryInterceptor or forwardStream AND update this test",
+				m.FullMethod, m.Description)
+		}
+	}
+}


### PR DESCRIPTION
### Description
Add `TestAllForwardToDPUMethodsHaveHandlers` which validates that every method registered as `ForwardToDPU` in `defaultForwardableMethods` has a corresponding forwarding handler implemented.

This catches the bug where a method is added to the registry but the dispatch switch/if-else is not updated, resulting in `Unimplemented: forwarding not yet implemented` at runtime (as happened with `OS.Verify` — see #663).

### How it works
The test maintains two explicit sets (`unaryHandled`, `streamHandled`) mirroring the dispatch cases. If someone adds a registry entry but forgets to update the handler AND the test, the test fails.

### Depends on
- #663 (OS.Verify/Activate handlers)

### Type of change
- [x] Test case improvement