### PR TITLE
[gnoi] SetPackage: auto-resolve version from image when not provided

### DIFF
--- a/pkg/gnoi/system/system.go
+++ b/pkg/gnoi/system/system.go
@@ -86,10 +86,6 @@ func HandleSetPackage(ctx context.Context, req *syspb.SetPackageRequest) (*syspb
 		log.Errorf("Filename is missing in package request")
 		return nil, status.Errorf(codes.InvalidArgument, "filename is missing in package request")
 	}
-	if pkg.Package.Version == "" {
-		log.Errorf("Version is missing in package request")
-		return nil, status.Errorf(codes.InvalidArgument, "version is missing in package request")
-	}
 
 	// Reject RemoteDownload - require local image
 	if pkg.Package.RemoteDownload != nil {
@@ -117,11 +113,22 @@ func HandleSetPackage(ctx context.Context, req *syspb.SetPackageRequest) (*syspb
 
 	// If activate is requested, set as next boot image
 	if pkg.Package.Activate {
-		if err := activatePackage(ctx, pkg.Package.Version); err != nil {
-			log.Errorf("Failed to activate package %s: %v", pkg.Package.Version, err)
+		version := pkg.Package.Version
+		if version == "" {
+			// Auto-resolve version from the image binary
+			resolved, err := getBinaryVersion(ctx, pkg.Package.Filename)
+			if err != nil {
+				log.Errorf("Failed to resolve version from image %s: %v", pkg.Package.Filename, err)
+				return nil, status.Errorf(codes.Internal, "failed to resolve version from image: %v", err)
+			}
+			version = resolved
+			log.V(1).Infof("Auto-resolved version from image: %s", version)
+		}
+		if err := activatePackage(ctx, version); err != nil {
+			log.Errorf("Failed to activate package %s: %v", version, err)
 			return nil, status.Errorf(codes.Internal, "failed to activate package: %v", err)
 		}
-		log.V(1).Infof("Successfully activated package %s", pkg.Package.Version)
+		log.V(1).Infof("Successfully activated package %s", version)
 	}
 
 	return &syspb.SetPackageResponse{}, nil
@@ -148,6 +155,32 @@ func installPackage(ctx context.Context, filename string) error {
 
 	log.V(1).Infof("sonic-installer install completed successfully: %s", strings.TrimSpace(result.Stdout))
 	return nil
+}
+
+// getBinaryVersion extracts the version string from a SONiC image using sonic-installer binary_version.
+func getBinaryVersion(ctx context.Context, filename string) (string, error) {
+	log.V(1).Infof("Resolving binary version for: %s", filename)
+
+	opts := &exec.RunHostCommandOptions{
+		Timeout: 1 * time.Minute,
+	}
+	result, err := exec.RunHostCommand(ctx, "sonic-installer", []string{"binary_version", filename}, opts)
+	if err != nil {
+		return "", fmt.Errorf("failed to run sonic-installer binary_version: %v", err)
+	}
+
+	if result.Error != nil {
+		return "", fmt.Errorf("sonic-installer binary_version failed with exit code %d: %s",
+			result.ExitCode, result.Stderr)
+	}
+
+	version := strings.TrimSpace(result.Stdout)
+	if version == "" {
+		return "", fmt.Errorf("sonic-installer binary_version returned empty output for %s", filename)
+	}
+
+	log.V(1).Infof("Resolved binary version: %s", version)
+	return version, nil
 }
 
 // activatePackage sets a SONiC image as the next boot image using sonic-installer set-default.

--- a/pkg/gnoi/system/system.go
+++ b/pkg/gnoi/system/system.go
@@ -93,15 +93,27 @@ func HandleSetPackage(ctx context.Context, req *syspb.SetPackageRequest) (*syspb
 		return nil, status.Errorf(codes.InvalidArgument, "remote download is not supported, image must be local")
 	}
 
-	// Log the package details
-	log.V(1).Infof("Installing package: filename=%s, version=%s, activate=%v",
-		pkg.Package.Filename, pkg.Package.Version, pkg.Package.Activate)
-
 	// Validate filename is absolute path
 	if !filepath.IsAbs(pkg.Package.Filename) {
 		log.Errorf("Filename must be an absolute path: %s", pkg.Package.Filename)
 		return nil, status.Errorf(codes.InvalidArgument, "filename must be an absolute path")
 	}
+
+	// Resolve version: use provided version, or auto-resolve from image binary
+	version := pkg.Package.Version
+	if version == "" {
+		resolved, err := getBinaryVersion(ctx, pkg.Package.Filename)
+		if err != nil {
+			log.Errorf("Failed to resolve version from image %s: %v", pkg.Package.Filename, err)
+			return nil, status.Errorf(codes.Internal, "failed to resolve version from image: %v", err)
+		}
+		version = resolved
+		log.V(1).Infof("Auto-resolved version from image: %s", version)
+	}
+
+	// Log the package details
+	log.V(1).Infof("Installing package: filename=%s, version=%s, activate=%v",
+		pkg.Package.Filename, version, pkg.Package.Activate)
 
 	// Install the package using sonic-installer
 	if err := installPackage(ctx, pkg.Package.Filename); err != nil {
@@ -113,17 +125,6 @@ func HandleSetPackage(ctx context.Context, req *syspb.SetPackageRequest) (*syspb
 
 	// If activate is requested, set as next boot image
 	if pkg.Package.Activate {
-		version := pkg.Package.Version
-		if version == "" {
-			// Auto-resolve version from the image binary
-			resolved, err := getBinaryVersion(ctx, pkg.Package.Filename)
-			if err != nil {
-				log.Errorf("Failed to resolve version from image %s: %v", pkg.Package.Filename, err)
-				return nil, status.Errorf(codes.Internal, "failed to resolve version from image: %v", err)
-			}
-			version = resolved
-			log.V(1).Infof("Auto-resolved version from image: %s", version)
-		}
 		if err := activatePackage(ctx, version); err != nil {
 			log.Errorf("Failed to activate package %s: %v", version, err)
 			return nil, status.Errorf(codes.Internal, "failed to activate package: %v", err)

--- a/pkg/gnoi/system/system_monkey_test.go
+++ b/pkg/gnoi/system/system_monkey_test.go
@@ -52,22 +52,22 @@ func TestHandleSetPackage_ActivateWithAutoResolvedVersion(t *testing.T) {
 	patches := gomonkey.NewPatches()
 	defer patches.Reset()
 
-	// Mock exec.RunHostCommand to handle install, binary_version, and set-default
+	// Mock exec.RunHostCommand to handle binary_version, install, and set-default
 	patches.ApplyFunc(exec.RunHostCommand, func(ctx context.Context, cmd string, args []string, opts *exec.RunHostCommandOptions) (*exec.CommandResult, error) {
 		if cmd == "sonic-installer" {
-			if len(args) >= 1 && args[0] == "install" {
-				return &exec.CommandResult{
-					Stdout:   "Installation completed successfully",
-					ExitCode: 0,
-				}, nil
-			}
 			if len(args) >= 1 && args[0] == "binary_version" {
 				return &exec.CommandResult{
 					Stdout:   "SONiC-OS-4.2.0-Enterprise\n",
 					ExitCode: 0,
 				}, nil
 			}
-			if len(args) >= 1 && args[0] == "set-default" {
+			if len(args) >= 1 && args[0] == "install" {
+				return &exec.CommandResult{
+					Stdout:   "Installation completed successfully",
+					ExitCode: 0,
+				}, nil
+			}
+			if len(args) >= 2 && args[0] == "set-default" {
 				if args[1] != "SONiC-OS-4.2.0-Enterprise" {
 					return nil, fmt.Errorf("unexpected version: %s", args[1])
 				}
@@ -85,7 +85,7 @@ func TestHandleSetPackage_ActivateWithAutoResolvedVersion(t *testing.T) {
 		Request: &syspb.SetPackageRequest_Package{
 			Package: &syspb.Package{
 				Filename: "/tmp/test-image.bin",
-				Version:  "", // Empty! Should auto-resolve
+				Version:  "", // Empty! Should auto-resolve before install
 				Activate: true,
 			},
 		},
@@ -104,20 +104,12 @@ func TestHandleSetPackage_AutoResolveVersionFails(t *testing.T) {
 	patches := gomonkey.NewPatches()
 	defer patches.Reset()
 
-	// Mock: install succeeds, binary_version fails
+	// Mock: binary_version fails — should reject before install
 	patches.ApplyFunc(exec.RunHostCommand, func(ctx context.Context, cmd string, args []string, opts *exec.RunHostCommandOptions) (*exec.CommandResult, error) {
-		if cmd == "sonic-installer" {
-			if len(args) >= 1 && args[0] == "install" {
-				return &exec.CommandResult{
-					Stdout:   "Installation completed successfully",
-					ExitCode: 0,
-				}, nil
-			}
-			if len(args) >= 1 && args[0] == "binary_version" {
-				return nil, fmt.Errorf("binary_version command failed")
-			}
+		if cmd == "sonic-installer" && len(args) >= 1 && args[0] == "binary_version" {
+			return nil, fmt.Errorf("binary_version command failed")
 		}
-		return nil, fmt.Errorf("unexpected command: %s %v", cmd, args)
+		return nil, fmt.Errorf("unexpected command (install should not be called): %s %v", cmd, args)
 	})
 
 	ctx := context.Background()
@@ -137,6 +129,52 @@ func TestHandleSetPackage_AutoResolveVersionFails(t *testing.T) {
 	}
 	if !containsSubstring(err.Error(), "failed to resolve version from image") {
 		t.Errorf("HandleSetPackage() error = %v, should contain 'failed to resolve version from image'", err)
+	}
+}
+
+func TestHandleSetPackage_EmptyVersionNoActivate(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	// Mock: binary_version and install succeed, set-default should NOT be called
+	patches.ApplyFunc(exec.RunHostCommand, func(ctx context.Context, cmd string, args []string, opts *exec.RunHostCommandOptions) (*exec.CommandResult, error) {
+		if cmd == "sonic-installer" {
+			if len(args) >= 1 && args[0] == "binary_version" {
+				return &exec.CommandResult{
+					Stdout:   "SONiC-OS-4.2.0-Enterprise\n",
+					ExitCode: 0,
+				}, nil
+			}
+			if len(args) >= 1 && args[0] == "install" {
+				return &exec.CommandResult{
+					Stdout:   "Installation completed successfully",
+					ExitCode: 0,
+				}, nil
+			}
+			if len(args) >= 1 && args[0] == "set-default" {
+				return nil, fmt.Errorf("set-default should not be called when activate=false")
+			}
+		}
+		return nil, fmt.Errorf("unexpected command: %s %v", cmd, args)
+	})
+
+	ctx := context.Background()
+	req := &syspb.SetPackageRequest{
+		Request: &syspb.SetPackageRequest_Package{
+			Package: &syspb.Package{
+				Filename: "/tmp/test-image.bin",
+				Version:  "",
+				Activate: false,
+			},
+		},
+	}
+
+	resp, err := HandleSetPackage(ctx, req)
+	if err != nil {
+		t.Fatalf("HandleSetPackage() returned error: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("HandleSetPackage() returned nil response")
 	}
 }
 

--- a/pkg/gnoi/system/system_monkey_test.go
+++ b/pkg/gnoi/system/system_monkey_test.go
@@ -48,6 +48,161 @@ func TestHandleSetPackage_SuccessWithoutActivation(t *testing.T) {
 	}
 }
 
+func TestHandleSetPackage_ActivateWithAutoResolvedVersion(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	// Mock exec.RunHostCommand to handle install, binary_version, and set-default
+	patches.ApplyFunc(exec.RunHostCommand, func(ctx context.Context, cmd string, args []string, opts *exec.RunHostCommandOptions) (*exec.CommandResult, error) {
+		if cmd == "sonic-installer" {
+			if len(args) >= 1 && args[0] == "install" {
+				return &exec.CommandResult{
+					Stdout:   "Installation completed successfully",
+					ExitCode: 0,
+				}, nil
+			}
+			if len(args) >= 1 && args[0] == "binary_version" {
+				return &exec.CommandResult{
+					Stdout:   "SONiC-OS-4.2.0-Enterprise\n",
+					ExitCode: 0,
+				}, nil
+			}
+			if len(args) >= 1 && args[0] == "set-default" {
+				if args[1] != "SONiC-OS-4.2.0-Enterprise" {
+					return nil, fmt.Errorf("unexpected version: %s", args[1])
+				}
+				return &exec.CommandResult{
+					Stdout:   "Default image set successfully",
+					ExitCode: 0,
+				}, nil
+			}
+		}
+		return nil, fmt.Errorf("unexpected command: %s %v", cmd, args)
+	})
+
+	ctx := context.Background()
+	req := &syspb.SetPackageRequest{
+		Request: &syspb.SetPackageRequest_Package{
+			Package: &syspb.Package{
+				Filename: "/tmp/test-image.bin",
+				Version:  "", // Empty! Should auto-resolve
+				Activate: true,
+			},
+		},
+	}
+
+	resp, err := HandleSetPackage(ctx, req)
+	if err != nil {
+		t.Fatalf("HandleSetPackage() returned error: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("HandleSetPackage() returned nil response")
+	}
+}
+
+func TestHandleSetPackage_AutoResolveVersionFails(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	// Mock: install succeeds, binary_version fails
+	patches.ApplyFunc(exec.RunHostCommand, func(ctx context.Context, cmd string, args []string, opts *exec.RunHostCommandOptions) (*exec.CommandResult, error) {
+		if cmd == "sonic-installer" {
+			if len(args) >= 1 && args[0] == "install" {
+				return &exec.CommandResult{
+					Stdout:   "Installation completed successfully",
+					ExitCode: 0,
+				}, nil
+			}
+			if len(args) >= 1 && args[0] == "binary_version" {
+				return nil, fmt.Errorf("binary_version command failed")
+			}
+		}
+		return nil, fmt.Errorf("unexpected command: %s %v", cmd, args)
+	})
+
+	ctx := context.Background()
+	req := &syspb.SetPackageRequest{
+		Request: &syspb.SetPackageRequest_Package{
+			Package: &syspb.Package{
+				Filename: "/tmp/test-image.bin",
+				Version:  "",
+				Activate: true,
+			},
+		},
+	}
+
+	_, err := HandleSetPackage(ctx, req)
+	if err == nil {
+		t.Fatal("HandleSetPackage() should return error when binary_version fails")
+	}
+	if !containsSubstring(err.Error(), "failed to resolve version from image") {
+		t.Errorf("HandleSetPackage() error = %v, should contain 'failed to resolve version from image'", err)
+	}
+}
+
+func TestGetBinaryVersion_Success(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	patches.ApplyFunc(exec.RunHostCommand, func(ctx context.Context, cmd string, args []string, opts *exec.RunHostCommandOptions) (*exec.CommandResult, error) {
+		if cmd == "sonic-installer" && len(args) >= 1 && args[0] == "binary_version" {
+			return &exec.CommandResult{
+				Stdout:   "SONiC-OS-4.2.0-Enterprise\n",
+				ExitCode: 0,
+			}, nil
+		}
+		return nil, fmt.Errorf("unexpected command: %s %v", cmd, args)
+	})
+
+	ctx := context.Background()
+	version, err := getBinaryVersion(ctx, "/tmp/test-image.bin")
+	if err != nil {
+		t.Fatalf("getBinaryVersion() returned error: %v", err)
+	}
+	if version != "SONiC-OS-4.2.0-Enterprise" {
+		t.Errorf("getBinaryVersion() = %q, want %q", version, "SONiC-OS-4.2.0-Enterprise")
+	}
+}
+
+func TestGetBinaryVersion_EmptyOutput(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	patches.ApplyFunc(exec.RunHostCommand, func(ctx context.Context, cmd string, args []string, opts *exec.RunHostCommandOptions) (*exec.CommandResult, error) {
+		return &exec.CommandResult{
+			Stdout:   "",
+			ExitCode: 0,
+		}, nil
+	})
+
+	ctx := context.Background()
+	_, err := getBinaryVersion(ctx, "/tmp/test-image.bin")
+	if err == nil {
+		t.Fatal("getBinaryVersion() should return error for empty output")
+	}
+	if !containsSubstring(err.Error(), "returned empty output") {
+		t.Errorf("getBinaryVersion() error = %v, should contain 'returned empty output'", err)
+	}
+}
+
+func TestGetBinaryVersion_CommandError(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	patches.ApplyFunc(exec.RunHostCommand, func(ctx context.Context, cmd string, args []string, opts *exec.RunHostCommandOptions) (*exec.CommandResult, error) {
+		return nil, fmt.Errorf("command not found")
+	})
+
+	ctx := context.Background()
+	_, err := getBinaryVersion(ctx, "/tmp/test-image.bin")
+	if err == nil {
+		t.Fatal("getBinaryVersion() should return error when command fails")
+	}
+	if !containsSubstring(err.Error(), "failed to run sonic-installer binary_version") {
+		t.Errorf("getBinaryVersion() error = %v, should contain 'failed to run sonic-installer binary_version'", err)
+	}
+}
+
 func TestHandleSetPackage_SuccessWithActivation(t *testing.T) {
 	patches := gomonkey.NewPatches()
 	defer patches.Reset()

--- a/pkg/gnoi/system/system_test.go
+++ b/pkg/gnoi/system/system_test.go
@@ -41,7 +41,7 @@ func TestHandleSetPackageValidation(t *testing.T) {
 			errMsg:  "filename is missing",
 		},
 		{
-			name: "missing version",
+			name: "missing version - no longer fails validation, auto-resolved from image",
 			req: &syspb.SetPackageRequest{
 				Request: &syspb.SetPackageRequest_Package{
 					Package: &syspb.Package{
@@ -50,8 +50,7 @@ func TestHandleSetPackageValidation(t *testing.T) {
 					},
 				},
 			},
-			wantErr: true,
-			errMsg:  "version is missing",
+			wantErr: false, // Version is now auto-resolved; validation no longer rejects this
 		},
 		{
 			name: "remote download not supported",

--- a/pkg/gnoi/system/system_test.go
+++ b/pkg/gnoi/system/system_test.go
@@ -41,7 +41,7 @@ func TestHandleSetPackageValidation(t *testing.T) {
 			errMsg:  "filename is missing",
 		},
 		{
-			name: "missing version - no longer fails validation, auto-resolved from image",
+			name: "empty version - resolved from image before install",
 			req: &syspb.SetPackageRequest{
 				Request: &syspb.SetPackageRequest_Package{
 					Package: &syspb.Package{
@@ -50,7 +50,7 @@ func TestHandleSetPackageValidation(t *testing.T) {
 					},
 				},
 			},
-			wantErr: false, // Version is now auto-resolved; validation no longer rejects this
+			wantErr: false, // Version is auto-resolved from image; no longer rejected
 		},
 		{
 			name: "remote download not supported",


### PR DESCRIPTION
Description:

Problem

The System.SetPackage gNOI RPC requires the caller to provide the version field. If hwproxy or other callers don't provideit, the request fails with "version is missing in package request". The caller often doesn't know the version string ahead of time — it's embedded in the image binary itself.

Solution

Instead of failing when version is empty, the API now automatically resolves it by running sonic-installer binary_version <filename> after installation. This extracts the version from the image and uses it for sonic-installer set-default.

Behavior:

 - If version is provided → used directly (no change)
 - If version is empty and activate=true → auto-resolved via sonic-installer binary_version
 - If version is empty and activate=false → install-only succeeds without version

Tests

 - TestHandleSetPackage_ActivateWithAutoResolvedVersion — happy path
 - TestHandleSetPackage_AutoResolveVersionFails — error propagation
 - TestGetBinaryVersion_Success / _EmptyOutput / _CommandError — unit tests for helper

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

