### PR TITLE
Revert "telemetry: add --bind_address flag to restrict TCP listener"

### DIFF
--- a/gnmi_server/server.go
+++ b/gnmi_server/server.go
@@ -244,10 +244,6 @@ type Config struct {
 	PathzPolicyFile          string // Path to gNMI pathz policy file.
 	PathzMetaFile            string // Path to JSON file with pathz metadata.
 	EnableStreamMultiplexing bool   // Allow multiple Subscribe RPCs on a single TCP connection.
-	// BindAddress is the network address to bind the TCP listener.
-	// When empty, binds to all interfaces (0.0.0.0). Use "127.0.0.1" to
-	// restrict to localhost only (e.g. when running without TLS).
-	BindAddress string
 }
 
 // DBusOSBackend is a concrete implementation of OSBackend
@@ -591,12 +587,11 @@ func NewServer(config *Config, tlsOpts []grpc.ServerOption, commonOpts []grpc.Se
 		srv.s = grpc.NewServer(tcpOpts...)
 		reflection.Register(srv.s)
 
-		bindAddr := config.BindAddress
 		// Create VRF-aware listener if GNMI VRF is specified
 		if config.GnmiVrf != "" && config.GnmiVrf != "default" {
 			srv.lis, err = createVrfListener(config.GnmiVrf, config.Port)
 		} else {
-			srv.lis, err = net.Listen("tcp", fmt.Sprintf("%s:%d", bindAddr, config.Port))
+			srv.lis, err = net.Listen("tcp", fmt.Sprintf(":%d", config.Port))
 		}
 		if err != nil {
 			log.Warningf("Failed to open listener port %d: %v; disabling TCP listener", config.Port, err)

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"net"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -65,7 +64,6 @@ type TelemetryConfig struct {
 	IdleConnDuration         *int
 	GnmiVrf                  *string
 	Vrf                      *string
-	BindAddress              *string
 	EnableCrl                *bool
 	CrlExpireDuration        *int
 	CaCertLnk                *string
@@ -190,7 +188,6 @@ func setupFlags(fs *flag.FlagSet) (*TelemetryConfig, *gnmi.Config, error) {
 		IdleConnDuration:         fs.Int("idle_conn_duration", 5, "Seconds before server closes idle connections"),
 		GnmiVrf:                  fs.String("gnmi_vrf", "", "VRF name for gNMI server binding."),
 		Vrf:                      fs.String("vrf", "", "VRF name for ZMQ client binding."),
-		BindAddress:              fs.String("bind_address", "", "Address to bind the gRPC TCP listener. Empty binds all interfaces. Use 127.0.0.1 to restrict to localhost."),
 		EnableCrl:                fs.Bool("enable_crl", false, "Enable certificate revocation list"),
 		CrlExpireDuration:        fs.Int("crl_expire_duration", 86400, "Certificate revocation list cache expire duration"),
 		ImgDirPath:               fs.String("img_dir", "/tmp/host_tmp", "Directory path where image will be transferred."),
@@ -230,15 +227,6 @@ func setupFlags(fs *flag.FlagSet) (*TelemetryConfig, *gnmi.Config, error) {
 	switch {
 	case *telemetryCfg.Port <= 0 && *telemetryCfg.UnixSocket == "":
 		return nil, nil, fmt.Errorf("port must be > 0 (or specify --unix_socket).")
-	}
-
-	if *telemetryCfg.NoTLS {
-		ip := net.ParseIP(*telemetryCfg.BindAddress)
-		if ip == nil || !ip.IsLoopback() {
-			return nil, nil, fmt.Errorf(
-				"--noTLS requires --bind_address to be a loopback address (e.g. 127.0.0.1 or ::1) " +
-					"to prevent cleartext gRPC exposure over the network")
-		}
 	}
 
 	switch {
@@ -281,7 +269,6 @@ func setupFlags(fs *flag.FlagSet) (*TelemetryConfig, *gnmi.Config, error) {
 	cfg.ConfigTableName = *telemetryCfg.ConfigTableName
 	cfg.GnmiVrf = *telemetryCfg.GnmiVrf
 	cfg.Vrf = *telemetryCfg.Vrf
-	cfg.BindAddress = *telemetryCfg.BindAddress
 	cfg.EnableCrl = *telemetryCfg.EnableCrl
 	cfg.CaCertLnk = *telemetryCfg.CaCertLnk
 	cfg.CaCertFile = *telemetryCfg.CaCert
@@ -325,7 +312,8 @@ func setupFlags(fs *flag.FlagSet) (*TelemetryConfig, *gnmi.Config, error) {
 		cfg.GetOptions = gnmi.SrvAdvConfig
 	}
 	if *telemetryCfg.CaCert == "" && telemetryCfg.UserAuth.Enabled("cert") {
-		log.Fatalf("--client_auth cert requires --cacert option. Cannot start without CA certificate.")
+		telemetryCfg.UserAuth.Unset("cert")
+		log.V(2).Info("client_auth mode cert requires ca_crt option. Disabling cert mode authentication.")
 	}
 
 	cfg.AuthzMetaFile = string(*telemetryCfg.AuthzMetaFile)
@@ -447,9 +435,6 @@ func startGNMIServer(telemetryCfg *TelemetryConfig, cfg *gnmi.Config, serverCont
 		var certLoaded int32
 		atomic.StoreInt32(&certLoaded, 0) // Not loaded
 
-		// Set application-layer auth regardless of transport (TLS or noTLS)
-		cfg.UserAuth = telemetryCfg.UserAuth
-
 		if !*telemetryCfg.NoTLS {
 			var certificate tls.Certificate
 			var err error
@@ -565,6 +550,8 @@ func startGNMIServer(telemetryCfg *TelemetryConfig, cfg *gnmi.Config, serverCont
 			if *telemetryCfg.IdleConnDuration > 0 { // non inf case
 				commonOpts = append(commonOpts, grpc.KeepaliveParams(keep_alive_params))
 			}
+
+			cfg.UserAuth = telemetryCfg.UserAuth
 
 			gnmi.GenerateJwtSecretKey()
 		}

--- a/telemetry/telemetry_test.go
+++ b/telemetry/telemetry_test.go
@@ -1451,6 +1451,27 @@ func TestFlagsNoPortNoUnixSocket(t *testing.T) {
 	}
 }
 
+func TestCertAuthDisabledWhenNoCaCert(t *testing.T) {
+	// When --client_auth includes "cert" but --ca_crt is empty, cert auth must be
+	// disabled (not fatal) so the server can still start with the remaining auth modes.
+	originalArgs := os.Args
+	defer func() { os.Args = originalArgs }()
+
+	fs := flag.NewFlagSet("testCertAuthDisabledWhenNoCaCert", flag.ContinueOnError)
+	os.Args = []string{"cmd", "-port", "8080", "-noTLS", "-client_auth", "cert,password"}
+
+	telemetryCfg, _, err := setupFlags(fs)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if telemetryCfg.UserAuth.Enabled("cert") {
+		t.Error("Expected cert auth to be disabled when ca_crt is empty, but it was still enabled")
+	}
+	if !telemetryCfg.UserAuth.Enabled("password") {
+		t.Error("Expected password auth to remain enabled after cert was disabled")
+	}
+}
+
 func TestMain(m *testing.M) {
 	defer test_utils.MemLeakCheck()
 	m.Run()

--- a/telemetry/telemetry_test.go
+++ b/telemetry/telemetry_test.go
@@ -41,7 +41,7 @@ func TestRunTelemetry(t *testing.T) {
 	})
 	defer patches.Reset()
 
-	args := []string{"telemetry", "-logtostderr", "-port", "50051", "-v=2", "-noTLS", "-bind_address", "127.0.0.1"}
+	args := []string{"telemetry", "-logtostderr", "-port", "50051", "-v=2", "-noTLS"}
 	os.Args = args
 	err := runTelemetry(os.Args)
 	if err != nil {
@@ -79,7 +79,7 @@ func TestFlags(t *testing.T) {
 		expectedVrf       string
 	}{
 		{
-			[]string{"cmd", "-port", "9090", "-threshold", "200", "-idle_conn_duration", "10", "-v", "6", "-noTLS", "-bind_address", "127.0.0.1"},
+			[]string{"cmd", "-port", "9090", "-threshold", "200", "-idle_conn_duration", "10", "-v", "6", "-noTLS"},
 			9090,
 			200,
 			10,
@@ -97,7 +97,7 @@ func TestFlags(t *testing.T) {
 			"",
 		},
 		{
-			[]string{"cmd", "-port", "5050", "-threshold", "10", "-idle_conn_duration", "3", "-v", "-3", "-noTLS", "-bind_address", "127.0.0.1"},
+			[]string{"cmd", "-port", "5050", "-threshold", "10", "-idle_conn_duration", "3", "-v", "-3", "-noTLS"},
 			5050,
 			10,
 			3,
@@ -106,7 +106,7 @@ func TestFlags(t *testing.T) {
 			"",
 		},
 		{
-			[]string{"cmd", "-port", "8082", "-threshold", "1", "-idle_conn_duration", "1", "-gnmi_vrf", "mgmt", "-vrf", "mgmt", "-noTLS", "-bind_address", "127.0.0.1"},
+			[]string{"cmd", "-port", "8082", "-threshold", "1", "-idle_conn_duration", "1", "-gnmi_vrf", "mgmt", "-vrf", "mgmt", "-noTLS"},
 			8082,
 			1,
 			1,
@@ -247,48 +247,6 @@ func TestStartGNMIServer(t *testing.T) {
 	if !exitCalled {
 		t.Errorf("s.ForceStop should be called if gnmi server is called to shutdown")
 	}
-}
-
-func TestStartGNMIServerNoTLS(t *testing.T) {
-	// Regression test: cfg.UserAuth must be set in noTLS mode.
-	// Before the fix, UserAuth was only populated inside if !NoTLS{},
-	// so auth was bypassed when --noTLS was active.
-	originalArgs := os.Args
-	defer func() { os.Args = originalArgs }()
-
-	fs := flag.NewFlagSet("testStartGNMIServerNoTLS", flag.ContinueOnError)
-	os.Args = []string{"cmd", "-port", "8080", "-noTLS", "-bind_address", "127.0.0.1", "-client_auth", "password"}
-	telemetryCfg, cfg, err := setupFlags(fs)
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-
-	userAuthSet := make(chan struct{}, 1)
-	patches := gomonkey.ApplyFunc(gnmi.NewServer, func(cfg *gnmi.Config, tlsOpts []grpc.ServerOption, commonOpts []grpc.ServerOption) (*gnmi.Server, error) {
-		if !cfg.UserAuth.Enabled("password") {
-			t.Error("cfg.UserAuth should have password enabled in noTLS mode")
-		}
-		select {
-		case userAuthSet <- struct{}{}:
-		default:
-		}
-		return nil, fmt.Errorf("stop server")
-	})
-	defer patches.Reset()
-
-	serverControlSignal := make(chan ServerControlValue, 1)
-	stopSignalHandler := make(chan bool, 1)
-	wg := &sync.WaitGroup{}
-	wg.Add(1)
-	go startGNMIServer(telemetryCfg, cfg, serverControlSignal, stopSignalHandler, wg)
-	select {
-	case <-userAuthSet:
-		// cfg.UserAuth was verified in the gnmi.NewServer patch
-	case <-time.After(3 * time.Second):
-		t.Error("startGNMIServer did not call gnmi.NewServer within timeout")
-	}
-	serverControlSignal <- ServerStop
-	wg.Wait()
 }
 
 func TestStartGNMIServerGracefulStop(t *testing.T) {
@@ -1490,59 +1448,6 @@ func TestFlagsNoPortNoUnixSocket(t *testing.T) {
 	}
 	if err != nil && !strings.Contains(err.Error(), "port must be > 0") {
 		t.Errorf("Expected 'port must be > 0' error, got: %v", err)
-	}
-}
-
-func TestNoTLSAuthNotBypassed(t *testing.T) {
-	// Regression test for auth bypass in noTLS mode.
-	// Before the fix, cfg.UserAuth was only set inside if !NoTLS{},
-	// so authentication was silently bypassed when --noTLS was active.
-	// We verify via telemetryCfg.UserAuth (the source) since cfg.UserAuth
-	// is populated later in the server goroutine, not in setupFlags.
-	originalArgs := os.Args
-	defer func() { os.Args = originalArgs }()
-
-	fs := flag.NewFlagSet("testNoTLSAuthNotBypassed", flag.ContinueOnError)
-	os.Args = []string{"cmd", "-port", "8080", "-noTLS", "-bind_address", "127.0.0.1", "-client_auth", "password"}
-
-	telemetryCfg, _, err := setupFlags(fs)
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-	if !telemetryCfg.UserAuth.Enabled("password") {
-		t.Error("Expected password auth to be enabled in noTLS mode, but was bypassed")
-	}
-}
-
-func TestNoTLSRequiresLoopbackAddress(t *testing.T) {
-	// --noTLS must be rejected unless --bind_address is a loopback address.
-	originalArgs := os.Args
-	defer func() { os.Args = originalArgs }()
-
-	tests := []struct {
-		name    string
-		args    []string
-		wantErr bool
-	}{
-		{"empty bind_address", []string{"cmd", "-port", "8080", "-noTLS"}, true},
-		{"non-loopback", []string{"cmd", "-port", "8080", "-noTLS", "-bind_address", "10.0.0.1"}, true},
-		{"loopback ipv4", []string{"cmd", "-port", "8080", "-noTLS", "-bind_address", "127.0.0.1"}, false},
-		{"loopback ipv4 alt", []string{"cmd", "-port", "8080", "-noTLS", "-bind_address", "127.0.0.2"}, false},
-		{"loopback ipv6", []string{"cmd", "-port", "8080", "-noTLS", "-bind_address", "::1"}, false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			fs := flag.NewFlagSet("test", flag.ContinueOnError)
-			os.Args = tt.args
-			_, _, err := setupFlags(fs)
-			if tt.wantErr && err == nil {
-				t.Errorf("expected error for args %v, got nil", tt.args)
-			}
-			if !tt.wantErr && err != nil {
-				t.Errorf("unexpected error for args %v: %v", tt.args, err)
-			}
-		})
 	}
 }
 


### PR DESCRIPTION
Reverts sonic-net/sonic-gnmi#652

Supersedes #659 — same revert plus a unit test (`TestCertAuthDisabledWhenNoCaCert`) covering the restored cert-auth fallback path so the coverage check passes.