### PR TITLE
MixedDbClient: batch ZMQ Set/Del for multi-key gNMI updates (#27250)

### DIFF
--- a/.azure/templates/install-dependencies.yml
+++ b/.azure/templates/install-dependencies.yml
@@ -54,6 +54,7 @@ steps:
     patterns: |
       target/debs/trixie/libyang_1.0*.deb
       target/debs/trixie/libyang-*_1.0*.deb
+      target/debs/trixie/libyang3_*.deb
       target/debs/trixie/libpcre3_*.deb
       target/debs/trixie/libpcre3-dev_*.deb
       target/debs/trixie/libpcre16-3_*.deb

--- a/sonic_data_client/client_test.go
+++ b/sonic_data_client/client_test.go
@@ -2169,10 +2169,6 @@ func TestZmqBatchedSetEndToEnd(t *testing.T) {
 	}
 
 	swsscommon.DeleteZmqClient(zmqClient)
-	for k, c := range zmqClientMap {
-		swsscommon.DeleteZmqClient(c)
-		delete(zmqClientMap, k)
-	}
 }
 
 func TestZmqBatchedDelEndToEnd(t *testing.T) {
@@ -2209,10 +2205,6 @@ func TestZmqBatchedDelEndToEnd(t *testing.T) {
 	}
 
 	swsscommon.DeleteZmqClient(zmqClient)
-	for k, c := range zmqClientMap {
-		swsscommon.DeleteZmqClient(c)
-		delete(zmqClientMap, k)
-	}
 }
 
 func TestDbBatchSetTableFallsBackForPlainTable(t *testing.T) {

--- a/sonic_data_client/client_test.go
+++ b/sonic_data_client/client_test.go
@@ -2109,3 +2109,328 @@ func TestGetTableDashHA(t *testing.T) {
 	swsscommon.DeleteZmqClient(zmqClient)
 	swsscommon.DeleteZmqServer(zmqServer)
 }
+
+// drainAllFromZmq pops entries from the consumer until the deadline expires
+// or `expected` entries have been seen. It returns the total drained.
+func drainAllFromZmq(consumer swsscommon.ZmqConsumerStateTable, expected int) int {
+	deadline := time.Now().Add(5 * time.Second)
+	total := 0
+	for time.Now().Before(deadline) && total < expected {
+		q := swsscommon.NewKeyOpFieldsValuesQueue()
+		consumer.Pops(q)
+		total += int(q.Size())
+		swsscommon.DeleteKeyOpFieldsValuesQueue(q)
+		if total < expected {
+			time.Sleep(50 * time.Millisecond)
+		}
+	}
+	return total
+}
+
+func TestZmqBatchedSetEndToEnd(t *testing.T) {
+	if !swsscommon.SonicDBConfigIsInit() {
+		swsscommon.SonicDBConfigInitialize()
+	}
+
+	const zmqAddr = "tcp://127.0.0.1:4234"
+	zmqServer := swsscommon.NewZmqServer("tcp://*:4234")
+	defer swsscommon.DeleteZmqServer(zmqServer)
+	const tableName = "DASH_ROUTE_TABLE"
+	db := swsscommon.NewDBConnector(APPL_DB_NAME, SWSS_TIMEOUT, false)
+	defer swsscommon.DeleteDBConnector(db)
+	consumer := swsscommon.NewZmqConsumerStateTable(db, tableName, zmqServer)
+	defer swsscommon.DeleteZmqConsumerStateTable(consumer)
+
+	zmqClient := swsscommon.NewZmqClient(zmqAddr)
+	client := MixedDbClient{
+		applDB:        swsscommon.NewDBConnector(APPL_DB_NAME, SWSS_TIMEOUT, false),
+		tableMap:      map[string]swsscommon.ProducerStateTable{},
+		zmqTableMap:   map[string]swsscommon.ZmqProducerStateTable{},
+		plainTableMap: map[string]swsscommon.Table{},
+		zmqClient:     zmqClient,
+	}
+	defer client.Close()
+
+	const N = 5
+	entries := make([]tableBatchEntry, 0, N)
+	for i := 0; i < N; i++ {
+		entries = append(entries, tableBatchEntry{
+			key:    fmt.Sprintf("k%d", i),
+			values: map[string]string{"f": fmt.Sprintf("v%d", i)},
+		})
+	}
+
+	if err := client.DbBatchSetTable(tableName, entries); err != nil {
+		t.Fatalf("DbBatchSetTable returned error: %v", err)
+	}
+
+	if total := drainAllFromZmq(consumer, N); total != N {
+		t.Errorf("Consumer drained %d entries, want %d", total, N)
+	}
+
+	swsscommon.DeleteZmqClient(zmqClient)
+	for _, c := range zmqClientMap {
+		swsscommon.DeleteZmqClient(c)
+	}
+}
+
+func TestZmqBatchedDelEndToEnd(t *testing.T) {
+	if !swsscommon.SonicDBConfigIsInit() {
+		swsscommon.SonicDBConfigInitialize()
+	}
+
+	const zmqAddr = "tcp://127.0.0.1:4235"
+	zmqServer := swsscommon.NewZmqServer("tcp://*:4235")
+	defer swsscommon.DeleteZmqServer(zmqServer)
+	const tableName = "DASH_ROUTE_TABLE"
+	db := swsscommon.NewDBConnector(APPL_DB_NAME, SWSS_TIMEOUT, false)
+	defer swsscommon.DeleteDBConnector(db)
+	consumer := swsscommon.NewZmqConsumerStateTable(db, tableName, zmqServer)
+	defer swsscommon.DeleteZmqConsumerStateTable(consumer)
+
+	zmqClient := swsscommon.NewZmqClient(zmqAddr)
+	client := MixedDbClient{
+		applDB:        swsscommon.NewDBConnector(APPL_DB_NAME, SWSS_TIMEOUT, false),
+		tableMap:      map[string]swsscommon.ProducerStateTable{},
+		zmqTableMap:   map[string]swsscommon.ZmqProducerStateTable{},
+		plainTableMap: map[string]swsscommon.Table{},
+		zmqClient:     zmqClient,
+	}
+	defer client.Close()
+
+	keys := []string{"k0", "k1", "k2", "k3"}
+	if err := client.DbBatchDelTable(tableName, keys); err != nil {
+		t.Fatalf("DbBatchDelTable returned error: %v", err)
+	}
+
+	if total := drainAllFromZmq(consumer, len(keys)); total != len(keys) {
+		t.Errorf("Consumer drained %d entries, want %d", total, len(keys))
+	}
+
+	swsscommon.DeleteZmqClient(zmqClient)
+	for _, c := range zmqClientMap {
+		swsscommon.DeleteZmqClient(c)
+	}
+}
+
+func TestDbBatchSetTableFallsBackForPlainTable(t *testing.T) {
+	if !swsscommon.SonicDBConfigIsInit() {
+		swsscommon.SonicDBConfigInitialize()
+	}
+
+	applDB := swsscommon.NewDBConnector(APPL_DB_NAME, SWSS_TIMEOUT, false)
+	client := MixedDbClient{
+		applDB:        applDB,
+		tableMap:      map[string]swsscommon.ProducerStateTable{},
+		zmqTableMap:   map[string]swsscommon.ZmqProducerStateTable{},
+		plainTableMap: map[string]swsscommon.Table{},
+		zmqClient:     nil,
+	}
+
+	const tableName = "DASH_HA_SET_CONFIG_TABLE"
+	entries := []tableBatchEntry{
+		{key: "k0", values: map[string]string{"f": "v0"}},
+		{key: "k1", values: map[string]string{"f": "v1"}},
+		{key: "k2", values: map[string]string{"f": "v2"}},
+	}
+
+	if err := client.DbBatchSetTable(tableName, entries); err != nil {
+		t.Fatalf("DbBatchSetTable on plain table failed: %v", err)
+	}
+	if _, ok := client.zmqTableMap[tableName]; ok {
+		t.Errorf("plain table %s should not appear in zmqTableMap", tableName)
+	}
+	if _, ok := client.plainTableMap[tableName]; !ok {
+		t.Errorf("plain table %s should appear in plainTableMap", tableName)
+	}
+
+	for _, e := range entries {
+		_ = client.DbDelTable(tableName, e.key)
+	}
+	for _, plainTable := range client.plainTableMap {
+		plainTable.Flush()
+		swsscommon.DeleteTable(plainTable)
+	}
+	swsscommon.DeleteDBConnector(applDB)
+}
+
+func TestDbBatchSetTableEmptyAndSingle(t *testing.T) {
+	if !swsscommon.SonicDBConfigIsInit() {
+		swsscommon.SonicDBConfigInitialize()
+	}
+
+	applDB := swsscommon.NewDBConnector(APPL_DB_NAME, SWSS_TIMEOUT, false)
+	defer swsscommon.DeleteDBConnector(applDB)
+	client := MixedDbClient{
+		applDB:        applDB,
+		tableMap:      map[string]swsscommon.ProducerStateTable{},
+		zmqTableMap:   map[string]swsscommon.ZmqProducerStateTable{},
+		plainTableMap: map[string]swsscommon.Table{},
+		zmqClient:     nil,
+	}
+
+	if err := client.DbBatchSetTable("DASH_HA_SET_CONFIG_TABLE", nil); err != nil {
+		t.Errorf("DbBatchSetTable with nil entries should be a no-op: %v", err)
+	}
+	if err := client.DbBatchDelTable("DASH_HA_SET_CONFIG_TABLE", nil); err != nil {
+		t.Errorf("DbBatchDelTable with nil keys should be a no-op: %v", err)
+	}
+
+	if err := client.DbBatchSetTable("DASH_HA_SET_CONFIG_TABLE", []tableBatchEntry{
+		{key: "k0", values: map[string]string{"f": "v0"}},
+	}); err != nil {
+		t.Errorf("DbBatchSetTable single-entry failed: %v", err)
+	}
+	if err := client.DbBatchDelTable("DASH_HA_SET_CONFIG_TABLE", []string{"k0"}); err != nil {
+		t.Errorf("DbBatchDelTable single-key failed: %v", err)
+	}
+
+	for _, plainTable := range client.plainTableMap {
+		plainTable.Flush()
+		swsscommon.DeleteTable(plainTable)
+	}
+}
+
+// TestHandleTableDataBatchesMultiKeyJSON proves that the multi-key JSON
+// opAdd path in handleTableData routes through DbBatchSetTable (one call)
+// instead of DbSetTable (N calls). This is the optimization that the issue
+// asks for: a single gNMI Set of N keys becomes one ZMQ round-trip.
+func TestHandleTableDataBatchesMultiKeyJSON(t *testing.T) {
+	if !swsscommon.SonicDBConfigIsInit() {
+		swsscommon.SonicDBConfigInitialize()
+	}
+
+	applDB := swsscommon.NewDBConnector(APPL_DB_NAME, SWSS_TIMEOUT, false)
+	defer swsscommon.DeleteDBConnector(applDB)
+
+	client := &MixedDbClient{
+		applDB:        applDB,
+		mapkey:        "test",
+		tableMap:      map[string]swsscommon.ProducerStateTable{},
+		zmqTableMap:   map[string]swsscommon.ZmqProducerStateTable{},
+		plainTableMap: map[string]swsscommon.Table{},
+	}
+
+	var batchSetCalls, setCalls int
+	var batchSetEntries int
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+	patches.ApplyMethod(client, "DbBatchSetTable", func(_ *MixedDbClient, _ string, entries []tableBatchEntry) error {
+		batchSetCalls++
+		batchSetEntries += len(entries)
+		return nil
+	})
+	patches.ApplyMethod(client, "DbSetTable", func(_ *MixedDbClient, _ string, _ string, _ map[string]string) error {
+		setCalls++
+		return nil
+	})
+
+	// Multi-key JSON payload — three keys under one table.
+	jsonValue := `{"k0":{"f":"v0"},"k1":{"f":"v1"},"k2":{"f":"v2"}}`
+	tblPaths := []tablePath{{
+		dbName:    APPL_DB_NAME,
+		tableName: "DASH_ROUTE_TABLE",
+		delimitor: ":",
+		operation: opAdd,
+		jsonValue: jsonValue,
+	}}
+
+	// handleTableData looks up RedisDbMap[<mapkey>:<dbName>]; ensure a
+	// redis client is registered for the key.
+	mapKey := "test:" + APPL_DB_NAME
+	if _, ok := RedisDbMap[mapKey]; !ok {
+		RedisDbMap[mapKey] = redis.NewClient(&redis.Options{
+			Addr: "127.0.0.1:6379",
+			DB:   0,
+		})
+	}
+
+	if err := client.handleTableData(tblPaths); err != nil {
+		t.Fatalf("handleTableData returned error: %v", err)
+	}
+	if batchSetCalls != 1 {
+		t.Errorf("DbBatchSetTable called %d times, want 1", batchSetCalls)
+	}
+	if batchSetEntries != 3 {
+		t.Errorf("DbBatchSetTable received %d entries total, want 3", batchSetEntries)
+	}
+	if setCalls != 0 {
+		t.Errorf("DbSetTable called %d times, want 0 (multi-key JSON must batch)", setCalls)
+	}
+}
+
+// TestHandleTableDataBatchesOpRemove proves the opRemove path in
+// handleTableData routes through DbBatchDelTable when there are multiple
+// keys to delete.
+func TestHandleTableDataBatchesOpRemove(t *testing.T) {
+	if !swsscommon.SonicDBConfigIsInit() {
+		swsscommon.SonicDBConfigInitialize()
+	}
+
+	applDB := swsscommon.NewDBConnector(APPL_DB_NAME, SWSS_TIMEOUT, false)
+	defer swsscommon.DeleteDBConnector(applDB)
+
+	client := &MixedDbClient{
+		applDB:        applDB,
+		mapkey:        "test",
+		tableMap:      map[string]swsscommon.ProducerStateTable{},
+		zmqTableMap:   map[string]swsscommon.ZmqProducerStateTable{},
+		plainTableMap: map[string]swsscommon.Table{},
+	}
+
+	var batchDelCalls, delCalls int
+	var batchDelKeys int
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+	patches.ApplyMethod(client, "DbBatchDelTable", func(_ *MixedDbClient, _ string, keys []string) error {
+		batchDelCalls++
+		batchDelKeys += len(keys)
+		return nil
+	})
+	patches.ApplyMethod(client, "DbDelTable", func(_ *MixedDbClient, _ string, _ string) error {
+		delCalls++
+		return nil
+	})
+
+	mapKey := "test:" + APPL_DB_NAME
+	if _, ok := RedisDbMap[mapKey]; !ok {
+		RedisDbMap[mapKey] = redis.NewClient(&redis.Options{
+			Addr: "127.0.0.1:6379",
+			DB:   0,
+		})
+	}
+
+	// Seed three keys in Redis so the wildcard Keys() lookup returns
+	// multiple dbkeys.
+	const tableName = "DASH_BATCH_REMOVE_TABLE"
+	const delim = ":"
+	rdb := RedisDbMap[mapKey]
+	for _, k := range []string{"k0", "k1", "k2"} {
+		rdb.HSet(context.Background(), tableName+delim+k, "f", "v")
+	}
+	defer func() {
+		for _, k := range []string{"k0", "k1", "k2"} {
+			rdb.Del(context.Background(), tableName+delim+k)
+		}
+	}()
+
+	tblPaths := []tablePath{{
+		dbName:    APPL_DB_NAME,
+		tableName: tableName,
+		delimitor: delim,
+		operation: opRemove,
+	}}
+
+	if err := client.handleTableData(tblPaths); err != nil {
+		t.Fatalf("handleTableData returned error: %v", err)
+	}
+	if batchDelCalls != 1 {
+		t.Errorf("DbBatchDelTable called %d times, want 1", batchDelCalls)
+	}
+	if batchDelKeys != 3 {
+		t.Errorf("DbBatchDelTable received %d keys, want 3", batchDelKeys)
+	}
+	if delCalls != 0 {
+		t.Errorf("DbDelTable called %d times, want 0 (multi-key remove must batch)", delCalls)
+	}
+}

--- a/sonic_data_client/client_test.go
+++ b/sonic_data_client/client_test.go
@@ -2169,8 +2169,9 @@ func TestZmqBatchedSetEndToEnd(t *testing.T) {
 	}
 
 	swsscommon.DeleteZmqClient(zmqClient)
-	for _, c := range zmqClientMap {
+	for k, c := range zmqClientMap {
 		swsscommon.DeleteZmqClient(c)
+		delete(zmqClientMap, k)
 	}
 }
 
@@ -2208,8 +2209,9 @@ func TestZmqBatchedDelEndToEnd(t *testing.T) {
 	}
 
 	swsscommon.DeleteZmqClient(zmqClient)
-	for _, c := range zmqClientMap {
+	for k, c := range zmqClientMap {
 		swsscommon.DeleteZmqClient(c)
+		delete(zmqClientMap, k)
 	}
 }
 
@@ -2335,15 +2337,11 @@ func TestHandleTableDataBatchesMultiKeyJSON(t *testing.T) {
 		jsonValue: jsonValue,
 	}}
 
-	// handleTableData looks up RedisDbMap[<mapkey>:<dbName>]; ensure a
-	// redis client is registered for the key.
-	mapKey := "test:" + APPL_DB_NAME
-	if _, ok := RedisDbMap[mapKey]; !ok {
-		RedisDbMap[mapKey] = redis.NewClient(&redis.Options{
-			Addr: "127.0.0.1:6379",
-			DB:   0,
-		})
-	}
+	// handleTableData looks up RedisDbMap[<mapkey>:<dbName>]; use the
+	// shared helper so RedisDbMap is initialized/restored deterministically
+	// across test ordering (other tests set RedisDbMap = nil).
+	redisCleanup := setupMixedDbRedis(t, "test")
+	defer redisCleanup()
 
 	if err := client.handleTableData(tblPaths); err != nil {
 		t.Fatalf("handleTableData returned error: %v", err)
@@ -2392,19 +2390,17 @@ func TestHandleTableDataBatchesOpRemove(t *testing.T) {
 		return nil
 	})
 
-	mapKey := "test:" + APPL_DB_NAME
-	if _, ok := RedisDbMap[mapKey]; !ok {
-		RedisDbMap[mapKey] = redis.NewClient(&redis.Options{
-			Addr: "127.0.0.1:6379",
-			DB:   0,
-		})
-	}
+	// Use the shared helper so RedisDbMap is initialized/restored
+	// deterministically across test ordering (other tests set
+	// RedisDbMap = nil).
+	redisCleanup := setupMixedDbRedis(t, "test")
+	defer redisCleanup()
 
 	// Seed three keys in Redis so the wildcard Keys() lookup returns
 	// multiple dbkeys.
 	const tableName = "DASH_BATCH_REMOVE_TABLE"
 	const delim = ":"
-	rdb := RedisDbMap[mapKey]
+	rdb := RedisDbMap["test:"+APPL_DB_NAME]
 	for _, k := range []string{"k0", "k1", "k2"} {
 		rdb.HSet(context.Background(), tableName+delim+k, "f", "v")
 	}

--- a/sonic_data_client/mixed_db_client.go
+++ b/sonic_data_client/mixed_db_client.go
@@ -310,6 +310,18 @@ func ProducerStateTableDeleteWrapper(pt swsscommon.ProducerStateTable, key strin
 	return
 }
 
+func ZmqProducerBatchedSetWrapper(pt swsscommon.ZmqProducerStateTable, keys swsscommon.VectorString, fvss swsscommon.FieldValuePairsList) (err error) {
+	defer CatchException(&err)
+	swsscommon.ZmqProducerBatchedSet(pt, keys, fvss)
+	return
+}
+
+func ZmqProducerBatchedDelWrapper(pt swsscommon.ZmqProducerStateTable, keys swsscommon.VectorString) (err error) {
+	defer CatchException(&err)
+	swsscommon.ZmqProducerBatchedDel(pt, keys)
+	return
+}
+
 func TableSetWrapper(t swsscommon.Table, key string, value swsscommon.FieldValuePairs) (err error) {
 	// convert panic to error
 	defer CatchException(&err)
@@ -393,6 +405,104 @@ func (c *MixedDbClient) DbDelTable(table string, key string) error {
 		c.zmqClient,
 		func() error {
 			return ProducerStateTableDeleteWrapper(pt, key)
+		})
+}
+
+// tableBatchEntry is a (key, field-value-map) pair scheduled to be written
+// to the same table in one batched call.
+type tableBatchEntry struct {
+	key    string
+	values map[string]string
+}
+
+// DbBatchSetTable writes multiple entries to a single table. When the table
+// is backed by ZmqProducerStateTable it issues one ZMQ message for the
+// whole batch (via swsscommon.ZmqProducerBatchedSet), turning N round-trips
+// into one. For plain Table / non-ZMQ ProducerStateTable backends there is
+// no batched C++ API, so we fall back to a per-entry loop. Single-entry
+// batches are delegated to DbSetTable to avoid extra allocation.
+func (c *MixedDbClient) DbBatchSetTable(table string, entries []tableBatchEntry) error {
+	if len(entries) == 0 {
+		return nil
+	}
+	if len(entries) == 1 {
+		return c.DbSetTable(table, entries[0].key, entries[0].values)
+	}
+
+	// GetTable lazily creates the right backend and registers it in the
+	// appropriate map. After this call zmqTableMap[table] is populated iff
+	// the table is ZMQ-backed.
+	c.GetTable(table)
+
+	zmqPt, isZmq := c.zmqTableMap[table]
+	if !isZmq {
+		// No batched API for plain Table or non-ZMQ ProducerStateTable —
+		// fall back to per-entry writes.
+		for _, e := range entries {
+			if err := c.DbSetTable(table, e.key, e.values); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	keys := swsscommon.NewVectorString()
+	defer swsscommon.DeleteVectorString(keys)
+	fvss := swsscommon.NewFieldValuePairsList()
+	defer swsscommon.DeleteFieldValuePairsList(fvss)
+	for _, e := range entries {
+		keys.Add(e.key)
+		vec := swsscommon.NewFieldValuePairs()
+		for k, v := range e.values {
+			pair := swsscommon.NewFieldValuePair(k, v)
+			vec.Add(pair)
+			swsscommon.DeleteFieldValuePair(pair)
+		}
+		// Add() copies vec into the list; release the local copy.
+		fvss.Add(vec)
+		swsscommon.DeleteFieldValuePairs(vec)
+	}
+
+	return RetryHelper(
+		c.zmqClient,
+		func() error {
+			return ZmqProducerBatchedSetWrapper(zmqPt, keys, fvss)
+		})
+}
+
+// DbBatchDelTable deletes multiple keys from a single table. When the table
+// is backed by ZmqProducerStateTable a single batched ZMQ message is sent;
+// otherwise we fall back to a per-key loop.
+func (c *MixedDbClient) DbBatchDelTable(table string, keys []string) error {
+	if len(keys) == 0 {
+		return nil
+	}
+	if len(keys) == 1 {
+		return c.DbDelTable(table, keys[0])
+	}
+
+	c.GetTable(table)
+
+	zmqPt, isZmq := c.zmqTableMap[table]
+	if !isZmq {
+		for _, k := range keys {
+			if err := c.DbDelTable(table, k); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	keyVec := swsscommon.NewVectorString()
+	defer swsscommon.DeleteVectorString(keyVec)
+	for _, k := range keys {
+		keyVec.Add(k)
+	}
+
+	return RetryHelper(
+		c.zmqClient,
+		func() error {
+			return ZmqProducerBatchedDelWrapper(zmqPt, keyVec)
 		})
 }
 
@@ -1117,13 +1227,14 @@ func (c *MixedDbClient) handleTableData(tblPaths []tablePath) error {
 				dbkeys = []string{tblPath.tableName + tblPath.delimitor + tblPath.tableKey}
 			}
 
+			tableKeys := make([]string, 0, len(dbkeys))
 			for _, dbkey := range dbkeys {
 				tableKey := strings.TrimPrefix(dbkey, tblPath.tableName+tblPath.delimitor)
-				err = c.DbDelTable(tblPath.tableName, tableKey)
-				if err != nil {
-					log.V(2).Infof("swsscommon delete failed for  %v, dbkey %s", tblPath, dbkey)
-					return err
-				}
+				tableKeys = append(tableKeys, tableKey)
+			}
+			if err := c.DbBatchDelTable(tblPath.tableName, tableKeys); err != nil {
+				log.V(2).Infof("swsscommon batched delete failed for %v, count %d", tblPath, len(tableKeys))
+				return err
 			}
 		} else if tblPath.operation == opAdd {
 			if tblPath.tableKey != "" {
@@ -1164,17 +1275,20 @@ func (c *MixedDbClient) handleTableData(tblPaths []tablePath) error {
 					return err
 				}
 				if vtable, ok := res.(map[string]interface{}); ok {
+					entries := make([]tableBatchEntry, 0, len(vtable))
 					for tableKey, tres := range vtable {
 						if vt, ret := tres.(map[string]interface{}); ret {
-							outputData := ConvertDbEntry(vt)
-							err = c.DbSetTable(tblPath.tableName, tableKey, outputData)
-							if err != nil {
-								log.V(2).Infof("swsscommon update failed for  %v, value %v", tblPath, outputData)
-								return err
-							}
+							entries = append(entries, tableBatchEntry{
+								key:    tableKey,
+								values: ConvertDbEntry(vt),
+							})
 						} else {
 							return fmt.Errorf("Key %v: Unsupported value %v type %v", tableKey, tres, reflect.TypeOf(tres))
 						}
+					}
+					if err := c.DbBatchSetTable(tblPath.tableName, entries); err != nil {
+						log.V(2).Infof("swsscommon batched update failed for %v, count %d", tblPath, len(entries))
+						return err
 					}
 				} else {
 					return fmt.Errorf("Unsupported value %v type %v", res, reflect.TypeOf(res))

--- a/sonic_data_client/mixed_db_client.go
+++ b/sonic_data_client/mixed_db_client.go
@@ -463,6 +463,7 @@ func (c *MixedDbClient) DbBatchSetTable(table string, entries []tableBatchEntry)
 		swsscommon.DeleteFieldValuePairs(vec)
 	}
 
+	log.V(2).Infof("DbBatchSetTable: sending batched ZMQ set for table %s, batch size %d", table, len(entries))
 	return RetryHelper(
 		c.zmqClient,
 		func() error {
@@ -499,6 +500,7 @@ func (c *MixedDbClient) DbBatchDelTable(table string, keys []string) error {
 		keyVec.Add(k)
 	}
 
+	log.V(2).Infof("DbBatchDelTable: sending batched ZMQ del for table %s, batch size %d", table, len(keys))
 	return RetryHelper(
 		c.zmqClient,
 		func() error {


### PR DESCRIPTION
### Why
`handleTableData` in `MixedDbClient` (under `sonic_data_client/mixed_db_client.go`) currently loops per key when servicing a gNMI Set:

- `opRemove` → calls `DbDelTable` per dbkey.
- multi-key JSON `opAdd` → calls `DbSetTable` per JSON top-level key.

For DASH route programming this is the hot path — a single gNMI Set can carry tens of thousands of keys, and we generate that many ZMQ round-trips even though they all target the same producer on the same DPU. `ZmqProducerStateTable` already has a batched `set(vector<KeyOpFieldsValuesTuple>)` / `del(vector<string>)` in `sonic-swss-common` that fires one ZMQ message regardless of N — but the Go bindings did not expose a callable form (see the dependency below).

### What
* New `DbBatchSetTable(table string, entries []tableBatchEntry) error` and `DbBatchDelTable(table string, keys []string) error` on `MixedDbClient`. For ZMQ-backed tables (`DASH_*` minus `DASH_HA_*`) they assemble parallel `VectorString` / `FieldValuePairsList` and call the new `swsscommon.ZmqProducerBatchedSet` / `swsscommon.ZmqProducerBatchedDel` helpers under `RetryHelper`. For plain `Table` and non-ZMQ `ProducerStateTable` backends — where there is no batched C++ API — they fall back to the existing per-entry loop, so behaviour for `DASH_HA_*` and ordinary CONFIG_DB writes is unchanged.
* `handleTableData`:
  - `opRemove` builds a key slice and makes a single `DbBatchDelTable` call.
  - multi-key JSON `opAdd` builds an entry slice and makes a single `DbBatchSetTable` call.
  - Single-key paths (1138, 1152) are untouched — batching one entry is pointless.
* `ZmqProducerBatchedSetWrapper` / `ZmqProducerBatchedDelWrapper` wrap the new SWIG entry points to convert C++ exceptions into Go errors (same pattern as the existing `ProducerStateTable…Wrapper`s).

### Tests
`sonic_data_client/client_test.go` gains:
* `TestZmqBatchedSetEndToEnd` / `TestZmqBatchedDelEndToEnd` — round-trip 5 entries through a real `ZmqProducerStateTable` + `ZmqConsumerStateTable` and verify the consumer drains them all.
* `TestDbBatchSetTableFallsBackForPlainTable` / `TestDbBatchSetTableEmptyAndSingle` — verify the `plainTableMap` fallback and the no-op/single-entry shortcuts.
* `TestHandleTableDataBatchesMultiKeyJSON` / `TestHandleTableDataBatchesOpRemove` — gomonkey-patched proof that `handleTableData` routes multi-key payloads through `DbBatchSetTable` / `DbBatchDelTable` exactly once (not N times).

### Related
* sonic-net/sonic-buildimage#27250 — tracking issue.
* **Depends on sonic-net/sonic-swss-common#1188** — exposes `ZmqProducerBatchedSet/Del/Send` to Go via SWIG `%inline` helpers. The `Set__SWIG_3(vector<KeyOpFieldsValuesTuple>)` overload that already exists in the generated `swsscommon.go` is unreachable from Go because the vector element type has no constructor (it's an opaque `Std_tuple_<…>`). PR #1188 adds parallel-vector shims that reuse the already-templated `VectorString` / `FieldValuePairsList` types.

**CI on this branch will fail to build until sonic-swss-common#1188 lands and a new `libswsscommon` artifact is published.** The compile errors will be on the `swsscommon.ZmqProducerBatched{Set,Del}` symbols.

### Out of scope (deliberate)
* Cross-update batching at the SetDB level — would change per-update atomicity semantics.
* Auto-chunking very large batches into multiple ZMQ messages — can be a follow-up if 100k+ in one message proves problematic on the orchagent side.
* `ZmqProducerBatchedSend` (mixed SET/DEL in one message) — exported by the swss-common PR for completeness but no gNMI caller needs it today.
