### PR TITLE
Add DPU_COUNTERS_DB virtual path handling for DASH_METER and ENI counters

### DIFF
--- a/.azure/templates/install-dependencies.yml
+++ b/.azure/templates/install-dependencies.yml
@@ -78,6 +78,8 @@ steps:
       sudo sed -ri 's/^# unixsocket/unixsocket/' /etc/redis/redis.conf
       sudo sed -ri 's/^unixsocketperm .../unixsocketperm 777/' /etc/redis/redis.conf
       sudo sed -ri 's/redis-server.sock/redis.sock/' /etc/redis/redis.conf
+      # DPU_COUNTERS_DB uses Redis DB index 18; raise the limit from the default 16.
+      sudo sed -ri 's/^databases .*/databases 20/' /etc/redis/redis.conf
       sudo service redis-server start
     displayName: "Install test dependencies (pytest, redis)"
 

--- a/proto/sonic.pb.go
+++ b/proto/sonic.pb.go
@@ -26,6 +26,7 @@ const (
 	Target_FLEX_COUNTER_DB Target = 5
 	Target_STATE_DB        Target = 6
 	Target_CHASSIS_STATE_DB Target = 13
+	Target_DPU_COUNTERS_DB  Target = 18
 	// For none-DB data
 	Target_OTHERS Target = 100
 )
@@ -39,6 +40,7 @@ var Target_name = map[int32]string{
 	// Duplicate value: 5: "FLEX_COUNTER_DB",
 	6:   "STATE_DB",
 	13:  "CHASSIS_STATE_DB",
+	18:  "DPU_COUNTERS_DB",
 	100: "OTHERS",
 }
 var Target_value = map[string]int32{
@@ -50,6 +52,7 @@ var Target_value = map[string]int32{
 	"FLEX_COUNTER_DB":  5,
 	"STATE_DB":         6,
 	"CHASSIS_STATE_DB": 13,
+	"DPU_COUNTERS_DB": 18,
 	"OTHERS":          100,
 }
 

--- a/proto/sonic.pb.go
+++ b/proto/sonic.pb.go
@@ -22,9 +22,9 @@ const (
 	Target_COUNTERS_DB Target = 2
 	Target_CONFIG_DB   Target = 4
 	// PFC_WD_DB shares the the same db number with FLEX_COUNTER_DB
-	Target_PFC_WD_DB       Target = 5
-	Target_FLEX_COUNTER_DB Target = 5
-	Target_STATE_DB        Target = 6
+	Target_PFC_WD_DB        Target = 5
+	Target_FLEX_COUNTER_DB  Target = 5
+	Target_STATE_DB         Target = 6
 	Target_CHASSIS_STATE_DB Target = 13
 	Target_DPU_COUNTERS_DB  Target = 18
 	// For none-DB data
@@ -52,8 +52,8 @@ var Target_value = map[string]int32{
 	"FLEX_COUNTER_DB":  5,
 	"STATE_DB":         6,
 	"CHASSIS_STATE_DB": 13,
-	"DPU_COUNTERS_DB": 18,
-	"OTHERS":          100,
+	"DPU_COUNTERS_DB":  18,
+	"OTHERS":           100,
 }
 
 func (x Target) String() string {

--- a/proto/sonic.proto
+++ b/proto/sonic.proto
@@ -17,6 +17,7 @@ enum Target {
   FLEX_COUNTER_DB   = 5;
   STATE_DB          = 6;
   CHASSIS_STATE_DB  = 13;
+  DPU_COUNTERS_DB   = 18;
   // For none-DB data
   OTHERS            = 100;
 }

--- a/sonic_data_client/client_test.go
+++ b/sonic_data_client/client_test.go
@@ -2129,7 +2129,7 @@ func TestV2rEniStats(t *testing.T) {
 	}
 
 	t.Run("Wildcard_AllENIs", func(t *testing.T) {
-		paths := []string{"DPU_COUNTERS_DB", "COUNTERS", "ENI*"}
+		paths := []string{"DPU_COUNTERS_DB", "COUNTERS", "ENI", "*"}
 		tblPaths, err := v2rEniStats(paths)
 		if err != nil {
 			t.Fatalf("v2rEniStats failed: %v", err)
@@ -2153,7 +2153,7 @@ func TestV2rEniStats(t *testing.T) {
 	})
 
 	t.Run("Specific_ENI", func(t *testing.T) {
-		paths := []string{"DPU_COUNTERS_DB", "COUNTERS", "eni1"}
+		paths := []string{"DPU_COUNTERS_DB", "COUNTERS", "ENI", "eni1"}
 		tblPaths, err := v2rEniStats(paths)
 		if err != nil {
 			t.Fatalf("v2rEniStats failed: %v", err)
@@ -2167,7 +2167,7 @@ func TestV2rEniStats(t *testing.T) {
 	})
 
 	t.Run("Invalid_ENI", func(t *testing.T) {
-		paths := []string{"DPU_COUNTERS_DB", "COUNTERS", "nonexistent"}
+		paths := []string{"DPU_COUNTERS_DB", "COUNTERS", "ENI", "nonexistent"}
 		_, err := v2rEniStats(paths)
 		if err == nil {
 			t.Errorf("expected error for invalid ENI name")
@@ -2538,14 +2538,14 @@ func TestParsePathDpuCountersDb(t *testing.T) {
 	t.Run("DPU_COUNTERS_DB_ENI_VirtualPath", func(t *testing.T) {
 		pathG2S := make(map[*gnmipb.Path][]tablePath)
 		prefix := &gnmipb.Path{Target: "DPU_COUNTERS_DB"}
-		path := &gnmipb.Path{Elem: []*gnmipb.PathElem{{Name: "COUNTERS"}, {Name: "eni1"}}}
+		path := &gnmipb.Path{Elem: []*gnmipb.PathElem{{Name: "COUNTERS"}, {Name: "ENI"}, {Name: "eni1"}}}
 		err := parsePath(prefix, path, &pathG2S)
 		if err != nil {
 			t.Fatalf("parsePath failed: %v", err)
 		}
 		for _, tblPaths := range pathG2S {
 			if !tblPaths[0].isVirtualPath {
-				t.Errorf("expected isVirtualPath=true for COUNTERS/eni1")
+				t.Errorf("expected isVirtualPath=true for COUNTERS/ENI/eni1")
 			}
 			if tblPaths[0].tableKey != "oid:0xENI1" {
 				t.Errorf("expected tableKey oid:0xENI1, got %v", tblPaths[0].tableKey)

--- a/sonic_data_client/client_test.go
+++ b/sonic_data_client/client_test.go
@@ -1054,18 +1054,6 @@ func setupTestTarget2RedisDb(t *testing.T) func() {
 		t.Fatalf("useRedisTcpClient failed: %v", err)
 	}
 
-	// Remove clients whose Redis DB index exceeds the server's limit.
-	// This happens when a DB like DPU_COUNTERS_DB uses an ID (e.g. 18)
-	// above the default Redis "databases 16" setting.
-	for _, nsMap := range Target2RedisDb {
-		for dbName, rc := range nsMap {
-			if err := rc.Ping(context.Background()).Err(); err != nil {
-				rc.Close()
-				delete(nsMap, dbName)
-			}
-		}
-	}
-
 	return func() {
 		for _, nsMap := range Target2RedisDb {
 			for _, rc := range nsMap {

--- a/sonic_data_client/client_test.go
+++ b/sonic_data_client/client_test.go
@@ -1054,6 +1054,18 @@ func setupTestTarget2RedisDb(t *testing.T) func() {
 		t.Fatalf("useRedisTcpClient failed: %v", err)
 	}
 
+	// Remove clients whose Redis DB index exceeds the server's limit.
+	// This happens when a DB like DPU_COUNTERS_DB uses an ID (e.g. 18)
+	// above the default Redis "databases 16" setting.
+	for _, nsMap := range Target2RedisDb {
+		for dbName, rc := range nsMap {
+			if err := rc.Ping(context.Background()).Err(); err != nil {
+				rc.Close()
+				delete(nsMap, dbName)
+			}
+		}
+	}
+
 	return func() {
 		for _, nsMap := range Target2RedisDb {
 			for _, rc := range nsMap {

--- a/sonic_data_client/client_test.go
+++ b/sonic_data_client/client_test.go
@@ -2197,7 +2197,7 @@ func TestV2rDashMeterByEniAndClass(t *testing.T) {
 	ns := ""
 	rclient := Target2RedisDb[ns]["DPU_COUNTERS_DB"]
 	if rclient == nil {
-		t.Skip("DPU_COUNTERS_DB Redis client not available")
+		t.Fatal("DPU_COUNTERS_DB Redis client not available — ensure Redis is configured with 'databases 20'")
 	}
 
 	// Insert a DASH_METER key
@@ -2266,7 +2266,7 @@ func TestV2rDashMeterByEni(t *testing.T) {
 	ns := ""
 	rclient := Target2RedisDb[ns]["DPU_COUNTERS_DB"]
 	if rclient == nil {
-		t.Skip("DPU_COUNTERS_DB Redis client not available")
+		t.Fatal("DPU_COUNTERS_DB Redis client not available — ensure Redis is configured with 'databases 20'")
 	}
 
 	// Insert multiple DASH_METER keys
@@ -2339,7 +2339,7 @@ func TestGetDpuCountersMap(t *testing.T) {
 	ns := ""
 	rclient := Target2RedisDb[ns]["DPU_COUNTERS_DB"]
 	if rclient == nil {
-		t.Skip("DPU_COUNTERS_DB Redis client not available")
+		t.Fatal("DPU_COUNTERS_DB Redis client not available — ensure Redis is configured with 'databases 20'")
 	}
 
 	rclient.HSet(context.Background(), "COUNTERS_ENI_NAME_MAP", "eni1", "oid:0xENI1")
@@ -2377,7 +2377,7 @@ func TestGetCountersMapForDb(t *testing.T) {
 	t.Run("DPU_COUNTERS_DB", func(t *testing.T) {
 		rclient := Target2RedisDb[ns]["DPU_COUNTERS_DB"]
 		if rclient == nil {
-			t.Skip("DPU_COUNTERS_DB Redis client not available")
+			t.Fatal("DPU_COUNTERS_DB Redis client not available — ensure Redis is configured with 'databases 20'")
 		}
 		rclient.HSet(context.Background(), "TEST_MAP", "key1", "val1")
 		defer rclient.Del(context.Background(), "TEST_MAP")
@@ -2447,7 +2447,7 @@ func TestGetDashMeterKeys(t *testing.T) {
 	ns := ""
 	rclient := Target2RedisDb[ns]["DPU_COUNTERS_DB"]
 	if rclient == nil {
-		t.Skip("DPU_COUNTERS_DB Redis client not available")
+		t.Fatal("DPU_COUNTERS_DB Redis client not available — ensure Redis is configured with 'databases 20'")
 	}
 
 	// Insert test keys

--- a/sonic_data_client/client_test.go
+++ b/sonic_data_client/client_test.go
@@ -2558,6 +2558,14 @@ func TestParsePathDpuCountersDb(t *testing.T) {
 }
 
 func TestClearMappingsIncludesEniMaps(t *testing.T) {
+	// Ensure maps are initialized (may be nil if a prior test's init failed)
+	if countersEniNameMap == nil {
+		countersEniNameMap = make(map[string]string)
+	}
+	if countersEniOidNameMap == nil {
+		countersEniOidNameMap = make(map[string]string)
+	}
+
 	// Populate ENI maps
 	countersEniNameMap["test_eni"] = "oid:0xTEST"
 	countersEniOidNameMap["oid:0xTEST"] = "test_eni"

--- a/sonic_data_client/client_test.go
+++ b/sonic_data_client/client_test.go
@@ -2109,3 +2109,467 @@ func TestGetTableDashHA(t *testing.T) {
 	swsscommon.DeleteZmqClient(zmqClient)
 	swsscommon.DeleteZmqServer(zmqServer)
 }
+
+func TestV2rEniStats(t *testing.T) {
+	// Save and restore the ENI maps
+	origEniNameMap := countersEniNameMap
+	origEniOidNameMap := countersEniOidNameMap
+	defer func() {
+		countersEniNameMap = origEniNameMap
+		countersEniOidNameMap = origEniOidNameMap
+	}()
+
+	countersEniNameMap = map[string]string{
+		"eni1": "oid:0xENI1",
+		"eni2": "oid:0xENI2",
+	}
+	countersEniOidNameMap = map[string]string{
+		"oid:0xENI1": "eni1",
+		"oid:0xENI2": "eni2",
+	}
+
+	t.Run("Wildcard_AllENIs", func(t *testing.T) {
+		paths := []string{"DPU_COUNTERS_DB", "COUNTERS", "ENI*"}
+		tblPaths, err := v2rEniStats(paths)
+		if err != nil {
+			t.Fatalf("v2rEniStats failed: %v", err)
+		}
+		if len(tblPaths) != 2 {
+			t.Fatalf("expected 2 tablePaths, got %d", len(tblPaths))
+		}
+		eniFound := map[string]bool{}
+		for _, tp := range tblPaths {
+			if tp.dbName != "DPU_COUNTERS_DB" {
+				t.Errorf("expected dbName DPU_COUNTERS_DB, got %v", tp.dbName)
+			}
+			if tp.tableName != "COUNTERS" {
+				t.Errorf("expected tableName COUNTERS, got %v", tp.tableName)
+			}
+			eniFound[tp.jsonTableKey] = true
+		}
+		if !eniFound["eni1"] || !eniFound["eni2"] {
+			t.Errorf("expected both eni1 and eni2 in results, got %v", eniFound)
+		}
+	})
+
+	t.Run("Specific_ENI", func(t *testing.T) {
+		paths := []string{"DPU_COUNTERS_DB", "COUNTERS", "eni1"}
+		tblPaths, err := v2rEniStats(paths)
+		if err != nil {
+			t.Fatalf("v2rEniStats failed: %v", err)
+		}
+		if len(tblPaths) != 1 {
+			t.Fatalf("expected 1 tablePath, got %d", len(tblPaths))
+		}
+		if tblPaths[0].tableKey != "oid:0xENI1" {
+			t.Errorf("expected tableKey oid:0xENI1, got %v", tblPaths[0].tableKey)
+		}
+	})
+
+	t.Run("Invalid_ENI", func(t *testing.T) {
+		paths := []string{"DPU_COUNTERS_DB", "COUNTERS", "nonexistent"}
+		_, err := v2rEniStats(paths)
+		if err == nil {
+			t.Errorf("expected error for invalid ENI name")
+		}
+	})
+}
+
+func TestV2rDashMeterByEniAndClass(t *testing.T) {
+	cleanup := setupTestTarget2RedisDb(t)
+	defer cleanup()
+
+	// Save and restore the ENI maps
+	origEniNameMap := countersEniNameMap
+	origEniOidNameMap := countersEniOidNameMap
+	defer func() {
+		countersEniNameMap = origEniNameMap
+		countersEniOidNameMap = origEniOidNameMap
+	}()
+
+	countersEniNameMap = map[string]string{
+		"eni1": "oid:0xENI1",
+	}
+	countersEniOidNameMap = map[string]string{
+		"oid:0xENI1": "eni1",
+	}
+
+	ns := ""
+	rclient := Target2RedisDb[ns]["DPU_COUNTERS_DB"]
+	if rclient == nil {
+		t.Skip("DPU_COUNTERS_DB Redis client not available")
+	}
+
+	// Insert a DASH_METER key
+	dashKey := `COUNTERS:{"eni_id":"oid:0xENI1","meter_class":"100","switch_id":"oid:0xSW1"}`
+	rclient.HSet(context.Background(), dashKey, "bytes", "1000", "packets", "10")
+	defer rclient.Del(context.Background(), dashKey)
+
+	t.Run("Specific_ENI_And_Class", func(t *testing.T) {
+		paths := []string{"DPU_COUNTERS_DB", "DASH_METER", "eni1", "100"}
+		tblPaths, err := v2rDashMeterByEniAndClass(paths)
+		if err != nil {
+			t.Fatalf("v2rDashMeterByEniAndClass failed: %v", err)
+		}
+		if len(tblPaths) != 1 {
+			t.Fatalf("expected 1 tablePath, got %d", len(tblPaths))
+		}
+		if tblPaths[0].dbName != "DPU_COUNTERS_DB" {
+			t.Errorf("expected dbName DPU_COUNTERS_DB, got %v", tblPaths[0].dbName)
+		}
+		if tblPaths[0].tableName != "COUNTERS" {
+			t.Errorf("expected tableName COUNTERS, got %v", tblPaths[0].tableName)
+		}
+		if tblPaths[0].jsonTableKey != "100" {
+			t.Errorf("expected jsonTableKey '100', got %v", tblPaths[0].jsonTableKey)
+		}
+	})
+
+	t.Run("Invalid_ENI", func(t *testing.T) {
+		paths := []string{"DPU_COUNTERS_DB", "DASH_METER", "bad_eni", "100"}
+		_, err := v2rDashMeterByEniAndClass(paths)
+		if err == nil {
+			t.Errorf("expected error for invalid ENI name")
+		}
+	})
+
+	t.Run("NoMatching_Class", func(t *testing.T) {
+		paths := []string{"DPU_COUNTERS_DB", "DASH_METER", "eni1", "999"}
+		_, err := v2rDashMeterByEniAndClass(paths)
+		if err == nil {
+			t.Errorf("expected error when no matching meter class")
+		}
+	})
+}
+
+func TestV2rDashMeterByEni(t *testing.T) {
+	cleanup := setupTestTarget2RedisDb(t)
+	defer cleanup()
+
+	// Save and restore the ENI maps
+	origEniNameMap := countersEniNameMap
+	origEniOidNameMap := countersEniOidNameMap
+	defer func() {
+		countersEniNameMap = origEniNameMap
+		countersEniOidNameMap = origEniOidNameMap
+	}()
+
+	countersEniNameMap = map[string]string{
+		"eni1": "oid:0xENI1",
+		"eni2": "oid:0xENI2",
+	}
+	countersEniOidNameMap = map[string]string{
+		"oid:0xENI1": "eni1",
+		"oid:0xENI2": "eni2",
+	}
+
+	ns := ""
+	rclient := Target2RedisDb[ns]["DPU_COUNTERS_DB"]
+	if rclient == nil {
+		t.Skip("DPU_COUNTERS_DB Redis client not available")
+	}
+
+	// Insert multiple DASH_METER keys
+	key1 := `COUNTERS:{"eni_id":"oid:0xENI1","meter_class":"100","switch_id":"oid:0xSW1"}`
+	key2 := `COUNTERS:{"eni_id":"oid:0xENI1","meter_class":"200","switch_id":"oid:0xSW1"}`
+	key3 := `COUNTERS:{"eni_id":"oid:0xENI2","meter_class":"100","switch_id":"oid:0xSW1"}`
+	// Also insert a non-JSON COUNTERS key that should be skipped
+	key4 := "COUNTERS:oid:0x1000000000039"
+	rclient.HSet(context.Background(), key1, "bytes", "1000")
+	rclient.HSet(context.Background(), key2, "bytes", "2000")
+	rclient.HSet(context.Background(), key3, "bytes", "3000")
+	rclient.HSet(context.Background(), key4, "SAI_PORT_STAT_IF_IN_OCTETS", "999")
+	defer func() {
+		rclient.Del(context.Background(), key1, key2, key3, key4)
+	}()
+
+	t.Run("Specific_ENI_AllClasses", func(t *testing.T) {
+		paths := []string{"DPU_COUNTERS_DB", "DASH_METER", "eni1"}
+		tblPaths, err := v2rDashMeterByEni(paths)
+		if err != nil {
+			t.Fatalf("v2rDashMeterByEni failed: %v", err)
+		}
+		if len(tblPaths) != 2 {
+			t.Fatalf("expected 2 tablePaths for eni1, got %d", len(tblPaths))
+		}
+		classFound := map[string]bool{}
+		for _, tp := range tblPaths {
+			classFound[tp.jsonTableKey] = true
+			if tp.dbName != "DPU_COUNTERS_DB" {
+				t.Errorf("expected dbName DPU_COUNTERS_DB, got %v", tp.dbName)
+			}
+		}
+		if !classFound["100"] || !classFound["200"] {
+			t.Errorf("expected classes 100 and 200, got %v", classFound)
+		}
+	})
+
+	t.Run("Wildcard_AllENIs_AllClasses", func(t *testing.T) {
+		paths := []string{"DPU_COUNTERS_DB", "DASH_METER", "*"}
+		tblPaths, err := v2rDashMeterByEni(paths)
+		if err != nil {
+			t.Fatalf("v2rDashMeterByEni failed: %v", err)
+		}
+		if len(tblPaths) != 3 {
+			t.Fatalf("expected 3 tablePaths for all ENIs, got %d", len(tblPaths))
+		}
+		keyFound := map[string]bool{}
+		for _, tp := range tblPaths {
+			keyFound[tp.jsonTableKey] = true
+		}
+		// Wildcard uses "eniName/class" format
+		if !keyFound["eni1/100"] || !keyFound["eni1/200"] || !keyFound["eni2/100"] {
+			t.Errorf("expected eni1/100, eni1/200, eni2/100 in results, got %v", keyFound)
+		}
+	})
+
+	t.Run("Invalid_ENI", func(t *testing.T) {
+		paths := []string{"DPU_COUNTERS_DB", "DASH_METER", "bad_eni"}
+		_, err := v2rDashMeterByEni(paths)
+		if err == nil {
+			t.Errorf("expected error for invalid ENI name")
+		}
+	})
+}
+
+func TestGetDpuCountersMap(t *testing.T) {
+	cleanup := setupTestTarget2RedisDb(t)
+	defer cleanup()
+
+	ns := ""
+	rclient := Target2RedisDb[ns]["DPU_COUNTERS_DB"]
+	if rclient == nil {
+		t.Skip("DPU_COUNTERS_DB Redis client not available")
+	}
+
+	rclient.HSet(context.Background(), "COUNTERS_ENI_NAME_MAP", "eni1", "oid:0xENI1")
+	defer rclient.Del(context.Background(), "COUNTERS_ENI_NAME_MAP")
+
+	result, err := GetDpuCountersMap("COUNTERS_ENI_NAME_MAP")
+	if err != nil {
+		t.Fatalf("GetDpuCountersMap failed: %v", err)
+	}
+	if result["eni1"] != "oid:0xENI1" {
+		t.Errorf("expected eni1->oid:0xENI1, got %v", result)
+	}
+}
+
+func TestGetCountersMapForDb(t *testing.T) {
+	cleanup := setupTestTarget2RedisDb(t)
+	defer cleanup()
+
+	ns := ""
+
+	t.Run("COUNTERS_DB", func(t *testing.T) {
+		rclient := Target2RedisDb[ns]["COUNTERS_DB"]
+		rclient.HSet(context.Background(), "COUNTERS_PORT_NAME_MAP", "Ethernet0", "oid:0x100")
+		defer rclient.Del(context.Background(), "COUNTERS_PORT_NAME_MAP")
+
+		result, err := GetCountersMapForDb("COUNTERS_DB", "COUNTERS_PORT_NAME_MAP")
+		if err != nil {
+			t.Fatalf("GetCountersMapForDb failed: %v", err)
+		}
+		if result["Ethernet0"] != "oid:0x100" {
+			t.Errorf("expected Ethernet0->oid:0x100, got %v", result)
+		}
+	})
+
+	t.Run("DPU_COUNTERS_DB", func(t *testing.T) {
+		rclient := Target2RedisDb[ns]["DPU_COUNTERS_DB"]
+		if rclient == nil {
+			t.Skip("DPU_COUNTERS_DB Redis client not available")
+		}
+		rclient.HSet(context.Background(), "TEST_MAP", "key1", "val1")
+		defer rclient.Del(context.Background(), "TEST_MAP")
+
+		result, err := GetCountersMapForDb("DPU_COUNTERS_DB", "TEST_MAP")
+		if err != nil {
+			t.Fatalf("GetCountersMapForDb failed: %v", err)
+		}
+		if result["key1"] != "val1" {
+			t.Errorf("expected key1->val1, got %v", result)
+		}
+	})
+}
+
+func TestInitCountersEniNameMap(t *testing.T) {
+	origFn := getDpuCountersMapFn
+	defer func() { getDpuCountersMapFn = origFn }()
+
+	t.Run("Success", func(t *testing.T) {
+		os.Setenv("UNIT_TEST", "1")
+		ClearMappings()
+		os.Unsetenv("UNIT_TEST")
+
+		getDpuCountersMapFn = func(tableName string) (map[string]string, error) {
+			switch tableName {
+			case "COUNTERS_ENI_NAME_MAP":
+				return map[string]string{"eni1": "oid:0xENI1"}, nil
+			case "COUNTERS_ENI_OID_NAME_MAP":
+				return map[string]string{"oid:0xENI1": "eni1"}, nil
+			default:
+				return nil, fmt.Errorf("unexpected table %s", tableName)
+			}
+		}
+
+		err := initCountersEniNameMap()
+		if err != nil {
+			t.Fatalf("initCountersEniNameMap failed: %v", err)
+		}
+		if countersEniNameMap["eni1"] != "oid:0xENI1" {
+			t.Errorf("expected eni1->oid:0xENI1, got %v", countersEniNameMap)
+		}
+		if countersEniOidNameMap["oid:0xENI1"] != "eni1" {
+			t.Errorf("expected oid:0xENI1->eni1, got %v", countersEniOidNameMap)
+		}
+	})
+
+	t.Run("Error_NameMap", func(t *testing.T) {
+		os.Setenv("UNIT_TEST", "1")
+		ClearMappings()
+		os.Unsetenv("UNIT_TEST")
+
+		getDpuCountersMapFn = func(tableName string) (map[string]string, error) {
+			return nil, fmt.Errorf("redis error")
+		}
+
+		err := initCountersEniNameMap()
+		if err == nil {
+			t.Errorf("expected error when COUNTERS_ENI_NAME_MAP fails")
+		}
+	})
+}
+
+func TestGetDashMeterKeys(t *testing.T) {
+	cleanup := setupTestTarget2RedisDb(t)
+	defer cleanup()
+
+	ns := ""
+	rclient := Target2RedisDb[ns]["DPU_COUNTERS_DB"]
+	if rclient == nil {
+		t.Skip("DPU_COUNTERS_DB Redis client not available")
+	}
+
+	// Insert test keys
+	key1 := `COUNTERS:{"eni_id":"oid:0xENI1","meter_class":"100","switch_id":"oid:0xSW1"}`
+	key2 := `COUNTERS:{"eni_id":"oid:0xENI2","meter_class":"200","switch_id":"oid:0xSW1"}`
+	// Non-JSON key that should be skipped
+	key3 := "COUNTERS:oid:0x1000000000039"
+	rclient.HSet(context.Background(), key1, "bytes", "1000")
+	rclient.HSet(context.Background(), key2, "bytes", "2000")
+	rclient.HSet(context.Background(), key3, "SAI_PORT_STAT_IF_IN_OCTETS", "999")
+	defer func() {
+		rclient.Del(context.Background(), key1, key2, key3)
+	}()
+
+	t.Run("All_Keys", func(t *testing.T) {
+		results, err := getDashMeterKeys(rclient, ":", "", "")
+		if err != nil {
+			t.Fatalf("getDashMeterKeys failed: %v", err)
+		}
+		if len(results) != 2 {
+			t.Fatalf("expected 2 results (non-JSON key skipped), got %d", len(results))
+		}
+	})
+
+	t.Run("Filter_By_ENI", func(t *testing.T) {
+		results, err := getDashMeterKeys(rclient, ":", "oid:0xENI1", "")
+		if err != nil {
+			t.Fatalf("getDashMeterKeys failed: %v", err)
+		}
+		if len(results) != 1 {
+			t.Fatalf("expected 1 result for ENI1, got %d", len(results))
+		}
+		if results[0].eniOid != "oid:0xENI1" {
+			t.Errorf("expected eniOid oid:0xENI1, got %v", results[0].eniOid)
+		}
+	})
+
+	t.Run("Filter_By_ENI_And_Class", func(t *testing.T) {
+		results, err := getDashMeterKeys(rclient, ":", "oid:0xENI1", "100")
+		if err != nil {
+			t.Fatalf("getDashMeterKeys failed: %v", err)
+		}
+		if len(results) != 1 {
+			t.Fatalf("expected 1 result, got %d", len(results))
+		}
+		if results[0].meterClass != "100" {
+			t.Errorf("expected meterClass 100, got %v", results[0].meterClass)
+		}
+	})
+
+	t.Run("No_Match", func(t *testing.T) {
+		results, err := getDashMeterKeys(rclient, ":", "oid:0xNONEXISTENT", "")
+		if err != nil {
+			t.Fatalf("getDashMeterKeys failed: %v", err)
+		}
+		if len(results) != 0 {
+			t.Errorf("expected 0 results, got %d", len(results))
+		}
+	})
+}
+
+func TestParsePathDpuCountersDb(t *testing.T) {
+	// Save and restore the ENI maps
+	origEniNameMap := countersEniNameMap
+	origEniOidNameMap := countersEniOidNameMap
+	origFn := getDpuCountersMapFn
+	defer func() {
+		countersEniNameMap = origEniNameMap
+		countersEniOidNameMap = origEniOidNameMap
+		getDpuCountersMapFn = origFn
+	}()
+
+	getDpuCountersMapFn = func(tableName string) (map[string]string, error) {
+		switch tableName {
+		case "COUNTERS_ENI_NAME_MAP":
+			return map[string]string{"eni1": "oid:0xENI1"}, nil
+		case "COUNTERS_ENI_OID_NAME_MAP":
+			return map[string]string{"oid:0xENI1": "eni1"}, nil
+		default:
+			return nil, fmt.Errorf("unexpected table %s", tableName)
+		}
+	}
+
+	os.Setenv("UNIT_TEST", "1")
+	ClearMappings()
+	os.Unsetenv("UNIT_TEST")
+
+	t.Run("DPU_COUNTERS_DB_ENI_VirtualPath", func(t *testing.T) {
+		pathG2S := make(map[*gnmipb.Path][]tablePath)
+		prefix := &gnmipb.Path{Target: "DPU_COUNTERS_DB"}
+		path := &gnmipb.Path{Elem: []*gnmipb.PathElem{{Name: "COUNTERS"}, {Name: "eni1"}}}
+		err := parsePath(prefix, path, &pathG2S)
+		if err != nil {
+			t.Fatalf("parsePath failed: %v", err)
+		}
+		for _, tblPaths := range pathG2S {
+			if !tblPaths[0].isVirtualPath {
+				t.Errorf("expected isVirtualPath=true for COUNTERS/eni1")
+			}
+			if tblPaths[0].tableKey != "oid:0xENI1" {
+				t.Errorf("expected tableKey oid:0xENI1, got %v", tblPaths[0].tableKey)
+			}
+			if tblPaths[0].dbName != "DPU_COUNTERS_DB" {
+				t.Errorf("expected dbName DPU_COUNTERS_DB, got %v", tblPaths[0].dbName)
+			}
+		}
+	})
+}
+
+func TestClearMappingsIncludesEniMaps(t *testing.T) {
+	// Populate ENI maps
+	countersEniNameMap["test_eni"] = "oid:0xTEST"
+	countersEniOidNameMap["oid:0xTEST"] = "test_eni"
+
+	os.Setenv("UNIT_TEST", "1")
+	ClearMappings()
+	os.Unsetenv("UNIT_TEST")
+
+	if len(countersEniNameMap) != 0 {
+		t.Errorf("expected countersEniNameMap to be cleared, got %v", countersEniNameMap)
+	}
+	if len(countersEniOidNameMap) != 0 {
+		t.Errorf("expected countersEniOidNameMap to be cleared, got %v", countersEniOidNameMap)
+	}
+}

--- a/sonic_data_client/client_test.go
+++ b/sonic_data_client/client_test.go
@@ -2372,7 +2372,7 @@ func TestV2rDashMeterByEni(t *testing.T) {
 	})
 }
 
-func TestGetDpuCountersMap(t *testing.T) {
+func TestGetDpuCountersMapForDb(t *testing.T) {
 	cleanup := setupTestTarget2RedisDb(t)
 	defer cleanup()
 
@@ -2385,9 +2385,9 @@ func TestGetDpuCountersMap(t *testing.T) {
 	rclient.HSet(context.Background(), "COUNTERS_ENI_NAME_MAP", "eni1", "oid:0xENI1")
 	defer rclient.Del(context.Background(), "COUNTERS_ENI_NAME_MAP")
 
-	result, err := GetDpuCountersMap("COUNTERS_ENI_NAME_MAP")
+	result, err := GetCountersMapForDb("DPU_COUNTERS_DB", "COUNTERS_ENI_NAME_MAP")
 	if err != nil {
-		t.Fatalf("GetDpuCountersMap failed: %v", err)
+		t.Fatalf("GetCountersMapForDb for DPU_COUNTERS_DB failed: %v", err)
 	}
 	if result["eni1"] != "oid:0xENI1" {
 		t.Errorf("expected eni1->oid:0xENI1, got %v", result)
@@ -2476,6 +2476,27 @@ func TestInitCountersEniNameMap(t *testing.T) {
 		err := initCountersEniNameMap()
 		if err == nil {
 			t.Errorf("expected error when COUNTERS_ENI_NAME_MAP fails")
+		}
+	})
+
+	t.Run("Error_OidNameMap_NilsOutNameMap", func(t *testing.T) {
+		os.Setenv("UNIT_TEST", "1")
+		ClearMappings()
+		os.Unsetenv("UNIT_TEST")
+
+		getDpuCountersMapFn = func(tableName string) (map[string]string, error) {
+			if tableName == "COUNTERS_ENI_NAME_MAP" {
+				return map[string]string{"eni1": "oid:0xENI1"}, nil
+			}
+			return nil, fmt.Errorf("redis error on OID map")
+		}
+
+		err := initCountersEniNameMap()
+		if err == nil {
+			t.Errorf("expected error when COUNTERS_ENI_OID_NAME_MAP fails")
+		}
+		if countersEniNameMap != nil {
+			t.Errorf("expected countersEniNameMap to be nil after partial failure, got %v", countersEniNameMap)
 		}
 	})
 }

--- a/sonic_data_client/client_test.go
+++ b/sonic_data_client/client_test.go
@@ -2240,6 +2240,46 @@ func TestV2rDashMeterByEniAndClass(t *testing.T) {
 			t.Errorf("expected error when no matching meter class")
 		}
 	})
+
+	t.Run("Wildcard_ENI_Specific_Class", func(t *testing.T) {
+		// Add a second ENI with the same meter class and a different class key
+		countersEniNameMap["eni2"] = "oid:0xENI2"
+		countersEniOidNameMap["oid:0xENI2"] = "eni2"
+		dashKey2 := `COUNTERS:{"eni_id":"oid:0xENI2","meter_class":"100","switch_id":"oid:0xSW1"}`
+		dashKey3 := `COUNTERS:{"eni_id":"oid:0xENI2","meter_class":"200","switch_id":"oid:0xSW1"}`
+		rclient.HSet(context.Background(), dashKey2, "bytes", "2000", "packets", "20")
+		rclient.HSet(context.Background(), dashKey3, "bytes", "3000", "packets", "30")
+		defer rclient.Del(context.Background(), dashKey2)
+		defer rclient.Del(context.Background(), dashKey3)
+		defer func() {
+			delete(countersEniNameMap, "eni2")
+			delete(countersEniOidNameMap, "oid:0xENI2")
+		}()
+
+		paths := []string{"DPU_COUNTERS_DB", "DASH_METER", "*", "100"}
+		tblPaths, err := v2rDashMeterByEniAndClass(paths)
+		if err != nil {
+			t.Fatalf("v2rDashMeterByEniAndClass wildcard failed: %v", err)
+		}
+		if len(tblPaths) != 2 {
+			t.Fatalf("expected 2 tablePaths for wildcard ENI, got %d", len(tblPaths))
+		}
+		// Verify exact jsonTableKeys returned
+		keyFound := map[string]bool{}
+		for _, tp := range tblPaths {
+			if tp.tableName != "COUNTERS" {
+				t.Errorf("expected tableName COUNTERS, got %v", tp.tableName)
+			}
+			keyFound[tp.jsonTableKey] = true
+		}
+		if !keyFound["eni1/100"] || !keyFound["eni2/100"] {
+			t.Errorf("expected eni1/100 and eni2/100, got %v", keyFound)
+		}
+		// class 200 must not be returned when filtering for class 100
+		if keyFound["eni2/200"] {
+			t.Errorf("class 200 should not be returned when filtering for class 100")
+		}
+	})
 }
 
 func TestV2rDashMeterByEni(t *testing.T) {

--- a/sonic_data_client/client_test.go
+++ b/sonic_data_client/client_test.go
@@ -2595,6 +2595,88 @@ func TestParsePathDpuCountersDb(t *testing.T) {
 			}
 		}
 	})
+
+	// Non-virtual (direct) DPU_COUNTERS_DB path should work regardless of ENI map state
+	t.Run("DPU_COUNTERS_DB_DirectPath", func(t *testing.T) {
+		pathG2S := make(map[*gnmipb.Path][]tablePath)
+		prefix := &gnmipb.Path{Target: "DPU_COUNTERS_DB"}
+		path := &gnmipb.Path{Elem: []*gnmipb.PathElem{{Name: "SOME_TABLE"}, {Name: "some_key"}}}
+		err := parsePath(prefix, path, &pathG2S)
+		if err != nil {
+			t.Fatalf("parsePath failed for direct DPU_COUNTERS_DB path: %v", err)
+		}
+		for _, tblPaths := range pathG2S {
+			if tblPaths[0].isVirtualPath {
+				t.Errorf("expected isVirtualPath=false for direct path")
+			}
+			if tblPaths[0].dbName != "DPU_COUNTERS_DB" {
+				t.Errorf("expected dbName DPU_COUNTERS_DB, got %v", tblPaths[0].dbName)
+			}
+			if tblPaths[0].tableName != "SOME_TABLE" {
+				t.Errorf("expected tableName SOME_TABLE, got %v", tblPaths[0].tableName)
+			}
+			if tblPaths[0].tableKey != "some_key" {
+				t.Errorf("expected tableKey some_key, got %v", tblPaths[0].tableKey)
+			}
+		}
+	})
+}
+
+// TestParsePathDpuCountersDb_EniMapInitFails verifies that parsePath does not
+// return an error when initCountersEniNameMap fails (e.g., ENI mapping tables
+// don't exist in DPU_COUNTERS_DB or DPU_COUNTERS_DB is unavailable). This
+// ensures non-ENI DPU_COUNTERS_DB paths and other DB paths are unaffected.
+func TestParsePathDpuCountersDb_EniMapInitFails(t *testing.T) {
+	origEniNameMap := countersEniNameMap
+	origEniOidNameMap := countersEniOidNameMap
+	origFn := getDpuCountersMapFn
+	defer func() {
+		countersEniNameMap = origEniNameMap
+		countersEniOidNameMap = origEniOidNameMap
+		getDpuCountersMapFn = origFn
+	}()
+
+	// Simulate DPU_COUNTERS_DB not having ENI mapping tables (or DB not existing)
+	getDpuCountersMapFn = func(tableName string) (map[string]string, error) {
+		return nil, fmt.Errorf("DPU_COUNTERS_DB not available")
+	}
+
+	os.Setenv("UNIT_TEST", "1")
+	ClearMappings()
+	os.Unsetenv("UNIT_TEST")
+
+	t.Run("DirectPath_Succeeds", func(t *testing.T) {
+		pathG2S := make(map[*gnmipb.Path][]tablePath)
+		prefix := &gnmipb.Path{Target: "DPU_COUNTERS_DB"}
+		path := &gnmipb.Path{Elem: []*gnmipb.PathElem{{Name: "SOME_TABLE"}, {Name: "some_key"}}}
+		err := parsePath(prefix, path, &pathG2S)
+		if err != nil {
+			t.Fatalf("parsePath should not fail for direct path when ENI init fails: %v", err)
+		}
+		for _, tblPaths := range pathG2S {
+			if tblPaths[0].isVirtualPath {
+				t.Errorf("expected isVirtualPath=false for direct path")
+			}
+			if tblPaths[0].tableName != "SOME_TABLE" {
+				t.Errorf("expected tableName SOME_TABLE, got %v", tblPaths[0].tableName)
+			}
+		}
+	})
+
+	t.Run("OtherDb_Unaffected", func(t *testing.T) {
+		pathG2S := make(map[*gnmipb.Path][]tablePath)
+		prefix := &gnmipb.Path{Target: "STATE_DB"}
+		path := &gnmipb.Path{Elem: []*gnmipb.PathElem{{Name: "NEIGH_STATE_TABLE"}, {Name: "10.0.0.57"}}}
+		err := parsePath(prefix, path, &pathG2S)
+		if err != nil {
+			t.Fatalf("parsePath for STATE_DB should not be affected by DPU init failure: %v", err)
+		}
+		for _, tblPaths := range pathG2S {
+			if tblPaths[0].tableKey != "10.0.0.57" {
+				t.Errorf("expected tableKey 10.0.0.57, got %v", tblPaths[0].tableKey)
+			}
+		}
+	})
 }
 
 func TestClearMappingsIncludesEniMaps(t *testing.T) {

--- a/sonic_data_client/db_client.go
+++ b/sonic_data_client/db_client.go
@@ -683,6 +683,13 @@ func parsePath(prefix, path *gnmipb.Path, pathG2S *map[*gnmipb.Path][]tablePath)
 		}
 	}
 
+	if targetDbName == "DPU_COUNTERS_DB" {
+		err := initCountersEniNameMap()
+		if err != nil {
+			return err
+		}
+	}
+
 	fullPath := path
 	if prefix != nil {
 		fullPath = gnmiFullPath(prefix, path)

--- a/sonic_data_client/db_client.go
+++ b/sonic_data_client/db_client.go
@@ -686,7 +686,7 @@ func parsePath(prefix, path *gnmipb.Path, pathG2S *map[*gnmipb.Path][]tablePath)
 	if targetDbName == "DPU_COUNTERS_DB" {
 		err := initCountersEniNameMap()
 		if err != nil {
-			return err
+			log.Errorf("Could not create CountersEniNameMap: %v", err)
 		}
 	}
 

--- a/sonic_data_client/virtual_db.go
+++ b/sonic_data_client/virtual_db.go
@@ -131,7 +131,7 @@ var (
 			path:      []string{"COUNTERS_DB", "PORT_PHY_ATTR", "Ethernet*", "*"},
 			transFunc: v2rTranslate(v2rPortPhyAttrFieldStats),
 		}, { // ENI counters stats for one or all ENIs in DPU_COUNTERS_DB
-			path:      []string{"DPU_COUNTERS_DB", "COUNTERS", "ENI*"},
+			path:      []string{"DPU_COUNTERS_DB", "COUNTERS", "ENI", "*"},
 			transFunc: v2rTranslate(v2rEniStats),
 		}, { // DASH_METER stats for specific ENI and metering class
 			path:      []string{"DPU_COUNTERS_DB", "DASH_METER", "*", "*"},
@@ -1306,7 +1306,7 @@ func getDashMeterKeys(redisDb *redis.Client, separator string, eniOid string, me
 }
 
 // v2rEniStats translates virtual ENI counter paths to real Redis paths.
-// Handles: [DPU_COUNTERS_DB COUNTERS ENI*] and [DPU_COUNTERS_DB COUNTERS <eni_name>]
+// Handles: [DPU_COUNTERS_DB COUNTERS ENI *] and [DPU_COUNTERS_DB COUNTERS ENI <eni_name>]
 func v2rEniStats(paths []string) ([]tablePath, error) {
 	clearMappingsMu.RLock()
 	defer clearMappingsMu.RUnlock()
@@ -1314,7 +1314,7 @@ func v2rEniStats(paths []string) ([]tablePath, error) {
 	namespace, _ := sdcfg.GetDbDefaultNamespace()
 	separator, _ := GetTableKeySeparator(paths[DbIdx], namespace)
 
-	if strings.HasSuffix(paths[KeyIdx], "*") { // All ENIs
+	if strings.HasSuffix(paths[FieldIdx], "*") { // All ENIs
 		for eniName, oid := range countersEniNameMap {
 			tblPath := tablePath{
 				dbNamespace:  namespace,
@@ -1327,7 +1327,7 @@ func v2rEniStats(paths []string) ([]tablePath, error) {
 			tblPaths = append(tblPaths, tblPath)
 		}
 	} else { // specific ENI
-		eniName := paths[KeyIdx]
+		eniName := paths[FieldIdx]
 		oid, ok := countersEniNameMap[eniName]
 		if !ok {
 			return nil, fmt.Errorf("%v not a valid ENI name", eniName)

--- a/sonic_data_client/virtual_db.go
+++ b/sonic_data_client/virtual_db.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -10,6 +11,7 @@ import (
 	sdcfg "github.com/sonic-net/sonic-gnmi/sonic_db_config"
 
 	log "github.com/golang/glog"
+	"github.com/redis/go-redis/v9"
 )
 
 // virtual db is to Handle
@@ -65,6 +67,11 @@ var (
 	// SONiC Switch ID to Switch Stat packet integrity drop counters
 	countersDebugNameSwitchStatMap = make(map[string]string)
 
+	// ENI name to OID map in COUNTERS_ENI_NAME_MAP of DPU_COUNTERS_DB
+	countersEniNameMap = make(map[string]string)
+	// ENI OID to name map in COUNTERS_ENI_OID_NAME_MAP of DPU_COUNTERS_DB
+	countersEniOidNameMap = make(map[string]string)
+
 	// sync.Once guards for each init function
 	initCountersPortNameMapOnce       sync.Once
 	initCountersQueueNameMapOnce      sync.Once
@@ -74,6 +81,7 @@ var (
 	initAliasMapOnce                  sync.Once
 	initCountersPfcwdNameMapOnce      sync.Once
 	initCountersFabricPortNameMapOnce sync.Once
+	initCountersEniNameMapOnce        sync.Once
 
 	// Mutex to protect ClearMappings from racing with init functions
 	clearMappingsMu sync.RWMutex
@@ -122,6 +130,15 @@ var (
 		}, { // specific field stats for PORT_PHY_ATTR for one or all Ethernet ports (no alias translation)
 			path:      []string{"COUNTERS_DB", "PORT_PHY_ATTR", "Ethernet*", "*"},
 			transFunc: v2rTranslate(v2rPortPhyAttrFieldStats),
+		}, { // ENI counters stats for one or all ENIs in DPU_COUNTERS_DB
+			path:      []string{"DPU_COUNTERS_DB", "COUNTERS", "ENI*"},
+			transFunc: v2rTranslate(v2rEniStats),
+		}, { // DASH_METER stats for specific ENI and metering class
+			path:      []string{"DPU_COUNTERS_DB", "DASH_METER", "*", "*"},
+			transFunc: v2rTranslate(v2rDashMeterByEniAndClass),
+		}, { // DASH_METER stats for all metering classes of a specific ENI (or all ENIs)
+			path:      []string{"DPU_COUNTERS_DB", "DASH_METER", "*"},
+			transFunc: v2rTranslate(v2rDashMeterByEni),
 		},
 	}
 )
@@ -133,6 +150,7 @@ var (
 	getAliasMapFn          = func() (map[string]string, map[string]string, map[string]string, error) { return GetAliasMap() }
 	getFabricCountersMapFn = func(t string) (map[string]string, error) { return GetFabricCountersMap(t) }
 	getPfcwdMapFn          = func() (map[string]map[string]string, error) { return GetPfcwdMap() }
+	getDpuCountersMapFn    = func(t string) (map[string]string, error) { return GetDpuCountersMap(t) }
 )
 
 func (t *Trie) v2rTriePopulate() {
@@ -285,6 +303,25 @@ func initDebugNameSwitchStatMap() error {
 		}
 	}
 	return nil
+}
+
+func initCountersEniNameMap() error {
+	clearMappingsMu.RLock()
+	defer clearMappingsMu.RUnlock()
+	var initErr error
+	initCountersEniNameMapOnce.Do(func() {
+		var err error
+		countersEniNameMap, err = getDpuCountersMapFn("COUNTERS_ENI_NAME_MAP")
+		if err != nil {
+			initErr = err
+			return
+		}
+		countersEniOidNameMap, err = getDpuCountersMapFn("COUNTERS_ENI_OID_NAME_MAP")
+		if err != nil {
+			initErr = err
+		}
+	})
+	return initErr
 }
 
 // Get the mapping between sonic interface name and oids of their PFC-WD enabled queues in COUNTERS_DB
@@ -495,6 +532,31 @@ func GetFabricCountersMap(tableName string) (map[string]string, error) {
 		log.V(6).Infof("tableName: %s in namespace %v, map %v", tableName, namespace, namespaceFv)
 	}
 	return counter_map, nil
+}
+
+// GetCountersMapForDb retrieves a hash map from the specified DB.
+// This is a generalized version of GetCountersMap that accepts a DB name.
+func GetCountersMapForDb(dbName string, tableName string) (map[string]string, error) {
+	counter_map := make(map[string]string)
+	redis_client_map, err := GetRedisClientsForDb(dbName)
+	if err != nil {
+		return nil, err
+	}
+	for namespace, redisDb := range redis_client_map {
+		fv, err := redisDb.HGetAll(context.Background(), tableName).Result()
+		if err != nil {
+			log.V(2).Infof("redis HGetAll failed for %s in namespace %v, tableName: %s", dbName, namespace, tableName)
+			return nil, err
+		}
+		addmap(counter_map, fv)
+		log.V(6).Infof("tableName: %s in namespace %v, map %v", tableName, namespace, fv)
+	}
+	return counter_map, nil
+}
+
+// GetDpuCountersMap retrieves a hash map from DPU_COUNTERS_DB.
+func GetDpuCountersMap(tableName string) (map[string]string, error) {
+	return GetCountersMapForDb("DPU_COUNTERS_DB", tableName)
 }
 
 // Populate real data paths from paths like
@@ -1189,6 +1251,210 @@ func v2rEthPortPGPeriodicWMs(paths []string) ([]tablePath, error) {
 	return tblPaths, nil
 }
 
+// dashMeterKeyInfo holds parsed components of a DASH_METER JSON-formatted Redis key.
+type dashMeterKeyInfo struct {
+	fullKey    string // full Redis key, e.g. COUNTERS:{"eni_id":"oid:0x1","meter_class":"1","switch_id":"oid:0x2"}
+	eniOid     string
+	meterClass string
+	switchOid  string
+}
+
+// getDashMeterKeys scans DPU_COUNTERS_DB for DASH_METER keys (COUNTERS:{...} with JSON payloads)
+// and returns parsed key info. If eniOid is non-empty, only keys matching that ENI OID are returned.
+// If meterClass is non-empty, only keys matching that meter class are returned.
+func getDashMeterKeys(redisDb *redis.Client, separator string, eniOid string, meterClass string) ([]dashMeterKeyInfo, error) {
+	pattern := "COUNTERS" + separator + "*"
+	dbkeys, err := redisDb.Keys(context.Background(), pattern).Result()
+	if err != nil {
+		return nil, fmt.Errorf("redis Keys failed for pattern %s: %v", pattern, err)
+	}
+
+	prefix := "COUNTERS" + separator
+	var results []dashMeterKeyInfo
+	for _, dbkey := range dbkeys {
+		// DASH_METER keys have JSON after "COUNTERS<sep>"; skip non-JSON keys (e.g. COUNTERS:oid:...)
+		jsonPart := strings.TrimPrefix(dbkey, prefix)
+		if !strings.HasPrefix(jsonPart, "{") {
+			continue
+		}
+
+		var keyFields struct {
+			EniId      string `json:"eni_id"`
+			MeterClass string `json:"meter_class"`
+			SwitchId   string `json:"switch_id"`
+		}
+		if err := json.Unmarshal([]byte(jsonPart), &keyFields); err != nil {
+			log.V(4).Infof("Skipping non-JSON COUNTERS key: %s", dbkey)
+			continue
+		}
+
+		if eniOid != "" && keyFields.EniId != eniOid {
+			continue
+		}
+		if meterClass != "" && keyFields.MeterClass != meterClass {
+			continue
+		}
+
+		results = append(results, dashMeterKeyInfo{
+			fullKey:    dbkey,
+			eniOid:     keyFields.EniId,
+			meterClass: keyFields.MeterClass,
+			switchOid:  keyFields.SwitchId,
+		})
+	}
+	return results, nil
+}
+
+// v2rEniStats translates virtual ENI counter paths to real Redis paths.
+// Handles: [DPU_COUNTERS_DB COUNTERS ENI*] and [DPU_COUNTERS_DB COUNTERS <eni_name>]
+func v2rEniStats(paths []string) ([]tablePath, error) {
+	clearMappingsMu.RLock()
+	defer clearMappingsMu.RUnlock()
+	var tblPaths []tablePath
+	namespace, _ := sdcfg.GetDbDefaultNamespace()
+	separator, _ := GetTableKeySeparator(paths[DbIdx], namespace)
+
+	if strings.HasSuffix(paths[KeyIdx], "*") { // All ENIs
+		for eniName, oid := range countersEniNameMap {
+			tblPath := tablePath{
+				dbNamespace:  namespace,
+				dbName:       paths[DbIdx],
+				tableName:    paths[TblIdx],
+				tableKey:     oid,
+				delimitor:    separator,
+				jsonTableKey: eniName,
+			}
+			tblPaths = append(tblPaths, tblPath)
+		}
+	} else { // specific ENI
+		eniName := paths[KeyIdx]
+		oid, ok := countersEniNameMap[eniName]
+		if !ok {
+			return nil, fmt.Errorf("%v not a valid ENI name", eniName)
+		}
+		tblPaths = []tablePath{{
+			dbNamespace: namespace,
+			dbName:      paths[DbIdx],
+			tableName:   paths[TblIdx],
+			tableKey:    oid,
+			delimitor:   separator,
+		}}
+	}
+	log.V(6).Infof("v2rEniStats: %v", tblPaths)
+	return tblPaths, nil
+}
+
+// v2rDashMeterByEniAndClass translates a specific ENI + metering class path to real Redis keys.
+// Handles: [DPU_COUNTERS_DB DASH_METER <eni_name> <meter_class>]
+func v2rDashMeterByEniAndClass(paths []string) ([]tablePath, error) {
+	clearMappingsMu.RLock()
+	defer clearMappingsMu.RUnlock()
+
+	eniName := paths[KeyIdx]
+	meterClass := paths[FieldIdx]
+	namespace, _ := sdcfg.GetDbDefaultNamespace()
+	separator, _ := GetTableKeySeparator(paths[DbIdx], namespace)
+
+	eniOid, ok := countersEniNameMap[eniName]
+	if !ok {
+		return nil, fmt.Errorf("%v not a valid ENI name", eniName)
+	}
+
+	redisDb := Target2RedisDb[namespace][paths[DbIdx]]
+	if redisDb == nil {
+		return nil, fmt.Errorf("Redis client not available for %s", paths[DbIdx])
+	}
+
+	keys, err := getDashMeterKeys(redisDb, separator, eniOid, meterClass)
+	if err != nil {
+		return nil, err
+	}
+	if len(keys) == 0 {
+		return nil, fmt.Errorf("No DASH_METER entry found for ENI %v class %v", eniName, meterClass)
+	}
+
+	var tblPaths []tablePath
+	for _, k := range keys {
+		// tableKey is the JSON portion after "COUNTERS:"
+		tableKey := strings.TrimPrefix(k.fullKey, "COUNTERS"+separator)
+		tblPaths = append(tblPaths, tablePath{
+			dbNamespace:  namespace,
+			dbName:       paths[DbIdx],
+			tableName:    "COUNTERS",
+			tableKey:     tableKey,
+			delimitor:    separator,
+			jsonTableKey: meterClass,
+		})
+	}
+	log.V(6).Infof("v2rDashMeterByEniAndClass: %v", tblPaths)
+	return tblPaths, nil
+}
+
+// v2rDashMeterByEni translates ENI-level DASH_METER paths to real Redis keys.
+// Handles: [DPU_COUNTERS_DB DASH_METER <eni_name>] — all meter classes for one ENI
+// and [DPU_COUNTERS_DB DASH_METER *] — all meter classes for all ENIs
+func v2rDashMeterByEni(paths []string) ([]tablePath, error) {
+	clearMappingsMu.RLock()
+	defer clearMappingsMu.RUnlock()
+
+	namespace, _ := sdcfg.GetDbDefaultNamespace()
+	separator, _ := GetTableKeySeparator(paths[DbIdx], namespace)
+
+	redisDb := Target2RedisDb[namespace][paths[DbIdx]]
+	if redisDb == nil {
+		return nil, fmt.Errorf("Redis client not available for %s", paths[DbIdx])
+	}
+
+	var tblPaths []tablePath
+
+	if strings.HasSuffix(paths[KeyIdx], "*") { // All ENIs, all meter classes
+		keys, err := getDashMeterKeys(redisDb, separator, "", "")
+		if err != nil {
+			return nil, err
+		}
+		for _, k := range keys {
+			eniName, ok := countersEniOidNameMap[k.eniOid]
+			if !ok {
+				log.V(2).Infof("Unknown ENI OID %v in DASH_METER key, skipping", k.eniOid)
+				continue
+			}
+			tableKey := strings.TrimPrefix(k.fullKey, "COUNTERS"+separator)
+			tblPaths = append(tblPaths, tablePath{
+				dbNamespace:  namespace,
+				dbName:       paths[DbIdx],
+				tableName:    "COUNTERS",
+				tableKey:     tableKey,
+				delimitor:    separator,
+				jsonTableKey: eniName + "/" + k.meterClass,
+			})
+		}
+	} else { // Specific ENI, all meter classes
+		eniName := paths[KeyIdx]
+		eniOid, ok := countersEniNameMap[eniName]
+		if !ok {
+			return nil, fmt.Errorf("%v not a valid ENI name", eniName)
+		}
+
+		keys, err := getDashMeterKeys(redisDb, separator, eniOid, "")
+		if err != nil {
+			return nil, err
+		}
+		for _, k := range keys {
+			tableKey := strings.TrimPrefix(k.fullKey, "COUNTERS"+separator)
+			tblPaths = append(tblPaths, tablePath{
+				dbNamespace:  namespace,
+				dbName:       paths[DbIdx],
+				tableName:    "COUNTERS",
+				tableKey:     tableKey,
+				delimitor:    separator,
+				jsonTableKey: k.meterClass,
+			})
+		}
+	}
+	log.V(6).Infof("v2rDashMeterByEni: %v", tblPaths)
+	return tblPaths, nil
+}
+
 func ClearMappings() {
 	value := os.Getenv("UNIT_TEST")
 	if value != "1" {
@@ -1203,6 +1469,8 @@ func ClearMappings() {
 		countersFabricPortNameMap,
 		countersQueueNameMap,
 		countersAclRuleMap,
+		countersEniNameMap,
+		countersEniOidNameMap,
 	}
 	for _, counterMap := range counterMaps {
 		for entry := range counterMap {
@@ -1219,6 +1487,7 @@ func ClearMappings() {
 	initAliasMapOnce = sync.Once{}
 	initCountersPfcwdNameMapOnce = sync.Once{}
 	initCountersFabricPortNameMapOnce = sync.Once{}
+	initCountersEniNameMapOnce = sync.Once{}
 }
 
 func InitCountersPortNameMap() error       { return initCountersPortNameMap() }
@@ -1227,6 +1496,7 @@ func InitCountersPGNameMap() error         { return initCountersPGNameMap() }
 func InitCountersSidMap() error            { return initCountersSidMap() }
 func InitCountersAclRuleMap() error        { return initCountersAclRuleMap() }
 func InitCountersFabricPortNameMap() error { return initCountersFabricPortNameMap() }
+func InitCountersEniNameMap() error        { return initCountersEniNameMap() }
 
 func lookupV2R(paths []string) ([]tablePath, error) {
 	n, ok := v2rTrie.Find(paths)

--- a/sonic_data_client/virtual_db.go
+++ b/sonic_data_client/virtual_db.go
@@ -1344,47 +1344,71 @@ func v2rEniStats(paths []string) ([]tablePath, error) {
 	return tblPaths, nil
 }
 
-// v2rDashMeterByEniAndClass translates a specific ENI + metering class path to real Redis keys.
+// v2rDashMeterByEniAndClass translates ENI + metering class paths to real Redis keys.
 // Handles: [DPU_COUNTERS_DB DASH_METER <eni_name> <meter_class>]
+// and:     [DPU_COUNTERS_DB DASH_METER * <meter_class>] — specific class for all ENIs
 func v2rDashMeterByEniAndClass(paths []string) ([]tablePath, error) {
 	clearMappingsMu.RLock()
 	defer clearMappingsMu.RUnlock()
 
-	eniName := paths[KeyIdx]
 	meterClass := paths[FieldIdx]
 	namespace, _ := sdcfg.GetDbDefaultNamespace()
 	separator, _ := GetTableKeySeparator(paths[DbIdx], namespace)
-
-	eniOid, ok := countersEniNameMap[eniName]
-	if !ok {
-		return nil, fmt.Errorf("%v not a valid ENI name", eniName)
-	}
 
 	redisDb := Target2RedisDb[namespace][paths[DbIdx]]
 	if redisDb == nil {
 		return nil, fmt.Errorf("Redis client not available for %s", paths[DbIdx])
 	}
 
-	keys, err := getDashMeterKeys(redisDb, separator, eniOid, meterClass)
-	if err != nil {
-		return nil, err
-	}
-	if len(keys) == 0 {
-		return nil, fmt.Errorf("No DASH_METER entry found for ENI %v class %v", eniName, meterClass)
-	}
-
 	var tblPaths []tablePath
-	for _, k := range keys {
-		// tableKey is the JSON portion after "COUNTERS:"
-		tableKey := strings.TrimPrefix(k.fullKey, "COUNTERS"+separator)
-		tblPaths = append(tblPaths, tablePath{
-			dbNamespace:  namespace,
-			dbName:       paths[DbIdx],
-			tableName:    "COUNTERS",
-			tableKey:     tableKey,
-			delimitor:    separator,
-			jsonTableKey: meterClass,
-		})
+
+	if strings.HasSuffix(paths[KeyIdx], "*") { // All ENIs, specific meter class
+		keys, err := getDashMeterKeys(redisDb, separator, "", meterClass)
+		if err != nil {
+			return nil, err
+		}
+		for _, k := range keys {
+			eniName, ok := countersEniOidNameMap[k.eniOid]
+			if !ok {
+				log.V(2).Infof("Unknown ENI OID %v in DASH_METER key, skipping", k.eniOid)
+				continue
+			}
+			tableKey := strings.TrimPrefix(k.fullKey, "COUNTERS"+separator)
+			tblPaths = append(tblPaths, tablePath{
+				dbNamespace:  namespace,
+				dbName:       paths[DbIdx],
+				tableName:    "COUNTERS",
+				tableKey:     tableKey,
+				delimitor:    separator,
+				jsonTableKey: eniName + "/" + meterClass,
+			})
+		}
+	} else { // Specific ENI, specific meter class
+		eniName := paths[KeyIdx]
+		eniOid, ok := countersEniNameMap[eniName]
+		if !ok {
+			return nil, fmt.Errorf("%v not a valid ENI name", eniName)
+		}
+
+		keys, err := getDashMeterKeys(redisDb, separator, eniOid, meterClass)
+		if err != nil {
+			return nil, err
+		}
+		if len(keys) == 0 {
+			return nil, fmt.Errorf("No DASH_METER entry found for ENI %v class %v", eniName, meterClass)
+		}
+
+		for _, k := range keys {
+			tableKey := strings.TrimPrefix(k.fullKey, "COUNTERS"+separator)
+			tblPaths = append(tblPaths, tablePath{
+				dbNamespace:  namespace,
+				dbName:       paths[DbIdx],
+				tableName:    "COUNTERS",
+				tableKey:     tableKey,
+				delimitor:    separator,
+				jsonTableKey: meterClass,
+			})
+		}
 	}
 	log.V(6).Infof("v2rDashMeterByEniAndClass: %v", tblPaths)
 	return tblPaths, nil

--- a/sonic_data_client/virtual_db.go
+++ b/sonic_data_client/virtual_db.go
@@ -150,7 +150,7 @@ var (
 	getAliasMapFn          = func() (map[string]string, map[string]string, map[string]string, error) { return GetAliasMap() }
 	getFabricCountersMapFn = func(t string) (map[string]string, error) { return GetFabricCountersMap(t) }
 	getPfcwdMapFn          = func() (map[string]map[string]string, error) { return GetPfcwdMap() }
-	getDpuCountersMapFn    = func(t string) (map[string]string, error) { return GetDpuCountersMap(t) }
+	getDpuCountersMapFn    = func(t string) (map[string]string, error) { return GetCountersMapForDb("DPU_COUNTERS_DB", t) }
 )
 
 func (t *Trie) v2rTriePopulate() {
@@ -318,6 +318,7 @@ func initCountersEniNameMap() error {
 		}
 		countersEniOidNameMap, err = getDpuCountersMapFn("COUNTERS_ENI_OID_NAME_MAP")
 		if err != nil {
+			countersEniNameMap = nil
 			initErr = err
 		}
 	})
@@ -484,22 +485,7 @@ func addmap(a map[string]string, b map[string]string) {
 // Get the mapping between objects in counters DB, Ex. port name to oid in "COUNTERS_PORT_NAME_MAP" table.
 // Aussuming static port name to oid map in COUNTERS table
 func GetCountersMap(tableName string) (map[string]string, error) {
-	counter_map := make(map[string]string)
-	dbName := "COUNTERS_DB"
-	redis_client_map, err := GetRedisClientsForDb(dbName)
-	if err != nil {
-		return nil, err
-	}
-	for namespace, redisDb := range redis_client_map {
-		fv, err := redisDb.HGetAll(context.Background(), tableName).Result()
-		if err != nil {
-			log.V(2).Infof("redis HGetAll failed for COUNTERS_DB in namespace %v, tableName: %s", namespace, tableName)
-			return nil, err
-		}
-		addmap(counter_map, fv)
-		log.V(6).Infof("tableName: %s in namespace %v, map %v", tableName, namespace, fv)
-	}
-	return counter_map, nil
+	return GetCountersMapForDb("COUNTERS_DB", tableName)
 }
 
 // Get the mapping between objects in counters DB, Ex. port name to oid in "COUNTERS_FABRIC_PORT_NAME_MAP" table.
@@ -552,11 +538,6 @@ func GetCountersMapForDb(dbName string, tableName string) (map[string]string, er
 		log.V(6).Infof("tableName: %s in namespace %v, map %v", tableName, namespace, fv)
 	}
 	return counter_map, nil
-}
-
-// GetDpuCountersMap retrieves a hash map from DPU_COUNTERS_DB.
-func GetDpuCountersMap(tableName string) (map[string]string, error) {
-	return GetCountersMapForDb("DPU_COUNTERS_DB", tableName)
 }
 
 // Populate real data paths from paths like

--- a/testdata/database_config.json
+++ b/testdata/database_config.json
@@ -51,6 +51,11 @@
             "id" : 13,
             "separator": "|",
             "instance" : "redis"
+        },
+        "DPU_COUNTERS_DB" : {
+            "id" : 18,
+            "separator": ":",
+            "instance" : "redis"
         }
     },
     "VERSION" : "1.0"


### PR DESCRIPTION
## Description
Add special GET handling for two virtual path types in `DPU_COUNTERS_DB`:

### ENI Counters (`DPU_COUNTERS_DB/COUNTERS/ENI/<name>`)
Maps ENI friendly names to OIDs via `COUNTERS_ENI_NAME_MAP`, following the existing `COUNTERS_DB/COUNTERS/Ethernet*` convention. Supports wildcard (all ENIs) and specific ENI name lookups.

### DASH_METER (`DPU_COUNTERS_DB/DASH_METER/<eni>/<class>`)
Maps to JSON-formatted Redis keys: `COUNTERS:{"eni_id":"<OID>","meter_class":"<class>","switch_id":"<switch_oid>"}`

Supported operations:
- GET on specific ENI + metering class ID
- GET on specific ENI (returns all metering class IDs)
- GET with wildcard ENI (returns all metering class IDs for all ENIs)
- GET with wildcard ENI + specific class (returns that class for all ENIs)

## Changes
- **Proto**: Add `DPU_COUNTERS_DB = 18` to `Target` enum in `sonic.proto` / `sonic.pb.go` (with `gofmt` applied)
- **Helpers**: `GetCountersMapForDb()` (generalized DB map fetcher — `GetCountersMap` now delegates to it), `getDashMeterKeys()` (Redis scanner for JSON-formatted keys)
- **Translation functions**: `v2rEniStats`, `v2rDashMeterByEni`, `v2rDashMeterByEniAndClass` with trie registration; `v2rDashMeterByEniAndClass` supports wildcard ENI (`*`) to match the pattern used by other 4-arg handlers
- **Init**: `initCountersEniNameMap()` using `COUNTERS_ENI_NAME_MAP` and `COUNTERS_ENI_OID_NAME_MAP` from `DPU_COUNTERS_DB`; nils out partial state on failure
- **parsePath**: Added `DPU_COUNTERS_DB` init block; logs error instead of returning on init failure to avoid breaking non-ENI DPU paths
- **Tests**: Comprehensive unit tests for all new functions, including wildcard ENI queries, partial init failure cleanup, init failure resilience for direct paths and other DBs
- **Cleanup**: Removed one-line `GetDpuCountersMap` wrapper (inlined); `GetCountersMap` rewritten to delegate to `GetCountersMapForDb`

## Design Notes
- GET-only for now; code structured so future Subscribe support requires minimal changes
- DASH_METER JSON keys discovered via Redis KEYS scan + JSON parse (robust to field ordering)
- Non-JSON `COUNTERS:oid:...` keys safely filtered during scanning
- `ClearMappings()` updated to support test isolation
- `initCountersEniNameMap` failure is non-fatal (log only) — matches pattern of other optional init functions (e.g. `initCountersPfcwdNameMap`), preventing DPU_COUNTERS_DB availability issues from breaking unrelated paths
