### PR TITLE
[gnoi] expand File.Put whitelist to /host/ + mkdir-p parent dirs

### DIFF
--- a/pkg/gnoi/file/file.go
+++ b/pkg/gnoi/file/file.go
@@ -175,19 +175,21 @@ func translatePathForContainer(path string) string {
 // Allowed directories for SONiC devices:
 //   - /tmp/      - Temporary files, firmware images
 //   - /var/tmp/  - Temporary files that persist across reboots
+//   - /host/     - Next-image overlay staging (e.g. /host/image-*/rw/etc/sonic/...)
 //
 // Rejected paths include:
 //   - /etc/, /boot/, /usr/, /bin/, /sbin/ - Critical system directories
-//   - /host/ - Contains grub config, overlayfs layers, machine.conf
 //   - /var/log/ - System logs
 //   - /home/, /root/ - User home directories with SSH keys
 //   - Relative paths or paths with .. traversal
 //
-// Rationale: Only temporary directories are safe for firmware downloads.
-// Writing to /host/ risks:
-//   - Overwriting /host/grub/grub.cfg (brick device on reboot)
-//   - Corrupting /host/image-*/rw/ (overlayfs upperdir, kernel panic)
-//   - Modifying /host/machine.conf (platform detection failure)
+// Note on /host/: a broad /host/ prefix is currently accepted so the SONiC
+// upgrade agent can stage configs/certs into the next-image overlay at
+// /host/image-*/rw/etc/sonic/. This whitelist is intentionally permissive
+// for now; a follow-up will tighten the prefix to /host/image-*/rw/ once
+// callers stabilize. Writes under /host/ are still gated by filesystem
+// permissions inside the container (the gnmi container only sees /host as
+// rw when the platform mounts it that way; see sonic-buildimage PR-B).
 func validatePath(path string) error {
 	// Clean the path to resolve . and .. components
 	cleanPath := filepath.Clean(path)
@@ -206,6 +208,7 @@ func validatePath(path string) error {
 	allowedPrefixes := []string{
 		"/tmp/",
 		"/var/tmp/",
+		"/host/",
 	}
 
 	for _, prefix := range allowedPrefixes {
@@ -214,7 +217,7 @@ func validatePath(path string) error {
 		}
 	}
 
-	return fmt.Errorf("path must be under /tmp/ or /var/tmp/, got: %s", cleanPath)
+	return fmt.Errorf("path must be under /tmp/, /var/tmp/, or /host/, got: %s", cleanPath)
 }
 
 // HandlePut implements the complete logic for the Put RPC with DPU routing support.
@@ -223,7 +226,7 @@ func validatePath(path string) error {
 //
 // This function handles:
 //   - Receiving Open message with file path and permissions
-//   - Path validation (only /tmp/ and /var/tmp/)
+//   - Path validation (only /tmp/, /var/tmp/, and /host/)
 //   - Container path translation (prepends /mnt/host when running in container)
 //   - Receiving file contents in chunks
 //   - MD5 hash verification
@@ -291,6 +294,16 @@ func HandlePut(stream gnoi_file_pb.File_PutServer) error {
 
 	// Step 4: Create temp file for atomic write
 	tempPath := translatedPath + ".tmp"
+	// Ensure parent dir exists so callers don't need an out-of-band mkdir.
+	// Mirrors the behavior of typical file-upload servers; the alternative
+	// is forcing every gNOI client to pre-create parent dirs via SSH or
+	// another channel, which defeats the purpose of File.Put as a
+	// self-contained upload primitive. Runs after validatePath (Step 2) and
+	// translatePathForContainer (Step 3) so no privilege escalation risk
+	// beyond what the existing whitelist already accepts.
+	if err := os.MkdirAll(filepath.Dir(tempPath), 0755); err != nil {
+		return status.Errorf(codes.Internal, "failed to create parent dir: %v", err)
+	}
 	f, err := os.OpenFile(tempPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 	if err != nil {
 		return status.Errorf(codes.Internal, "failed to create temp file: %v", err)

--- a/pkg/gnoi/file/file_test.go
+++ b/pkg/gnoi/file/file_test.go
@@ -355,6 +355,14 @@ func TestValidatePath_AllowedPaths(t *testing.T) {
 		{"tmp nested", "/tmp/upgrades/v1.0/firmware.bin"},
 		{"var tmp file", "/var/tmp/firmware.bin"},
 		{"var tmp nested", "/var/tmp/downloads/image.bin"},
+		// NOTE: broad /host/ whitelist accepts /host/grub/grub.cfg and
+		// /host/machine.conf too. Follow-up will narrow to /host/image-*/rw/.
+		// Until then the upgrade agent needs broad /host/ access to stage
+		// configs/certs into the next-image overlay.
+		{"host file allowed (broad)", "/host/grub/grub.cfg"},
+		{"host machine.conf allowed (broad)", "/host/machine.conf"},
+		{"host overlayfs rw root", "/host/image-master/rw/usr/bin/test"},
+		{"host image rw", "/host/image-internal.164866913-743c646df0/rw/etc/sonic/minigraph.xml"},
 	}
 
 	for _, tt := range tests {
@@ -381,62 +389,52 @@ func TestValidatePath_RejectedPaths(t *testing.T) {
 		{
 			name:        "path traversal",
 			path:        "/tmp/../etc/passwd",
-			expectedErr: "path must be under /tmp/ or /var/tmp/",
+			expectedErr: "path must be under /tmp/, /var/tmp/, or /host/",
 		},
 		{
 			name:        "etc directory",
 			path:        "/etc/passwd",
-			expectedErr: "path must be under /tmp/ or /var/tmp/",
+			expectedErr: "path must be under /tmp/, /var/tmp/, or /host/",
 		},
 		{
 			name:        "boot directory",
 			path:        "/boot/grub/grub.cfg",
-			expectedErr: "path must be under /tmp/ or /var/tmp/",
+			expectedErr: "path must be under /tmp/, /var/tmp/, or /host/",
 		},
 		{
 			name:        "usr directory",
 			path:        "/usr/bin/malicious",
-			expectedErr: "path must be under /tmp/ or /var/tmp/",
+			expectedErr: "path must be under /tmp/, /var/tmp/, or /host/",
 		},
 		{
 			name:        "root directory",
 			path:        "/root/.ssh/authorized_keys",
-			expectedErr: "path must be under /tmp/ or /var/tmp/",
+			expectedErr: "path must be under /tmp/, /var/tmp/, or /host/",
 		},
 		{
 			name:        "bin directory",
 			path:        "/bin/bash",
-			expectedErr: "path must be under /tmp/ or /var/tmp/",
+			expectedErr: "path must be under /tmp/, /var/tmp/, or /host/",
 		},
 		{
 			name:        "sbin directory",
 			path:        "/sbin/init",
-			expectedErr: "path must be under /tmp/ or /var/tmp/",
+			expectedErr: "path must be under /tmp/, /var/tmp/, or /host/",
 		},
 		{
 			name:        "home directory",
 			path:        "/home/admin/.ssh/id_rsa",
-			expectedErr: "path must be under /tmp/ or /var/tmp/",
+			expectedErr: "path must be under /tmp/, /var/tmp/, or /host/",
 		},
 		{
-			name:        "host grub config",
-			path:        "/host/grub/grub.cfg",
-			expectedErr: "path must be under /tmp/ or /var/tmp/",
-		},
-		{
-			name:        "host machine.conf",
-			path:        "/host/machine.conf",
-			expectedErr: "path must be under /tmp/ or /var/tmp/",
-		},
-		{
-			name:        "host overlayfs rw",
-			path:        "/host/image-master/rw/usr/bin/test",
-			expectedErr: "path must be under /tmp/ or /var/tmp/",
+			name:        "host traversal",
+			path:        "/host/image-foo/../../etc/passwd",
+			expectedErr: "path must be under /tmp/, /var/tmp/, or /host/",
 		},
 		{
 			name:        "var log",
 			path:        "/var/log/syslog",
-			expectedErr: "path must be under /tmp/ or /var/tmp/",
+			expectedErr: "path must be under /tmp/, /var/tmp/, or /host/",
 		},
 	}
 
@@ -617,6 +615,64 @@ func TestHandlePut_Success(t *testing.T) {
 	os.Remove(path)
 }
 
+func TestHandlePut_CreatesParentDir(t *testing.T) {
+	// Verify HandlePut creates missing parent directories so callers don't
+	// need an out-of-band mkdir. Use a fresh, deeply-nested path under /tmp/
+	// where the parent chain does NOT exist before the call.
+	uniq := fmt.Sprintf("handleput-mkdir-test-%d", time.Now().UnixNano())
+	logicalPath := "/tmp/" + uniq + "/sub/dir/file.txt"
+
+	// translatePathForContainer prepends /mnt/host when /mnt/host exists.
+	hostMount := "/mnt/host"
+	physRoot := "/tmp"
+	if _, err := os.Stat(hostMount); err == nil {
+		physRoot = hostMount + "/tmp"
+	}
+	physPath := physRoot + "/" + uniq + "/sub/dir/file.txt"
+	physParent := filepath.Dir(physPath)
+	physTop := physRoot + "/" + uniq
+
+	// Cleanup the entire fresh subtree.
+	t.Cleanup(func() { _ = os.RemoveAll(physTop) })
+
+	// Pre-condition: parent must not exist.
+	if _, err := os.Stat(physParent); !os.IsNotExist(err) {
+		t.Fatalf("precondition: parent dir %q must not exist before HandlePut, stat err=%v", physParent, err)
+	}
+
+	content := []byte("hello deep dir")
+	hasher := md5.New()
+	hasher.Write(content)
+	expectedHash := hasher.Sum(nil)
+
+	stream := newMockPutStream()
+	stream.addOpenRequest(logicalPath, 0644)
+	stream.addContentRequest(content)
+	stream.addHashRequest(expectedHash)
+
+	if err := HandlePut(stream); err != nil {
+		t.Fatalf("HandlePut() error = %v", err)
+	}
+
+	// File must exist at the translated physical path with the right content.
+	data, err := os.ReadFile(physPath)
+	if err != nil {
+		t.Fatalf("uploaded file not found at %q: %v", physPath, err)
+	}
+	if string(data) != string(content) {
+		t.Errorf("file content = %q, want %q", data, content)
+	}
+
+	// Parent directory must exist (mkdir-p ran).
+	info, err := os.Stat(physParent)
+	if err != nil {
+		t.Fatalf("parent dir %q missing after HandlePut: %v", physParent, err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("expected %q to be a directory", physParent)
+	}
+}
+
 func TestHandlePut_MultipleChunks(t *testing.T) {
 	// Test file upload with multiple content chunks
 	stream := newMockPutStream()
@@ -731,7 +787,7 @@ func TestHandlePut_InvalidPaths(t *testing.T) {
 		{"home directory", "/home/admin/.ssh/id_rsa"},
 		{"root directory", "/root/.bashrc"},
 		{"var log", "/var/log/syslog"},
-		{"host grub", "/host/grub/grub.cfg"},
+		{"host traversal", "/host/image-foo/../../etc/passwd"},
 	}
 
 	for _, tt := range tests {
@@ -1651,14 +1707,37 @@ func TestHandleTransferToRemoteForDPUStreaming_HTTPSuccessGRPCFail(t *testing.T)
 
 // Test specific error paths in HandlePut to improve coverage
 func TestHandlePut_ErrorPaths(t *testing.T) {
-	t.Run("file creation failure with permissions", func(t *testing.T) {
-		// Try to create file in invalid directory
+	t.Run("parent dir creation failure", func(t *testing.T) {
+		// HandlePut now MkdirAlls missing parents; provoke an actual mkdir
+		// failure by planting a regular file where a parent dir would need to
+		// be created — MkdirAll cannot traverse through a regular file.
+		uniq := fmt.Sprintf("%d", time.Now().UnixNano())
+		blocker := "/tmp/blocker-" + uniq
+		if err := os.WriteFile(blocker, []byte("not a dir"), 0644); err != nil {
+			t.Fatalf("setup: writefile blocker: %v", err)
+		}
+		t.Cleanup(func() { _ = os.Remove(blocker) })
+
+		// Mirror translatePathForContainer's /mnt/host prepend to decide which
+		// logical path to send so the physical mkdir target matches the blocker.
+		logical := "/tmp/blocker-" + uniq + "/sub/file.txt"
+		if _, err := os.Stat("/mnt/host"); err == nil {
+			// Container-prepended path: blocker also lives under /mnt/host/tmp,
+			// so re-plant it there.
+			altBlocker := "/mnt/host" + blocker
+			if err := os.MkdirAll(filepath.Dir(altBlocker), 0755); err == nil {
+				if err := os.WriteFile(altBlocker, []byte("not a dir"), 0644); err == nil {
+					t.Cleanup(func() { _ = os.Remove(altBlocker) })
+				}
+			}
+		}
+
 		stream := newMockPutStream()
-		stream.addOpenRequest("/tmp/nonexistent/subdir/file.txt", 0644)
+		stream.addOpenRequest(logical, 0644)
 
 		err := HandlePut(stream)
 		if err == nil {
-			t.Fatal("Expected error for invalid directory")
+			t.Fatal("Expected error when parent path is blocked by a regular file")
 		}
 
 		st, ok := status.FromError(err)


### PR DESCRIPTION
Two related changes to make `File.Put` usable for SONiC upgrade staging into the next-image overlay.

## 1) `validatePath` whitelist expansion (`/host/` allowed)

The current `allowedPrefixes = ["/tmp/", "/var/tmp/"]` blocks any write under `/host/`, including the legitimate next-image overlay staging path `/host/image-*/rw/etc/sonic/...`. The SONiC upgrade agent needs to put configs/certs into that directory between `InstallImage` and `Reboot`, so this PR appends `"/host/"` to the whitelist and updates the rejection error message accordingly.

The whitelist is **intentionally broad** for this PoC: it also accepts `/host/grub/grub.cfg` and `/host/machine.conf`. A follow-up PR will tighten the prefix to `/host/image-*/rw/` once callers stabilize. Mounted security is still enforced at the FS layer — without the companion sonic-buildimage PR ([gnmi] mount /host rw into gnmi container) the gnmi container only sees `/host` as read-only and writes return `EROFS` regardless of this whitelist.

The leading rationale comment block is rewritten to match the new behavior (the old block listed `/host/` as forbidden, which now contradicts the code).

### Residual risk (please review)

A client with `File.Put` access can now overwrite e.g. `/host/grub/grub.cfg` and brick the device on reboot. Mitigations: mTLS-gated RPC entry, the new mount in the buildimage PR is gnmi-only, and the follow-up will narrow the prefix. Happy to fold the narrower prefix into this PR if reviewers prefer; the upgrade agent's overlay path is fully covered by `/host/image-*/rw/`.

## 2) `HandlePut` mkdir-p parent dirs

`HandlePut` previously assumed the parent directory of the target path already existed; otherwise `os.OpenFile(tempPath, ...)` failed with `codes.Internal`. That forced every gNOI client to pre-create parent dirs via an out-of-band SSH mkdir, which defeats the purpose of `File.Put` as a self-contained upload primitive — especially painful for the upgrade agent because `/host/image-{next}/rw/etc/sonic/credentials/` usually does not exist yet on a freshly-installed next image.

This PR inserts `os.MkdirAll(filepath.Dir(tempPath), 0755)` right before the `os.OpenFile` call, after `validatePath` (Step 2) and `translatePathForContainer` (Step 3), so no new path can be reached that `validatePath` would not already accept.

## Tests

- `TestHandlePut_CreatesParentDir` asserts mkdir-p happens on a fresh deeply-nested `/tmp/<uniq>/sub/dir/file.txt` path.
- `TestHandlePut_ErrorPaths/"parent dir creation failure"` was rewritten to provoke an actual `MkdirAll` failure (a regular file planted where a parent dir would need to be), replacing the previous test which relied on the now-eliminated missing-parent failure path.
- Whitelist tests updated: `/host/grub/grub.cfg`, `/host/machine.conf` and `/host/image-master/rw/usr/bin/test` moved from the rejection table to the allowed-paths table (with an explicit `NOTE` about the broad prefix); a new positive case covers `/host/image-internal.164866913-.../rw/etc/sonic/minigraph.xml`; a `/host` traversal case (`/host/image-foo/../../etc/passwd`) verifies `filepath.Clean` resolves the traversal before the whitelist check.

`go test ./pkg/gnoi/file/...` is green locally.

## Companion PR

sonic-net/sonic-buildimage: `[gnmi] mount /host rw into gnmi container` — without it, this whitelist change has no effect inside the gnmi container.
