### PR TITLE
[202511] Add DPU_COUNTERS_DB virtual path handling for DASH_METER and ENI counters

### DIFF
--- a/.azure/templates/install-dependencies.yml
+++ b/.azure/templates/install-dependencies.yml
@@ -74,6 +74,8 @@ steps:
       sudo sed -ri 's/^# unixsocket/unixsocket/' /etc/redis/redis.conf
       sudo sed -ri 's/^unixsocketperm .../unixsocketperm 777/' /etc/redis/redis.conf
       sudo sed -ri 's/redis-server.sock/redis.sock/' /etc/redis/redis.conf
+      # DPU_COUNTERS_DB uses Redis DB index 18; raise the limit from the default 16.
+      sudo sed -ri 's/^databases .*/databases 20/' /etc/redis/redis.conf
       sudo service redis-server start
     displayName: "Install test dependencies (pytest, redis)"
 

--- a/proto/sonic.pb.go
+++ b/proto/sonic.pb.go
@@ -22,10 +22,11 @@ const (
 	Target_COUNTERS_DB Target = 2
 	Target_CONFIG_DB   Target = 4
 	// PFC_WD_DB shares the the same db number with FLEX_COUNTER_DB
-	Target_PFC_WD_DB       Target = 5
-	Target_FLEX_COUNTER_DB Target = 5
-	Target_STATE_DB        Target = 6
+	Target_PFC_WD_DB        Target = 5
+	Target_FLEX_COUNTER_DB  Target = 5
+	Target_STATE_DB         Target = 6
 	Target_CHASSIS_STATE_DB Target = 13
+	Target_DPU_COUNTERS_DB  Target = 18
 	// For none-DB data
 	Target_OTHERS Target = 100
 )
@@ -39,6 +40,7 @@ var Target_name = map[int32]string{
 	// Duplicate value: 5: "FLEX_COUNTER_DB",
 	6:   "STATE_DB",
 	13:  "CHASSIS_STATE_DB",
+	18:  "DPU_COUNTERS_DB",
 	100: "OTHERS",
 }
 var Target_value = map[string]int32{
@@ -50,7 +52,8 @@ var Target_value = map[string]int32{
 	"FLEX_COUNTER_DB":  5,
 	"STATE_DB":         6,
 	"CHASSIS_STATE_DB": 13,
-	"OTHERS":          100,
+	"DPU_COUNTERS_DB":  18,
+	"OTHERS":           100,
 }
 
 func (x Target) String() string {

--- a/proto/sonic.proto
+++ b/proto/sonic.proto
@@ -17,6 +17,7 @@ enum Target {
   FLEX_COUNTER_DB   = 5;
   STATE_DB          = 6;
   CHASSIS_STATE_DB  = 13;
+  DPU_COUNTERS_DB   = 18;
   // For none-DB data
   OTHERS            = 100;
 }

--- a/sonic_data_client/client_test.go
+++ b/sonic_data_client/client_test.go
@@ -1337,6 +1337,37 @@ func TestV2rDashMeterByEniAndClass(t *testing.T) {
 			t.Errorf("class 200 should not be returned when filtering for class 100")
 		}
 	})
+
+	t.Run("Nil_RedisClient", func(t *testing.T) {
+		// Temporarily remove DPU_COUNTERS_DB from Target2RedisDb
+		ns := ""
+		origNs := Target2RedisDb[ns]
+		Target2RedisDb[ns] = map[string]*redis.Client{}
+		defer func() { Target2RedisDb[ns] = origNs }()
+
+		paths := []string{"DPU_COUNTERS_DB", "DASH_METER", "eni1", "100"}
+		_, err := v2rDashMeterByEniAndClass(paths)
+		if err == nil {
+			t.Errorf("expected error when Redis client is nil")
+		}
+	})
+
+	t.Run("Wildcard_Unknown_ENI_OID", func(t *testing.T) {
+		// Insert a DASH_METER key with an OID not in countersEniOidNameMap
+		unknownKey := `COUNTERS:{"eni_id":"oid:0xUNKNOWN","meter_class":"100","switch_id":"oid:0xSW1"}`
+		rclient.HSet(unknownKey, "bytes", "999")
+		defer rclient.Del(unknownKey)
+
+		paths := []string{"DPU_COUNTERS_DB", "DASH_METER", "*", "100"}
+		tblPaths, err := v2rDashMeterByEniAndClass(paths)
+		if err != nil {
+			t.Fatalf("v2rDashMeterByEniAndClass wildcard failed: %v", err)
+		}
+		// Only eni1 should be returned; unknown OID should be skipped
+		if len(tblPaths) != 1 {
+			t.Fatalf("expected 1 tablePath (unknown OID skipped), got %d", len(tblPaths))
+		}
+	})
 }
 
 func TestV2rDashMeterByEni(t *testing.T) {
@@ -1425,6 +1456,37 @@ func TestV2rDashMeterByEni(t *testing.T) {
 		_, err := v2rDashMeterByEni(paths)
 		if err == nil {
 			t.Errorf("expected error for invalid ENI name")
+		}
+	})
+
+	t.Run("Nil_RedisClient", func(t *testing.T) {
+		// Temporarily remove DPU_COUNTERS_DB from Target2RedisDb
+		origNs := Target2RedisDb[ns]
+		Target2RedisDb[ns] = map[string]*redis.Client{}
+		defer func() { Target2RedisDb[ns] = origNs }()
+
+		paths := []string{"DPU_COUNTERS_DB", "DASH_METER", "eni1"}
+		_, err := v2rDashMeterByEni(paths)
+		if err == nil {
+			t.Errorf("expected error when Redis client is nil")
+		}
+	})
+
+	t.Run("Wildcard_Unknown_ENI_OID", func(t *testing.T) {
+		// Insert a key with an OID not in countersEniOidNameMap
+		unknownKey := `COUNTERS:{"eni_id":"oid:0xUNKNOWN","meter_class":"300","switch_id":"oid:0xSW1"}`
+		rclient.HSet(unknownKey, "bytes", "999")
+		defer rclient.Del(unknownKey)
+
+		paths := []string{"DPU_COUNTERS_DB", "DASH_METER", "*"}
+		tblPaths, err := v2rDashMeterByEni(paths)
+		if err != nil {
+			t.Fatalf("v2rDashMeterByEni wildcard failed: %v", err)
+		}
+		// Only 3 valid results (eni1 class 100, eni1 class 200, eni2 class 100);
+		// unknown OID key should be skipped
+		if len(tblPaths) != 3 {
+			t.Fatalf("expected 3 tablePaths (unknown OID skipped), got %d", len(tblPaths))
 		}
 	})
 }
@@ -1623,6 +1685,22 @@ func TestGetDashMeterKeys(t *testing.T) {
 		}
 		if len(results) != 0 {
 			t.Errorf("expected 0 results, got %d", len(results))
+		}
+	})
+
+	t.Run("Malformed_JSON_Key", func(t *testing.T) {
+		// Insert a key with invalid JSON that starts with '{' — should be skipped
+		badKey := "COUNTERS:{not valid json"
+		rclient.HSet(badKey, "foo", "bar")
+		defer rclient.Del(badKey)
+
+		results, err := getDashMeterKeys(rclient, ":", "", "")
+		if err != nil {
+			t.Fatalf("getDashMeterKeys failed: %v", err)
+		}
+		// Should still return 2 valid keys, skipping the malformed one
+		if len(results) != 2 {
+			t.Fatalf("expected 2 results (malformed JSON skipped), got %d", len(results))
 		}
 	})
 }

--- a/sonic_data_client/client_test.go
+++ b/sonic_data_client/client_test.go
@@ -832,6 +832,39 @@ func saveAndResetTarget2RedisDb() func() {
 	return func() { Target2RedisDb = orig }
 }
 
+func setupTestTarget2RedisDb(t *testing.T) func() {
+	t.Helper()
+	restore := saveAndResetTarget2RedisDb()
+	origFlag := UseRedisLocalTcpPort
+	UseRedisLocalTcpPort = true
+
+	ns := ""
+	patches := gomonkey.ApplyFunc(sdcfg.GetDbAllNamespaces, func() ([]string, error) {
+		return []string{ns}, nil
+	})
+	patches.ApplyFunc(sdcfg.GetDbTcpAddr, func(dbName string, _ string) (string, error) {
+		return "127.0.0.1:6379", nil
+	})
+
+	err := useRedisTcpClient()
+	patches.Reset()
+	UseRedisLocalTcpPort = origFlag
+
+	if err != nil {
+		restore()
+		t.Fatalf("useRedisTcpClient failed: %v", err)
+	}
+
+	return func() {
+		for _, nsMap := range Target2RedisDb {
+			for _, rc := range nsMap {
+				rc.FlushDB()
+			}
+		}
+		restore()
+	}
+}
+
 func TestInitRedisDbClients(t *testing.T) {
 	ns := ""
 
@@ -1590,136 +1623,6 @@ func TestGetDashMeterKeys(t *testing.T) {
 		}
 		if len(results) != 0 {
 			t.Errorf("expected 0 results, got %d", len(results))
-		}
-	})
-}
-
-func TestParsePathDpuCountersDb(t *testing.T) {
-	// Save and restore the ENI maps
-	origEniNameMap := countersEniNameMap
-	origEniOidNameMap := countersEniOidNameMap
-	origFn := getDpuCountersMapFn
-	defer func() {
-		countersEniNameMap = origEniNameMap
-		countersEniOidNameMap = origEniOidNameMap
-		getDpuCountersMapFn = origFn
-	}()
-
-	getDpuCountersMapFn = func(tableName string) (map[string]string, error) {
-		switch tableName {
-		case "COUNTERS_ENI_NAME_MAP":
-			return map[string]string{"eni1": "oid:0xENI1"}, nil
-		case "COUNTERS_ENI_OID_NAME_MAP":
-			return map[string]string{"oid:0xENI1": "eni1"}, nil
-		default:
-			return nil, fmt.Errorf("unexpected table %s", tableName)
-		}
-	}
-
-	os.Setenv("UNIT_TEST", "1")
-	ClearMappings()
-	os.Unsetenv("UNIT_TEST")
-
-	t.Run("DPU_COUNTERS_DB_ENI_VirtualPath", func(t *testing.T) {
-		pathG2S := make(map[*gnmipb.Path][]tablePath)
-		prefix := &gnmipb.Path{Target: "DPU_COUNTERS_DB"}
-		path := &gnmipb.Path{Elem: []*gnmipb.PathElem{{Name: "COUNTERS"}, {Name: "ENI"}, {Name: "eni1"}}}
-		err := parsePath(prefix, path, &pathG2S)
-		if err != nil {
-			t.Fatalf("parsePath failed: %v", err)
-		}
-		for _, tblPaths := range pathG2S {
-			if !tblPaths[0].isVirtualPath {
-				t.Errorf("expected isVirtualPath=true for COUNTERS/ENI/eni1")
-			}
-			if tblPaths[0].tableKey != "oid:0xENI1" {
-				t.Errorf("expected tableKey oid:0xENI1, got %v", tblPaths[0].tableKey)
-			}
-			if tblPaths[0].dbName != "DPU_COUNTERS_DB" {
-				t.Errorf("expected dbName DPU_COUNTERS_DB, got %v", tblPaths[0].dbName)
-			}
-		}
-	})
-
-	// Non-virtual (direct) DPU_COUNTERS_DB path should work regardless of ENI map state
-	t.Run("DPU_COUNTERS_DB_DirectPath", func(t *testing.T) {
-		pathG2S := make(map[*gnmipb.Path][]tablePath)
-		prefix := &gnmipb.Path{Target: "DPU_COUNTERS_DB"}
-		path := &gnmipb.Path{Elem: []*gnmipb.PathElem{{Name: "SOME_TABLE"}, {Name: "some_key"}}}
-		err := parsePath(prefix, path, &pathG2S)
-		if err != nil {
-			t.Fatalf("parsePath failed for direct DPU_COUNTERS_DB path: %v", err)
-		}
-		for _, tblPaths := range pathG2S {
-			if tblPaths[0].isVirtualPath {
-				t.Errorf("expected isVirtualPath=false for direct path")
-			}
-			if tblPaths[0].dbName != "DPU_COUNTERS_DB" {
-				t.Errorf("expected dbName DPU_COUNTERS_DB, got %v", tblPaths[0].dbName)
-			}
-			if tblPaths[0].tableName != "SOME_TABLE" {
-				t.Errorf("expected tableName SOME_TABLE, got %v", tblPaths[0].tableName)
-			}
-			if tblPaths[0].tableKey != "some_key" {
-				t.Errorf("expected tableKey some_key, got %v", tblPaths[0].tableKey)
-			}
-		}
-	})
-}
-
-// TestParsePathDpuCountersDb_EniMapInitFails verifies that parsePath does not
-// return an error when initCountersEniNameMap fails (e.g., ENI mapping tables
-// don't exist in DPU_COUNTERS_DB or DPU_COUNTERS_DB is unavailable). This
-// ensures non-ENI DPU_COUNTERS_DB paths and other DB paths are unaffected.
-func TestParsePathDpuCountersDb_EniMapInitFails(t *testing.T) {
-	origEniNameMap := countersEniNameMap
-	origEniOidNameMap := countersEniOidNameMap
-	origFn := getDpuCountersMapFn
-	defer func() {
-		countersEniNameMap = origEniNameMap
-		countersEniOidNameMap = origEniOidNameMap
-		getDpuCountersMapFn = origFn
-	}()
-
-	// Simulate DPU_COUNTERS_DB not having ENI mapping tables (or DB not existing)
-	getDpuCountersMapFn = func(tableName string) (map[string]string, error) {
-		return nil, fmt.Errorf("DPU_COUNTERS_DB not available")
-	}
-
-	os.Setenv("UNIT_TEST", "1")
-	ClearMappings()
-	os.Unsetenv("UNIT_TEST")
-
-	t.Run("DirectPath_Succeeds", func(t *testing.T) {
-		pathG2S := make(map[*gnmipb.Path][]tablePath)
-		prefix := &gnmipb.Path{Target: "DPU_COUNTERS_DB"}
-		path := &gnmipb.Path{Elem: []*gnmipb.PathElem{{Name: "SOME_TABLE"}, {Name: "some_key"}}}
-		err := parsePath(prefix, path, &pathG2S)
-		if err != nil {
-			t.Fatalf("parsePath should not fail for direct path when ENI init fails: %v", err)
-		}
-		for _, tblPaths := range pathG2S {
-			if tblPaths[0].isVirtualPath {
-				t.Errorf("expected isVirtualPath=false for direct path")
-			}
-			if tblPaths[0].tableName != "SOME_TABLE" {
-				t.Errorf("expected tableName SOME_TABLE, got %v", tblPaths[0].tableName)
-			}
-		}
-	})
-
-	t.Run("OtherDb_Unaffected", func(t *testing.T) {
-		pathG2S := make(map[*gnmipb.Path][]tablePath)
-		prefix := &gnmipb.Path{Target: "STATE_DB"}
-		path := &gnmipb.Path{Elem: []*gnmipb.PathElem{{Name: "NEIGH_STATE_TABLE"}, {Name: "10.0.0.57"}}}
-		err := parsePath(prefix, path, &pathG2S)
-		if err != nil {
-			t.Fatalf("parsePath for STATE_DB should not be affected by DPU init failure: %v", err)
-		}
-		for _, tblPaths := range pathG2S {
-			if tblPaths[0].tableKey != "10.0.0.57" {
-				t.Errorf("expected tableKey 10.0.0.57, got %v", tblPaths[0].tableKey)
-			}
 		}
 	})
 }

--- a/sonic_data_client/client_test.go
+++ b/sonic_data_client/client_test.go
@@ -1130,3 +1130,621 @@ func TestGetTableDashHA(t *testing.T) {
 	swsscommon.DeleteZmqClient(zmqClient)
 	swsscommon.DeleteZmqServer(zmqServer)
 }
+
+func TestV2rEniStats(t *testing.T) {
+	// Save and restore the ENI maps
+	origEniNameMap := countersEniNameMap
+	origEniOidNameMap := countersEniOidNameMap
+	defer func() {
+		countersEniNameMap = origEniNameMap
+		countersEniOidNameMap = origEniOidNameMap
+	}()
+
+	countersEniNameMap = map[string]string{
+		"eni1": "oid:0xENI1",
+		"eni2": "oid:0xENI2",
+	}
+	countersEniOidNameMap = map[string]string{
+		"oid:0xENI1": "eni1",
+		"oid:0xENI2": "eni2",
+	}
+
+	t.Run("Wildcard_AllENIs", func(t *testing.T) {
+		paths := []string{"DPU_COUNTERS_DB", "COUNTERS", "ENI", "*"}
+		tblPaths, err := v2rEniStats(paths)
+		if err != nil {
+			t.Fatalf("v2rEniStats failed: %v", err)
+		}
+		if len(tblPaths) != 2 {
+			t.Fatalf("expected 2 tablePaths, got %d", len(tblPaths))
+		}
+		eniFound := map[string]bool{}
+		for _, tp := range tblPaths {
+			if tp.dbName != "DPU_COUNTERS_DB" {
+				t.Errorf("expected dbName DPU_COUNTERS_DB, got %v", tp.dbName)
+			}
+			if tp.tableName != "COUNTERS" {
+				t.Errorf("expected tableName COUNTERS, got %v", tp.tableName)
+			}
+			eniFound[tp.jsonTableKey] = true
+		}
+		if !eniFound["eni1"] || !eniFound["eni2"] {
+			t.Errorf("expected both eni1 and eni2 in results, got %v", eniFound)
+		}
+	})
+
+	t.Run("Specific_ENI", func(t *testing.T) {
+		paths := []string{"DPU_COUNTERS_DB", "COUNTERS", "ENI", "eni1"}
+		tblPaths, err := v2rEniStats(paths)
+		if err != nil {
+			t.Fatalf("v2rEniStats failed: %v", err)
+		}
+		if len(tblPaths) != 1 {
+			t.Fatalf("expected 1 tablePath, got %d", len(tblPaths))
+		}
+		if tblPaths[0].tableKey != "oid:0xENI1" {
+			t.Errorf("expected tableKey oid:0xENI1, got %v", tblPaths[0].tableKey)
+		}
+	})
+
+	t.Run("Invalid_ENI", func(t *testing.T) {
+		paths := []string{"DPU_COUNTERS_DB", "COUNTERS", "ENI", "nonexistent"}
+		_, err := v2rEniStats(paths)
+		if err == nil {
+			t.Errorf("expected error for invalid ENI name")
+		}
+	})
+}
+
+func TestV2rDashMeterByEniAndClass(t *testing.T) {
+	cleanup := setupTestTarget2RedisDb(t)
+	defer cleanup()
+
+	// Save and restore the ENI maps
+	origEniNameMap := countersEniNameMap
+	origEniOidNameMap := countersEniOidNameMap
+	defer func() {
+		countersEniNameMap = origEniNameMap
+		countersEniOidNameMap = origEniOidNameMap
+	}()
+
+	countersEniNameMap = map[string]string{
+		"eni1": "oid:0xENI1",
+	}
+	countersEniOidNameMap = map[string]string{
+		"oid:0xENI1": "eni1",
+	}
+
+	ns := ""
+	rclient := Target2RedisDb[ns]["DPU_COUNTERS_DB"]
+	if rclient == nil {
+		t.Fatal("DPU_COUNTERS_DB Redis client not available — ensure Redis is configured with 'databases 20'")
+	}
+
+	// Insert a DASH_METER key
+	dashKey := `COUNTERS:{"eni_id":"oid:0xENI1","meter_class":"100","switch_id":"oid:0xSW1"}`
+	rclient.HSet(dashKey, "bytes", "1000")
+	rclient.HSet(dashKey, "packets", "10")
+	defer rclient.Del(dashKey)
+
+	t.Run("Specific_ENI_And_Class", func(t *testing.T) {
+		paths := []string{"DPU_COUNTERS_DB", "DASH_METER", "eni1", "100"}
+		tblPaths, err := v2rDashMeterByEniAndClass(paths)
+		if err != nil {
+			t.Fatalf("v2rDashMeterByEniAndClass failed: %v", err)
+		}
+		if len(tblPaths) != 1 {
+			t.Fatalf("expected 1 tablePath, got %d", len(tblPaths))
+		}
+		if tblPaths[0].dbName != "DPU_COUNTERS_DB" {
+			t.Errorf("expected dbName DPU_COUNTERS_DB, got %v", tblPaths[0].dbName)
+		}
+		if tblPaths[0].tableName != "COUNTERS" {
+			t.Errorf("expected tableName COUNTERS, got %v", tblPaths[0].tableName)
+		}
+		if tblPaths[0].jsonTableKey != "100" {
+			t.Errorf("expected jsonTableKey '100', got %v", tblPaths[0].jsonTableKey)
+		}
+	})
+
+	t.Run("Invalid_ENI", func(t *testing.T) {
+		paths := []string{"DPU_COUNTERS_DB", "DASH_METER", "bad_eni", "100"}
+		_, err := v2rDashMeterByEniAndClass(paths)
+		if err == nil {
+			t.Errorf("expected error for invalid ENI name")
+		}
+	})
+
+	t.Run("NoMatching_Class", func(t *testing.T) {
+		paths := []string{"DPU_COUNTERS_DB", "DASH_METER", "eni1", "999"}
+		_, err := v2rDashMeterByEniAndClass(paths)
+		if err == nil {
+			t.Errorf("expected error when no matching meter class")
+		}
+	})
+
+	t.Run("Wildcard_ENI_Specific_Class", func(t *testing.T) {
+		// Add a second ENI with the same meter class and a different class key
+		countersEniNameMap["eni2"] = "oid:0xENI2"
+		countersEniOidNameMap["oid:0xENI2"] = "eni2"
+		dashKey2 := `COUNTERS:{"eni_id":"oid:0xENI2","meter_class":"100","switch_id":"oid:0xSW1"}`
+		dashKey3 := `COUNTERS:{"eni_id":"oid:0xENI2","meter_class":"200","switch_id":"oid:0xSW1"}`
+		rclient.HSet(dashKey2, "bytes", "2000")
+		rclient.HSet(dashKey2, "packets", "20")
+		rclient.HSet(dashKey3, "bytes", "3000")
+		rclient.HSet(dashKey3, "packets", "30")
+		defer rclient.Del(dashKey2)
+		defer rclient.Del(dashKey3)
+		defer func() {
+			delete(countersEniNameMap, "eni2")
+			delete(countersEniOidNameMap, "oid:0xENI2")
+		}()
+
+		paths := []string{"DPU_COUNTERS_DB", "DASH_METER", "*", "100"}
+		tblPaths, err := v2rDashMeterByEniAndClass(paths)
+		if err != nil {
+			t.Fatalf("v2rDashMeterByEniAndClass wildcard failed: %v", err)
+		}
+		if len(tblPaths) != 2 {
+			t.Fatalf("expected 2 tablePaths for wildcard ENI, got %d", len(tblPaths))
+		}
+		// Verify exact jsonTableKeys returned
+		keyFound := map[string]bool{}
+		for _, tp := range tblPaths {
+			if tp.tableName != "COUNTERS" {
+				t.Errorf("expected tableName COUNTERS, got %v", tp.tableName)
+			}
+			keyFound[tp.jsonTableKey] = true
+		}
+		if !keyFound["eni1/100"] || !keyFound["eni2/100"] {
+			t.Errorf("expected eni1/100 and eni2/100, got %v", keyFound)
+		}
+		// class 200 must not be returned when filtering for class 100
+		if keyFound["eni2/200"] {
+			t.Errorf("class 200 should not be returned when filtering for class 100")
+		}
+	})
+}
+
+func TestV2rDashMeterByEni(t *testing.T) {
+	cleanup := setupTestTarget2RedisDb(t)
+	defer cleanup()
+
+	// Save and restore the ENI maps
+	origEniNameMap := countersEniNameMap
+	origEniOidNameMap := countersEniOidNameMap
+	defer func() {
+		countersEniNameMap = origEniNameMap
+		countersEniOidNameMap = origEniOidNameMap
+	}()
+
+	countersEniNameMap = map[string]string{
+		"eni1": "oid:0xENI1",
+		"eni2": "oid:0xENI2",
+	}
+	countersEniOidNameMap = map[string]string{
+		"oid:0xENI1": "eni1",
+		"oid:0xENI2": "eni2",
+	}
+
+	ns := ""
+	rclient := Target2RedisDb[ns]["DPU_COUNTERS_DB"]
+	if rclient == nil {
+		t.Fatal("DPU_COUNTERS_DB Redis client not available — ensure Redis is configured with 'databases 20'")
+	}
+
+	// Insert multiple DASH_METER keys
+	key1 := `COUNTERS:{"eni_id":"oid:0xENI1","meter_class":"100","switch_id":"oid:0xSW1"}`
+	key2 := `COUNTERS:{"eni_id":"oid:0xENI1","meter_class":"200","switch_id":"oid:0xSW1"}`
+	key3 := `COUNTERS:{"eni_id":"oid:0xENI2","meter_class":"100","switch_id":"oid:0xSW1"}`
+	// Also insert a non-JSON COUNTERS key that should be skipped
+	key4 := "COUNTERS:oid:0x1000000000039"
+	rclient.HSet(key1, "bytes", "1000")
+	rclient.HSet(key2, "bytes", "2000")
+	rclient.HSet(key3, "bytes", "3000")
+	rclient.HSet(key4, "SAI_PORT_STAT_IF_IN_OCTETS", "999")
+	defer func() {
+		rclient.Del(key1, key2, key3, key4)
+	}()
+
+	t.Run("Specific_ENI_AllClasses", func(t *testing.T) {
+		paths := []string{"DPU_COUNTERS_DB", "DASH_METER", "eni1"}
+		tblPaths, err := v2rDashMeterByEni(paths)
+		if err != nil {
+			t.Fatalf("v2rDashMeterByEni failed: %v", err)
+		}
+		if len(tblPaths) != 2 {
+			t.Fatalf("expected 2 tablePaths for eni1, got %d", len(tblPaths))
+		}
+		classFound := map[string]bool{}
+		for _, tp := range tblPaths {
+			classFound[tp.jsonTableKey] = true
+			if tp.dbName != "DPU_COUNTERS_DB" {
+				t.Errorf("expected dbName DPU_COUNTERS_DB, got %v", tp.dbName)
+			}
+		}
+		if !classFound["100"] || !classFound["200"] {
+			t.Errorf("expected classes 100 and 200, got %v", classFound)
+		}
+	})
+
+	t.Run("Wildcard_AllENIs_AllClasses", func(t *testing.T) {
+		paths := []string{"DPU_COUNTERS_DB", "DASH_METER", "*"}
+		tblPaths, err := v2rDashMeterByEni(paths)
+		if err != nil {
+			t.Fatalf("v2rDashMeterByEni failed: %v", err)
+		}
+		if len(tblPaths) != 3 {
+			t.Fatalf("expected 3 tablePaths for all ENIs, got %d", len(tblPaths))
+		}
+		keyFound := map[string]bool{}
+		for _, tp := range tblPaths {
+			keyFound[tp.jsonTableKey] = true
+		}
+		// Wildcard uses "eniName/class" format
+		if !keyFound["eni1/100"] || !keyFound["eni1/200"] || !keyFound["eni2/100"] {
+			t.Errorf("expected eni1/100, eni1/200, eni2/100 in results, got %v", keyFound)
+		}
+	})
+
+	t.Run("Invalid_ENI", func(t *testing.T) {
+		paths := []string{"DPU_COUNTERS_DB", "DASH_METER", "bad_eni"}
+		_, err := v2rDashMeterByEni(paths)
+		if err == nil {
+			t.Errorf("expected error for invalid ENI name")
+		}
+	})
+}
+
+func TestGetDpuCountersMapForDb(t *testing.T) {
+	cleanup := setupTestTarget2RedisDb(t)
+	defer cleanup()
+
+	ns := ""
+	rclient := Target2RedisDb[ns]["DPU_COUNTERS_DB"]
+	if rclient == nil {
+		t.Fatal("DPU_COUNTERS_DB Redis client not available — ensure Redis is configured with 'databases 20'")
+	}
+
+	rclient.HSet("COUNTERS_ENI_NAME_MAP", "eni1", "oid:0xENI1")
+	defer rclient.Del("COUNTERS_ENI_NAME_MAP")
+
+	result, err := GetCountersMapForDb("DPU_COUNTERS_DB", "COUNTERS_ENI_NAME_MAP")
+	if err != nil {
+		t.Fatalf("GetCountersMapForDb for DPU_COUNTERS_DB failed: %v", err)
+	}
+	if result["eni1"] != "oid:0xENI1" {
+		t.Errorf("expected eni1->oid:0xENI1, got %v", result)
+	}
+}
+
+func TestGetCountersMapForDb(t *testing.T) {
+	cleanup := setupTestTarget2RedisDb(t)
+	defer cleanup()
+
+	ns := ""
+
+	t.Run("COUNTERS_DB", func(t *testing.T) {
+		rclient := Target2RedisDb[ns]["COUNTERS_DB"]
+		rclient.HSet("COUNTERS_PORT_NAME_MAP", "Ethernet0", "oid:0x100")
+		defer rclient.Del("COUNTERS_PORT_NAME_MAP")
+
+		result, err := GetCountersMapForDb("COUNTERS_DB", "COUNTERS_PORT_NAME_MAP")
+		if err != nil {
+			t.Fatalf("GetCountersMapForDb failed: %v", err)
+		}
+		if result["Ethernet0"] != "oid:0x100" {
+			t.Errorf("expected Ethernet0->oid:0x100, got %v", result)
+		}
+	})
+
+	t.Run("DPU_COUNTERS_DB", func(t *testing.T) {
+		rclient := Target2RedisDb[ns]["DPU_COUNTERS_DB"]
+		if rclient == nil {
+			t.Fatal("DPU_COUNTERS_DB Redis client not available — ensure Redis is configured with 'databases 20'")
+		}
+		rclient.HSet("TEST_MAP", "key1", "val1")
+		defer rclient.Del("TEST_MAP")
+
+		result, err := GetCountersMapForDb("DPU_COUNTERS_DB", "TEST_MAP")
+		if err != nil {
+			t.Fatalf("GetCountersMapForDb failed: %v", err)
+		}
+		if result["key1"] != "val1" {
+			t.Errorf("expected key1->val1, got %v", result)
+		}
+	})
+}
+
+func TestInitCountersEniNameMap(t *testing.T) {
+	origFn := getDpuCountersMapFn
+	defer func() { getDpuCountersMapFn = origFn }()
+
+	t.Run("Success", func(t *testing.T) {
+		os.Setenv("UNIT_TEST", "1")
+		ClearMappings()
+		os.Unsetenv("UNIT_TEST")
+
+		getDpuCountersMapFn = func(tableName string) (map[string]string, error) {
+			switch tableName {
+			case "COUNTERS_ENI_NAME_MAP":
+				return map[string]string{"eni1": "oid:0xENI1"}, nil
+			case "COUNTERS_ENI_OID_NAME_MAP":
+				return map[string]string{"oid:0xENI1": "eni1"}, nil
+			default:
+				return nil, fmt.Errorf("unexpected table %s", tableName)
+			}
+		}
+
+		err := initCountersEniNameMap()
+		if err != nil {
+			t.Fatalf("initCountersEniNameMap failed: %v", err)
+		}
+		if countersEniNameMap["eni1"] != "oid:0xENI1" {
+			t.Errorf("expected eni1->oid:0xENI1, got %v", countersEniNameMap)
+		}
+		if countersEniOidNameMap["oid:0xENI1"] != "eni1" {
+			t.Errorf("expected oid:0xENI1->eni1, got %v", countersEniOidNameMap)
+		}
+	})
+
+	t.Run("Error_NameMap", func(t *testing.T) {
+		os.Setenv("UNIT_TEST", "1")
+		ClearMappings()
+		os.Unsetenv("UNIT_TEST")
+
+		getDpuCountersMapFn = func(tableName string) (map[string]string, error) {
+			return nil, fmt.Errorf("redis error")
+		}
+
+		err := initCountersEniNameMap()
+		if err == nil {
+			t.Errorf("expected error when COUNTERS_ENI_NAME_MAP fails")
+		}
+	})
+
+	t.Run("Error_OidNameMap_NilsOutNameMap", func(t *testing.T) {
+		os.Setenv("UNIT_TEST", "1")
+		ClearMappings()
+		os.Unsetenv("UNIT_TEST")
+
+		getDpuCountersMapFn = func(tableName string) (map[string]string, error) {
+			if tableName == "COUNTERS_ENI_NAME_MAP" {
+				return map[string]string{"eni1": "oid:0xENI1"}, nil
+			}
+			return nil, fmt.Errorf("redis error on OID map")
+		}
+
+		err := initCountersEniNameMap()
+		if err == nil {
+			t.Errorf("expected error when COUNTERS_ENI_OID_NAME_MAP fails")
+		}
+		if countersEniNameMap != nil {
+			t.Errorf("expected countersEniNameMap to be nil after partial failure, got %v", countersEniNameMap)
+		}
+	})
+}
+
+func TestGetDashMeterKeys(t *testing.T) {
+	cleanup := setupTestTarget2RedisDb(t)
+	defer cleanup()
+
+	ns := ""
+	rclient := Target2RedisDb[ns]["DPU_COUNTERS_DB"]
+	if rclient == nil {
+		t.Fatal("DPU_COUNTERS_DB Redis client not available — ensure Redis is configured with 'databases 20'")
+	}
+
+	// Insert test keys
+	key1 := `COUNTERS:{"eni_id":"oid:0xENI1","meter_class":"100","switch_id":"oid:0xSW1"}`
+	key2 := `COUNTERS:{"eni_id":"oid:0xENI2","meter_class":"200","switch_id":"oid:0xSW1"}`
+	// Non-JSON key that should be skipped
+	key3 := "COUNTERS:oid:0x1000000000039"
+	rclient.HSet(key1, "bytes", "1000")
+	rclient.HSet(key2, "bytes", "2000")
+	rclient.HSet(key3, "SAI_PORT_STAT_IF_IN_OCTETS", "999")
+	defer func() {
+		rclient.Del(key1, key2, key3)
+	}()
+
+	t.Run("All_Keys", func(t *testing.T) {
+		results, err := getDashMeterKeys(rclient, ":", "", "")
+		if err != nil {
+			t.Fatalf("getDashMeterKeys failed: %v", err)
+		}
+		if len(results) != 2 {
+			t.Fatalf("expected 2 results (non-JSON key skipped), got %d", len(results))
+		}
+	})
+
+	t.Run("Filter_By_ENI", func(t *testing.T) {
+		results, err := getDashMeterKeys(rclient, ":", "oid:0xENI1", "")
+		if err != nil {
+			t.Fatalf("getDashMeterKeys failed: %v", err)
+		}
+		if len(results) != 1 {
+			t.Fatalf("expected 1 result for ENI1, got %d", len(results))
+		}
+		if results[0].eniOid != "oid:0xENI1" {
+			t.Errorf("expected eniOid oid:0xENI1, got %v", results[0].eniOid)
+		}
+	})
+
+	t.Run("Filter_By_ENI_And_Class", func(t *testing.T) {
+		results, err := getDashMeterKeys(rclient, ":", "oid:0xENI1", "100")
+		if err != nil {
+			t.Fatalf("getDashMeterKeys failed: %v", err)
+		}
+		if len(results) != 1 {
+			t.Fatalf("expected 1 result, got %d", len(results))
+		}
+		if results[0].meterClass != "100" {
+			t.Errorf("expected meterClass 100, got %v", results[0].meterClass)
+		}
+	})
+
+	t.Run("No_Match", func(t *testing.T) {
+		results, err := getDashMeterKeys(rclient, ":", "oid:0xNONEXISTENT", "")
+		if err != nil {
+			t.Fatalf("getDashMeterKeys failed: %v", err)
+		}
+		if len(results) != 0 {
+			t.Errorf("expected 0 results, got %d", len(results))
+		}
+	})
+}
+
+func TestParsePathDpuCountersDb(t *testing.T) {
+	// Save and restore the ENI maps
+	origEniNameMap := countersEniNameMap
+	origEniOidNameMap := countersEniOidNameMap
+	origFn := getDpuCountersMapFn
+	defer func() {
+		countersEniNameMap = origEniNameMap
+		countersEniOidNameMap = origEniOidNameMap
+		getDpuCountersMapFn = origFn
+	}()
+
+	getDpuCountersMapFn = func(tableName string) (map[string]string, error) {
+		switch tableName {
+		case "COUNTERS_ENI_NAME_MAP":
+			return map[string]string{"eni1": "oid:0xENI1"}, nil
+		case "COUNTERS_ENI_OID_NAME_MAP":
+			return map[string]string{"oid:0xENI1": "eni1"}, nil
+		default:
+			return nil, fmt.Errorf("unexpected table %s", tableName)
+		}
+	}
+
+	os.Setenv("UNIT_TEST", "1")
+	ClearMappings()
+	os.Unsetenv("UNIT_TEST")
+
+	t.Run("DPU_COUNTERS_DB_ENI_VirtualPath", func(t *testing.T) {
+		pathG2S := make(map[*gnmipb.Path][]tablePath)
+		prefix := &gnmipb.Path{Target: "DPU_COUNTERS_DB"}
+		path := &gnmipb.Path{Elem: []*gnmipb.PathElem{{Name: "COUNTERS"}, {Name: "ENI"}, {Name: "eni1"}}}
+		err := parsePath(prefix, path, &pathG2S)
+		if err != nil {
+			t.Fatalf("parsePath failed: %v", err)
+		}
+		for _, tblPaths := range pathG2S {
+			if !tblPaths[0].isVirtualPath {
+				t.Errorf("expected isVirtualPath=true for COUNTERS/ENI/eni1")
+			}
+			if tblPaths[0].tableKey != "oid:0xENI1" {
+				t.Errorf("expected tableKey oid:0xENI1, got %v", tblPaths[0].tableKey)
+			}
+			if tblPaths[0].dbName != "DPU_COUNTERS_DB" {
+				t.Errorf("expected dbName DPU_COUNTERS_DB, got %v", tblPaths[0].dbName)
+			}
+		}
+	})
+
+	// Non-virtual (direct) DPU_COUNTERS_DB path should work regardless of ENI map state
+	t.Run("DPU_COUNTERS_DB_DirectPath", func(t *testing.T) {
+		pathG2S := make(map[*gnmipb.Path][]tablePath)
+		prefix := &gnmipb.Path{Target: "DPU_COUNTERS_DB"}
+		path := &gnmipb.Path{Elem: []*gnmipb.PathElem{{Name: "SOME_TABLE"}, {Name: "some_key"}}}
+		err := parsePath(prefix, path, &pathG2S)
+		if err != nil {
+			t.Fatalf("parsePath failed for direct DPU_COUNTERS_DB path: %v", err)
+		}
+		for _, tblPaths := range pathG2S {
+			if tblPaths[0].isVirtualPath {
+				t.Errorf("expected isVirtualPath=false for direct path")
+			}
+			if tblPaths[0].dbName != "DPU_COUNTERS_DB" {
+				t.Errorf("expected dbName DPU_COUNTERS_DB, got %v", tblPaths[0].dbName)
+			}
+			if tblPaths[0].tableName != "SOME_TABLE" {
+				t.Errorf("expected tableName SOME_TABLE, got %v", tblPaths[0].tableName)
+			}
+			if tblPaths[0].tableKey != "some_key" {
+				t.Errorf("expected tableKey some_key, got %v", tblPaths[0].tableKey)
+			}
+		}
+	})
+}
+
+// TestParsePathDpuCountersDb_EniMapInitFails verifies that parsePath does not
+// return an error when initCountersEniNameMap fails (e.g., ENI mapping tables
+// don't exist in DPU_COUNTERS_DB or DPU_COUNTERS_DB is unavailable). This
+// ensures non-ENI DPU_COUNTERS_DB paths and other DB paths are unaffected.
+func TestParsePathDpuCountersDb_EniMapInitFails(t *testing.T) {
+	origEniNameMap := countersEniNameMap
+	origEniOidNameMap := countersEniOidNameMap
+	origFn := getDpuCountersMapFn
+	defer func() {
+		countersEniNameMap = origEniNameMap
+		countersEniOidNameMap = origEniOidNameMap
+		getDpuCountersMapFn = origFn
+	}()
+
+	// Simulate DPU_COUNTERS_DB not having ENI mapping tables (or DB not existing)
+	getDpuCountersMapFn = func(tableName string) (map[string]string, error) {
+		return nil, fmt.Errorf("DPU_COUNTERS_DB not available")
+	}
+
+	os.Setenv("UNIT_TEST", "1")
+	ClearMappings()
+	os.Unsetenv("UNIT_TEST")
+
+	t.Run("DirectPath_Succeeds", func(t *testing.T) {
+		pathG2S := make(map[*gnmipb.Path][]tablePath)
+		prefix := &gnmipb.Path{Target: "DPU_COUNTERS_DB"}
+		path := &gnmipb.Path{Elem: []*gnmipb.PathElem{{Name: "SOME_TABLE"}, {Name: "some_key"}}}
+		err := parsePath(prefix, path, &pathG2S)
+		if err != nil {
+			t.Fatalf("parsePath should not fail for direct path when ENI init fails: %v", err)
+		}
+		for _, tblPaths := range pathG2S {
+			if tblPaths[0].isVirtualPath {
+				t.Errorf("expected isVirtualPath=false for direct path")
+			}
+			if tblPaths[0].tableName != "SOME_TABLE" {
+				t.Errorf("expected tableName SOME_TABLE, got %v", tblPaths[0].tableName)
+			}
+		}
+	})
+
+	t.Run("OtherDb_Unaffected", func(t *testing.T) {
+		pathG2S := make(map[*gnmipb.Path][]tablePath)
+		prefix := &gnmipb.Path{Target: "STATE_DB"}
+		path := &gnmipb.Path{Elem: []*gnmipb.PathElem{{Name: "NEIGH_STATE_TABLE"}, {Name: "10.0.0.57"}}}
+		err := parsePath(prefix, path, &pathG2S)
+		if err != nil {
+			t.Fatalf("parsePath for STATE_DB should not be affected by DPU init failure: %v", err)
+		}
+		for _, tblPaths := range pathG2S {
+			if tblPaths[0].tableKey != "10.0.0.57" {
+				t.Errorf("expected tableKey 10.0.0.57, got %v", tblPaths[0].tableKey)
+			}
+		}
+	})
+}
+
+func TestClearMappingsIncludesEniMaps(t *testing.T) {
+	// Ensure maps are initialized (may be nil if a prior test's init failed)
+	if countersEniNameMap == nil {
+		countersEniNameMap = make(map[string]string)
+	}
+	if countersEniOidNameMap == nil {
+		countersEniOidNameMap = make(map[string]string)
+	}
+
+	// Populate ENI maps
+	countersEniNameMap["test_eni"] = "oid:0xTEST"
+	countersEniOidNameMap["oid:0xTEST"] = "test_eni"
+
+	os.Setenv("UNIT_TEST", "1")
+	ClearMappings()
+	os.Unsetenv("UNIT_TEST")
+
+	if len(countersEniNameMap) != 0 {
+		t.Errorf("expected countersEniNameMap to be cleared, got %v", countersEniNameMap)
+	}
+	if len(countersEniOidNameMap) != 0 {
+		t.Errorf("expected countersEniOidNameMap to be cleared, got %v", countersEniOidNameMap)
+	}
+}

--- a/sonic_data_client/db_client.go
+++ b/sonic_data_client/db_client.go
@@ -706,6 +706,13 @@ func populateDbtablePath(prefix, path *gnmipb.Path, pathG2S *map[*gnmipb.Path][]
 		}
 	}
 
+	if targetDbName == "DPU_COUNTERS_DB" {
+		err := initCountersEniNameMap()
+		if err != nil {
+			log.Errorf("Could not create CountersEniNameMap: %v", err)
+		}
+	}
+
 	fullPath := path
 	if prefix != nil {
 		fullPath = gnmiFullPath(prefix, path)

--- a/sonic_data_client/virtual_db.go
+++ b/sonic_data_client/virtual_db.go
@@ -1137,25 +1137,6 @@ func getPortNamespace(port string) (string, error) {
 	return namespace, nil
 }
 
-func ClearMappings() {
-	value := os.Getenv("UNIT_TEST")
-	if value != "1" {
-		return
-	}
-	counterMaps := []map[string]string{
-		countersPortNameMap,
-		alias2nameMap,
-		countersFabricPortNameMap,
-		countersQueueNameMap,
-		countersAclRuleMap,
-	}
-	for _, counterMap := range counterMaps {
-		for entry := range counterMap {
-			delete(counterMap, entry)
-		}
-	}
-}
-
 func AliasToPortNameMap() map[string]string {
 	output := make(map[string]string, len(alias2nameMap))
 	for alias, portName := range alias2nameMap {

--- a/sonic_data_client/virtual_db.go
+++ b/sonic_data_client/virtual_db.go
@@ -1,10 +1,13 @@
 package client
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 
+	"github.com/go-redis/redis"
 	log "github.com/golang/glog"
 	sdcfg "github.com/sonic-net/sonic-gnmi/sonic_db_config"
 )
@@ -62,6 +65,25 @@ var (
 	// SONiC Switch ID to Switch Stat packet integrity drop counters
 	countersDebugNameSwitchStatMap = make(map[string]string)
 
+	// ENI name to OID map in COUNTERS_ENI_NAME_MAP of DPU_COUNTERS_DB
+	countersEniNameMap = make(map[string]string)
+	// ENI OID to name map in COUNTERS_ENI_OID_NAME_MAP of DPU_COUNTERS_DB
+	countersEniOidNameMap = make(map[string]string)
+
+	// sync.Once guards for each init function
+	initCountersPortNameMapOnce       sync.Once
+	initCountersQueueNameMapOnce      sync.Once
+	initCountersPGNameMapOnce         sync.Once
+	initCountersSidMapOnce            sync.Once
+	initCountersAclRuleMapOnce        sync.Once
+	initAliasMapOnce                  sync.Once
+	initCountersPfcwdNameMapOnce      sync.Once
+	initCountersFabricPortNameMapOnce sync.Once
+	initCountersEniNameMapOnce        sync.Once
+
+	// Mutex to protect ClearMappings from racing with init functions
+	clearMappingsMu sync.RWMutex
+
 	// path2TFuncTbl is used to populate trie tree which is reponsible
 	// for virtual path to real data path translation
 	pathTransFuncTbl = []pathTransFunc{
@@ -106,8 +128,27 @@ var (
 		}, { // specific field stats for PORT_PHY_ATTR for one or all Ethernet ports (no alias translation)
 			path:      []string{"COUNTERS_DB", "PORT_PHY_ATTR", "Ethernet*", "*"},
 			transFunc: v2rTranslate(v2rPortPhyAttrFieldStats),
+		}, { // ENI counters stats for one or all ENIs in DPU_COUNTERS_DB
+			path:      []string{"DPU_COUNTERS_DB", "COUNTERS", "ENI", "*"},
+			transFunc: v2rTranslate(v2rEniStats),
+		}, { // DASH_METER stats for specific ENI and metering class
+			path:      []string{"DPU_COUNTERS_DB", "DASH_METER", "*", "*"},
+			transFunc: v2rTranslate(v2rDashMeterByEniAndClass),
+		}, { // DASH_METER stats for all metering classes of a specific ENI (or all ENIs)
+			path:      []string{"DPU_COUNTERS_DB", "DASH_METER", "*"},
+			transFunc: v2rTranslate(v2rDashMeterByEni),
 		},
 	}
+)
+
+// Function variables for map fetching. Init functions call these instead of
+// the concrete implementations, allowing tests to inject errors.
+var (
+	getCountersMapFn       = func(t string) (map[string]string, error) { return GetCountersMap(t) }
+	getAliasMapFn          = func() (map[string]string, map[string]string, map[string]string, error) { return getAliasMap() }
+	getFabricCountersMapFn = func(t string) (map[string]string, error) { return getFabricCountersMap(t) }
+	getPfcwdMapFn          = func() (map[string]map[string]string, error) { return GetPfcwdMap() }
+	getDpuCountersMapFn    = func(t string) (map[string]string, error) { return GetCountersMapForDb("DPU_COUNTERS_DB", t) }
 )
 
 func (t *Trie) v2rTriePopulate() {
@@ -125,7 +166,7 @@ func (t *Trie) v2rTriePopulate() {
 func initCountersQueueNameMap() error {
 	var err error
 	if len(countersQueueNameMap) == 0 {
-		countersQueueNameMap, err = getCountersMap("COUNTERS_QUEUE_NAME_MAP")
+		countersQueueNameMap, err = GetCountersMap("COUNTERS_QUEUE_NAME_MAP")
 		if err != nil {
 			return err
 		}
@@ -135,7 +176,7 @@ func initCountersQueueNameMap() error {
 
 func initCountersPGNameMap() error {
 	if len(countersPGNameMap) == 0 {
-		pgOidMap, err := getCountersMap("COUNTERS_PG_NAME_MAP")
+		pgOidMap, err := GetCountersMap("COUNTERS_PG_NAME_MAP")
 		if err != nil {
 			return err
 		}
@@ -157,7 +198,7 @@ func initCountersPGNameMap() error {
 func initCountersPortNameMap() error {
 	var err error
 	if len(countersPortNameMap) == 0 {
-		countersPortNameMap, err = getCountersMap("COUNTERS_PORT_NAME_MAP")
+		countersPortNameMap, err = GetCountersMap("COUNTERS_PORT_NAME_MAP")
 		if err != nil {
 			return err
 		}
@@ -168,7 +209,7 @@ func initCountersPortNameMap() error {
 func initCountersSidMap() error {
 	var err error
 	if len(countersSidMap) == 0 {
-		countersSidMap, err = getCountersMap("COUNTERS_SRV6_NAME_MAP")
+		countersSidMap, err = GetCountersMap("COUNTERS_SRV6_NAME_MAP")
 		if err != nil {
 			return err
 		}
@@ -181,7 +222,7 @@ func initCountersAclRuleMap() error {
 	if len(countersAclRuleMap) == 0 {
 		// ACL_COUNTER_RULE_MAP is a hash in COUNTERS_DB:
 		//   "DATAACL:RULE_1" -> "oid:0x9000000000711"
-		countersAclRuleMap, err = getCountersMap("ACL_COUNTER_RULE_MAP")
+		countersAclRuleMap, err = GetCountersMap("ACL_COUNTER_RULE_MAP")
 		if err != nil {
 			return err
 		}
@@ -237,6 +278,26 @@ func initDebugNameSwitchStatMap() error {
 		}
 	}
 	return nil
+}
+
+func initCountersEniNameMap() error {
+	clearMappingsMu.RLock()
+	defer clearMappingsMu.RUnlock()
+	var initErr error
+	initCountersEniNameMapOnce.Do(func() {
+		var err error
+		countersEniNameMap, err = getDpuCountersMapFn("COUNTERS_ENI_NAME_MAP")
+		if err != nil {
+			initErr = err
+			return
+		}
+		countersEniOidNameMap, err = getDpuCountersMapFn("COUNTERS_ENI_OID_NAME_MAP")
+		if err != nil {
+			countersEniNameMap = nil
+			initErr = err
+		}
+	})
+	return initErr
 }
 
 // Get the mapping between sonic interface name and oids of their PFC-WD enabled queues in COUNTERS_DB
@@ -398,23 +459,8 @@ func addmap(a map[string]string, b map[string]string) {
 
 // Get the mapping between objects in counters DB, Ex. port name to oid in "COUNTERS_PORT_NAME_MAP" table.
 // Aussuming static port name to oid map in COUNTERS table
-func getCountersMap(tableName string) (map[string]string, error) {
-	counter_map := make(map[string]string)
-	dbName := "COUNTERS_DB"
-	redis_client_map, err := GetRedisClientsForDb(dbName)
-	if err != nil {
-		return nil, err
-	}
-	for namespace, redisDb := range redis_client_map {
-		fv, err := redisDb.HGetAll(tableName).Result()
-		if err != nil {
-			log.V(2).Infof("redis HGetAll failed for COUNTERS_DB in namespace %v, tableName: %s", namespace, tableName)
-			return nil, err
-		}
-		addmap(counter_map, fv)
-		log.V(6).Infof("tableName: %s in namespace %v, map %v", tableName, namespace, fv)
-	}
-	return counter_map, nil
+func GetCountersMap(tableName string) (map[string]string, error) {
+	return GetCountersMapForDb("COUNTERS_DB", tableName)
 }
 
 // Get the mapping between objects in counters DB, Ex. port name to oid in "COUNTERS_FABRIC_PORT_NAME_MAP" table.
@@ -445,6 +491,26 @@ func getFabricCountersMap(tableName string) (map[string]string, error) {
 		}
 		addmap(counter_map, namespaceFv)
 		log.V(6).Infof("tableName: %s in namespace %v, map %v", tableName, namespace, namespaceFv)
+	}
+	return counter_map, nil
+}
+
+// GetCountersMapForDb retrieves a hash map from the specified DB.
+// This is a generalized version of GetCountersMap that accepts a DB name.
+func GetCountersMapForDb(dbName string, tableName string) (map[string]string, error) {
+	counter_map := make(map[string]string)
+	redis_client_map, err := GetRedisClientsForDb(dbName)
+	if err != nil {
+		return nil, err
+	}
+	for namespace, redisDb := range redis_client_map {
+		fv, err := redisDb.HGetAll(tableName).Result()
+		if err != nil {
+			log.V(2).Infof("redis HGetAll failed for %s in namespace %v, tableName: %s", dbName, namespace, tableName)
+			return nil, err
+		}
+		addmap(counter_map, fv)
+		log.V(6).Infof("tableName: %s in namespace %v, map %v", tableName, namespace, fv)
 	}
 	return counter_map, nil
 }
@@ -1138,6 +1204,277 @@ func v2rEthPortPGPeriodicWMs(paths []string) ([]tablePath, error) {
 	log.V(6).Infof("v2rEthPortPGPeriodicWMs: %v", tblPaths)
 	return tblPaths, nil
 }
+
+// dashMeterKeyInfo holds parsed components of a DASH_METER JSON-formatted Redis key.
+type dashMeterKeyInfo struct {
+	fullKey    string // full Redis key, e.g. COUNTERS:{"eni_id":"oid:0x1","meter_class":"1","switch_id":"oid:0x2"}
+	eniOid     string
+	meterClass string
+	switchOid  string
+}
+
+// getDashMeterKeys scans DPU_COUNTERS_DB for DASH_METER keys (COUNTERS:{...} with JSON payloads)
+// and returns parsed key info. If eniOid is non-empty, only keys matching that ENI OID are returned.
+// If meterClass is non-empty, only keys matching that meter class are returned.
+func getDashMeterKeys(redisDb *redis.Client, separator string, eniOid string, meterClass string) ([]dashMeterKeyInfo, error) {
+	pattern := "COUNTERS" + separator + "*"
+	dbkeys, err := redisDb.Keys(pattern).Result()
+	if err != nil {
+		return nil, fmt.Errorf("redis Keys failed for pattern %s: %v", pattern, err)
+	}
+
+	prefix := "COUNTERS" + separator
+	var results []dashMeterKeyInfo
+	for _, dbkey := range dbkeys {
+		// DASH_METER keys have JSON after "COUNTERS<sep>"; skip non-JSON keys (e.g. COUNTERS:oid:...)
+		jsonPart := strings.TrimPrefix(dbkey, prefix)
+		if !strings.HasPrefix(jsonPart, "{") {
+			continue
+		}
+
+		var keyFields struct {
+			EniId      string `json:"eni_id"`
+			MeterClass string `json:"meter_class"`
+			SwitchId   string `json:"switch_id"`
+		}
+		if err := json.Unmarshal([]byte(jsonPart), &keyFields); err != nil {
+			log.V(4).Infof("Skipping non-JSON COUNTERS key: %s", dbkey)
+			continue
+		}
+
+		if eniOid != "" && keyFields.EniId != eniOid {
+			continue
+		}
+		if meterClass != "" && keyFields.MeterClass != meterClass {
+			continue
+		}
+
+		results = append(results, dashMeterKeyInfo{
+			fullKey:    dbkey,
+			eniOid:     keyFields.EniId,
+			meterClass: keyFields.MeterClass,
+			switchOid:  keyFields.SwitchId,
+		})
+	}
+	return results, nil
+}
+
+// v2rEniStats translates virtual ENI counter paths to real Redis paths.
+// Handles: [DPU_COUNTERS_DB COUNTERS ENI *] and [DPU_COUNTERS_DB COUNTERS ENI <eni_name>]
+func v2rEniStats(paths []string) ([]tablePath, error) {
+	clearMappingsMu.RLock()
+	defer clearMappingsMu.RUnlock()
+	var tblPaths []tablePath
+	namespace, _ := sdcfg.GetDbDefaultNamespace()
+	separator, _ := GetTableKeySeparator(paths[DbIdx], namespace)
+
+	if strings.HasSuffix(paths[FieldIdx], "*") { // All ENIs
+		for eniName, oid := range countersEniNameMap {
+			tblPath := tablePath{
+				dbNamespace:  namespace,
+				dbName:       paths[DbIdx],
+				tableName:    paths[TblIdx],
+				tableKey:     oid,
+				delimitor:    separator,
+				jsonTableKey: eniName,
+			}
+			tblPaths = append(tblPaths, tblPath)
+		}
+	} else { // specific ENI
+		eniName := paths[FieldIdx]
+		oid, ok := countersEniNameMap[eniName]
+		if !ok {
+			return nil, fmt.Errorf("%v not a valid ENI name", eniName)
+		}
+		tblPaths = []tablePath{{
+			dbNamespace: namespace,
+			dbName:      paths[DbIdx],
+			tableName:   paths[TblIdx],
+			tableKey:    oid,
+			delimitor:   separator,
+		}}
+	}
+	log.V(6).Infof("v2rEniStats: %v", tblPaths)
+	return tblPaths, nil
+}
+
+// v2rDashMeterByEniAndClass translates ENI + metering class paths to real Redis keys.
+// Handles: [DPU_COUNTERS_DB DASH_METER <eni_name> <meter_class>]
+// and:     [DPU_COUNTERS_DB DASH_METER * <meter_class>] — specific class for all ENIs
+func v2rDashMeterByEniAndClass(paths []string) ([]tablePath, error) {
+	clearMappingsMu.RLock()
+	defer clearMappingsMu.RUnlock()
+
+	meterClass := paths[FieldIdx]
+	namespace, _ := sdcfg.GetDbDefaultNamespace()
+	separator, _ := GetTableKeySeparator(paths[DbIdx], namespace)
+
+	redisDb := Target2RedisDb[namespace][paths[DbIdx]]
+	if redisDb == nil {
+		return nil, fmt.Errorf("Redis client not available for %s", paths[DbIdx])
+	}
+
+	var tblPaths []tablePath
+
+	if strings.HasSuffix(paths[KeyIdx], "*") { // All ENIs, specific meter class
+		keys, err := getDashMeterKeys(redisDb, separator, "", meterClass)
+		if err != nil {
+			return nil, err
+		}
+		for _, k := range keys {
+			eniName, ok := countersEniOidNameMap[k.eniOid]
+			if !ok {
+				log.V(2).Infof("Unknown ENI OID %v in DASH_METER key, skipping", k.eniOid)
+				continue
+			}
+			tableKey := strings.TrimPrefix(k.fullKey, "COUNTERS"+separator)
+			tblPaths = append(tblPaths, tablePath{
+				dbNamespace:  namespace,
+				dbName:       paths[DbIdx],
+				tableName:    "COUNTERS",
+				tableKey:     tableKey,
+				delimitor:    separator,
+				jsonTableKey: eniName + "/" + meterClass,
+			})
+		}
+	} else { // Specific ENI, specific meter class
+		eniName := paths[KeyIdx]
+		eniOid, ok := countersEniNameMap[eniName]
+		if !ok {
+			return nil, fmt.Errorf("%v not a valid ENI name", eniName)
+		}
+
+		keys, err := getDashMeterKeys(redisDb, separator, eniOid, meterClass)
+		if err != nil {
+			return nil, err
+		}
+		if len(keys) == 0 {
+			return nil, fmt.Errorf("No DASH_METER entry found for ENI %v class %v", eniName, meterClass)
+		}
+
+		for _, k := range keys {
+			tableKey := strings.TrimPrefix(k.fullKey, "COUNTERS"+separator)
+			tblPaths = append(tblPaths, tablePath{
+				dbNamespace:  namespace,
+				dbName:       paths[DbIdx],
+				tableName:    "COUNTERS",
+				tableKey:     tableKey,
+				delimitor:    separator,
+				jsonTableKey: meterClass,
+			})
+		}
+	}
+	log.V(6).Infof("v2rDashMeterByEniAndClass: %v", tblPaths)
+	return tblPaths, nil
+}
+
+// v2rDashMeterByEni translates ENI-level DASH_METER paths to real Redis keys.
+// Handles: [DPU_COUNTERS_DB DASH_METER <eni_name>] — all meter classes for one ENI
+// and [DPU_COUNTERS_DB DASH_METER *] — all meter classes for all ENIs
+func v2rDashMeterByEni(paths []string) ([]tablePath, error) {
+	clearMappingsMu.RLock()
+	defer clearMappingsMu.RUnlock()
+
+	namespace, _ := sdcfg.GetDbDefaultNamespace()
+	separator, _ := GetTableKeySeparator(paths[DbIdx], namespace)
+
+	redisDb := Target2RedisDb[namespace][paths[DbIdx]]
+	if redisDb == nil {
+		return nil, fmt.Errorf("Redis client not available for %s", paths[DbIdx])
+	}
+
+	var tblPaths []tablePath
+
+	if strings.HasSuffix(paths[KeyIdx], "*") { // All ENIs, all meter classes
+		keys, err := getDashMeterKeys(redisDb, separator, "", "")
+		if err != nil {
+			return nil, err
+		}
+		for _, k := range keys {
+			eniName, ok := countersEniOidNameMap[k.eniOid]
+			if !ok {
+				log.V(2).Infof("Unknown ENI OID %v in DASH_METER key, skipping", k.eniOid)
+				continue
+			}
+			tableKey := strings.TrimPrefix(k.fullKey, "COUNTERS"+separator)
+			tblPaths = append(tblPaths, tablePath{
+				dbNamespace:  namespace,
+				dbName:       paths[DbIdx],
+				tableName:    "COUNTERS",
+				tableKey:     tableKey,
+				delimitor:    separator,
+				jsonTableKey: eniName + "/" + k.meterClass,
+			})
+		}
+	} else { // Specific ENI, all meter classes
+		eniName := paths[KeyIdx]
+		eniOid, ok := countersEniNameMap[eniName]
+		if !ok {
+			return nil, fmt.Errorf("%v not a valid ENI name", eniName)
+		}
+
+		keys, err := getDashMeterKeys(redisDb, separator, eniOid, "")
+		if err != nil {
+			return nil, err
+		}
+		for _, k := range keys {
+			tableKey := strings.TrimPrefix(k.fullKey, "COUNTERS"+separator)
+			tblPaths = append(tblPaths, tablePath{
+				dbNamespace:  namespace,
+				dbName:       paths[DbIdx],
+				tableName:    "COUNTERS",
+				tableKey:     tableKey,
+				delimitor:    separator,
+				jsonTableKey: k.meterClass,
+			})
+		}
+	}
+	log.V(6).Infof("v2rDashMeterByEni: %v", tblPaths)
+	return tblPaths, nil
+}
+
+func ClearMappings() {
+	value := os.Getenv("UNIT_TEST")
+	if value != "1" {
+		return
+	}
+	clearMappingsMu.Lock()
+	defer clearMappingsMu.Unlock()
+
+	counterMaps := []map[string]string{
+		countersPortNameMap,
+		alias2nameMap,
+		countersFabricPortNameMap,
+		countersQueueNameMap,
+		countersAclRuleMap,
+		countersEniNameMap,
+		countersEniOidNameMap,
+	}
+	for _, counterMap := range counterMaps {
+		for entry := range counterMap {
+			delete(counterMap, entry)
+		}
+	}
+
+	// Reset sync.Once guards so the next call re-initializes.
+	initCountersPortNameMapOnce = sync.Once{}
+	initCountersQueueNameMapOnce = sync.Once{}
+	initCountersPGNameMapOnce = sync.Once{}
+	initCountersSidMapOnce = sync.Once{}
+	initCountersAclRuleMapOnce = sync.Once{}
+	initAliasMapOnce = sync.Once{}
+	initCountersPfcwdNameMapOnce = sync.Once{}
+	initCountersFabricPortNameMapOnce = sync.Once{}
+	initCountersEniNameMapOnce = sync.Once{}
+}
+
+func InitCountersPortNameMap() error       { return initCountersPortNameMap() }
+func InitCountersQueueNameMap() error      { return initCountersQueueNameMap() }
+func InitCountersPGNameMap() error         { return initCountersPGNameMap() }
+func InitCountersSidMap() error            { return initCountersSidMap() }
+func InitCountersAclRuleMap() error        { return initCountersAclRuleMap() }
+func InitCountersFabricPortNameMap() error { return initCountersFabricPortNameMap() }
+func InitCountersEniNameMap() error        { return initCountersEniNameMap() }
 
 func lookupV2R(paths []string) ([]tablePath, error) {
 	n, ok := v2rTrie.Find(paths)

--- a/testdata/database_config.json
+++ b/testdata/database_config.json
@@ -51,6 +51,11 @@
             "id" : 13,
             "separator": "|",
             "instance" : "redis"
+        },
+        "DPU_COUNTERS_DB" : {
+            "id" : 18,
+            "separator": ":",
+            "instance" : "redis"
         }
     },
     "VERSION" : "1.0"


### PR DESCRIPTION
Cherry-pick of #665 to the 202511 branch. Adapted to go-redis v6 API used on 202511 (no context parameter in Redis calls).