### PR TITLE
[chore/github]: Standardize GitHub PR description template

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -108,6 +108,11 @@ go tool cover -html=coverage.out
 - **Go formatting**: Code MUST pass `gofmt`
 - **Proto changes**: Update generated code when modifying `.proto` files
 - **Security**: gNMI server handles authentication — be security-conscious
+- **PR description template**: Fill out all sections of the [PR template](.github/pull_request_template.md) when submitting a pull request:
+  - **Description of PR**: Summary of the change, motivation/context, reviewer entry point, and dependencies; reference issues with `fixes #xxxx` / `closes #xxxx`.
+  - **Type of change**: Mark the box(es) that apply — bug fix, new feature, refactor / cleanup, documentation update, test improvement.
+  - **Approach**: Motivation; how you did it; how you verified/tested it; any platform-specific notes.
+  - **Documentation**: Link to wiki / doc updates relevant to new features or test cases.
 
 ## Common Patterns
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,49 +1,45 @@
 <!--
-     Please make sure you've read and understood our contributing guidelines:
-     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md
+Please make sure you've read and understood our contributing guidelines;
+https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md
 
-     ** Make sure all your commits include a signature generated with `git commit -s` **
-
-     If this is a bug fix, make sure your description includes "fixes #xxxx", or
-     "closes #xxxx" or "resolves #xxxx"
-
-     Please provide the following information:
+Please provide following information to help code review process a bit easier:
+-->
+### Description of PR
+<!--
+- Please include a summary of the change and which issue is fixed.
+- Please also include relevant motivation and context. Where should reviewer start? background context?
+- List any dependencies that are required for this change.
 -->
 
-#### Why I did it
+Summary:
+Fixes # (issue)
 
-#### How I did it
-
-#### How to verify it
-
-#### Which release branch to backport (provide reason below if selected)
+### Type of change
 
 <!--
-- Note we only backport fixes to a release branch, *not* features!
-- Please also provide a reason for the backporting below.
+- Fill x for your type of change.
 - e.g.
-- [x] 202006
+- [x] Bug fix
 -->
 
-- [ ] 201811
-- [ ] 201911
-- [ ] 202006
-- [ ] 202012
-- [ ] 202106
-- [ ] 202111
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor / cleanup
+- [ ] Documentation update
+- [ ] Test improvement
 
-#### Description for the changelog
+### Approach
+#### What is the motivation for this PR?
+
+#### How did you do it?
+
+#### How did you verify/test it?
+
+#### Any platform specific information?
+
+### Documentation
 <!--
-Write a short (one line) summary that describes the changes in this
-pull request for inclusion in the changelog:
+(If it's a new feature, new test case)
+Did you update documentation/Wiki relevant to your implementation?
+Link to the wiki page?
 -->
-
-#### Link to config_db schema for YANG module changes
-<!--
-Provide a link to config_db schema for the table for which YANG model
-is defined
-Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
--->
-
-#### A picture of a cute animal (not mandatory but encouraged)
-


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

Summary:
Align this repository's GitHub PR description template with the canonical
template used in [`sonic-buildimage`](https://github.com/sonic-net/sonic-buildimage/blob/master/.github/pull_request_template.md),
so contributors see the same prompts (Description of PR, Type of change,
Approach, Documentation) everywhere across SONiC.

Also update `.github/copilot-instructions.md` so AI-assisted PR descriptions
reference the new template sections.

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Documentation update
- [ ] Test improvement

### Approach
#### What is the motivation for this PR?

PR description templates across SONiC repositories have drifted from the
canonical `sonic-buildimage` template over time. A single shared structure
makes reviews predictable: contributors see the same prompts everywhere, and
reviewers can locate the same information in the same place across submodules.

#### How did you do it?

- Replaced `.github/pull_request_template.md` with the canonical `sonic-buildimage` template.
- Updated `.github/copilot-instructions.md` so the "PR description template" guidance lists the sections defined by the new template (Description of PR, Type of change, Approach, Documentation).

#### How did you verify/test it?

No functional changes — only files under `.github/` are touched. Verified by
rendering the new template on GitHub when opening this PR and confirming all
sections appear correctly.

#### Any platform specific information?

None.

### Documentation

N/A — process/template change only.
