### PR TITLE
Add additional allowlisted tables to bypass

### DIFF
--- a/pkg/bypass/bypass.go
+++ b/pkg/bypass/bypass.go
@@ -27,6 +27,8 @@ var AllowedTables = map[string]bool{
 	"VLAN_SUB_INTERFACE": true,
 	"ACL_RULE":           true,
 	"BGP_PEER_RANGE":     true,
+	"BGP_NEIGHBOR":       true,
+	"PREFIX_LIST":        true,
 }
 
 // AllowedSKUPrefixes lists HwSku prefixes that can use bypass validation

--- a/pkg/bypass/bypass_test.go
+++ b/pkg/bypass/bypass_test.go
@@ -835,7 +835,7 @@ func TestShouldBypassDelete(t *testing.T) {
 }
 
 func TestAllowedTables(t *testing.T) {
-	expectedTables := []string{"VNET", "VNET_ROUTE_TUNNEL", "VLAN_SUB_INTERFACE", "ACL_RULE", "BGP_PEER_RANGE"}
+	expectedTables := []string{"VNET", "VNET_ROUTE_TUNNEL", "VLAN_SUB_INTERFACE", "ACL_RULE", "BGP_PEER_RANGE", "BGP_NEIGHBOR", "PREFIX_LIST"}
 
 	for _, table := range expectedTables {
 		if !AllowedTables[table] {


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
BGP_NEIGHBOR and PREFIX_LIST need to be allowed to bypass yang

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Include BGP_NEIGHBOR and PREFIX_LIST in bypass allowlist

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

