### PR TITLE
Skip Redis client init for DBs not in database_config.json

### DIFF
--- a/sonic_data_client/client_test.go
+++ b/sonic_data_client/client_test.go
@@ -872,6 +872,53 @@ func TestInitRedisDbClients(t *testing.T) {
 		}
 	})
 
+	t.Run("SkipUnconfiguredDbWithoutGetDbSock", func(t *testing.T) {
+		defer saveAndResetTarget2RedisDb()()
+
+		const skippedDb = "CHASSIS_STATE_DB"
+		configuredDbs := []string{"CONFIG_DB", "APPL_DB", "STATE_DB"}
+		getDbSockCalls := 0
+		getDbSockCalledForSkipped := false
+
+		patches := gomonkey.ApplyFunc(sdcfg.GetDbAllNamespaces, func() ([]string, error) {
+			return []string{ns}, nil
+		})
+		defer patches.Reset()
+
+		patches.ApplyFunc(sdcfg.GetDbList, func(_ string) ([]string, error) {
+			return configuredDbs, nil
+		})
+
+		patches.ApplyFunc(sdcfg.GetDbSock, func(dbName string, _ string) (string, error) {
+			getDbSockCalls++
+			if dbName == skippedDb {
+				getDbSockCalledForSkipped = true
+			}
+			return "/var/run/redis/redis.sock", nil
+		})
+
+		initRedisDbClients()
+
+		nsMap, ok := Target2RedisDb[ns]
+		if !ok {
+			t.Fatal("Expected namespace to exist in Target2RedisDb")
+		}
+		if _, exists := nsMap[skippedDb]; exists {
+			t.Errorf("%s should have been skipped because it is not configured", skippedDb)
+		}
+		if getDbSockCalledForSkipped {
+			t.Errorf("GetDbSock should not be called for unconfigured DB %s", skippedDb)
+		}
+		if getDbSockCalls != len(configuredDbs) {
+			t.Errorf("Expected GetDbSock to be called %d times, got %d", len(configuredDbs), getDbSockCalls)
+		}
+		for _, dbName := range configuredDbs {
+			if _, exists := nsMap[dbName]; !exists {
+				t.Errorf("Expected %s to be initialized", dbName)
+			}
+		}
+	})
+
 	t.Run("AllDbsAvailable", func(t *testing.T) {
 		defer saveAndResetTarget2RedisDb()()
 

--- a/sonic_data_client/client_test.go
+++ b/sonic_data_client/client_test.go
@@ -1055,6 +1055,59 @@ func TestUseRedisTcpClient(t *testing.T) {
 		}
 	})
 
+	t.Run("SkipUnconfiguredDbWithoutGetDbTcpAddr", func(t *testing.T) {
+		defer saveAndResetTarget2RedisDb()()
+		origFlag := UseRedisLocalTcpPort
+		UseRedisLocalTcpPort = true
+		defer func() { UseRedisLocalTcpPort = origFlag }()
+
+		const skippedDb = "CHASSIS_STATE_DB"
+		configuredDbs := []string{"CONFIG_DB", "APPL_DB", "STATE_DB"}
+		getDbTcpAddrCalls := 0
+		getDbTcpAddrCalledForSkipped := false
+
+		patches := gomonkey.ApplyFunc(sdcfg.GetDbAllNamespaces, func() ([]string, error) {
+			return []string{ns}, nil
+		})
+		defer patches.Reset()
+
+		patches.ApplyFunc(sdcfg.GetDbList, func(_ string) ([]string, error) {
+			return configuredDbs, nil
+		})
+
+		patches.ApplyFunc(sdcfg.GetDbTcpAddr, func(dbName string, _ string) (string, error) {
+			getDbTcpAddrCalls++
+			if dbName == skippedDb {
+				getDbTcpAddrCalledForSkipped = true
+			}
+			return "127.0.0.1:6379", nil
+		})
+
+		err := useRedisTcpClient()
+		if err != nil {
+			t.Fatalf("Expected no error when skipping unconfigured DB, got: %v", err)
+		}
+
+		nsMap, ok := Target2RedisDb[ns]
+		if !ok {
+			t.Fatal("Expected namespace to exist in Target2RedisDb")
+		}
+		if _, exists := nsMap[skippedDb]; exists {
+			t.Errorf("%s should have been skipped because it is not configured", skippedDb)
+		}
+		if getDbTcpAddrCalledForSkipped {
+			t.Errorf("GetDbTcpAddr should not be called for unconfigured DB %s", skippedDb)
+		}
+		if getDbTcpAddrCalls != len(configuredDbs) {
+			t.Errorf("Expected GetDbTcpAddr to be called %d times, got %d", len(configuredDbs), getDbTcpAddrCalls)
+		}
+		for _, dbName := range configuredDbs {
+			if _, exists := nsMap[dbName]; !exists {
+				t.Errorf("Expected %s to be initialized in TCP mode", dbName)
+			}
+		}
+	})
+
 	t.Run("GetDbAllNamespacesFails", func(t *testing.T) {
 		defer saveAndResetTarget2RedisDb()()
 		origFlag := UseRedisLocalTcpPort
@@ -1072,6 +1125,19 @@ func TestUseRedisTcpClient(t *testing.T) {
 		}
 		if len(Target2RedisDb) != 0 {
 			t.Errorf("Expected Target2RedisDb to be empty, got %d entries", len(Target2RedisDb))
+		}
+	})
+}
+
+func TestConfiguredDbSet(t *testing.T) {
+	t.Run("GetDbListFailureReturnsNil", func(t *testing.T) {
+		patches := gomonkey.ApplyFunc(sdcfg.GetDbList, func(_ string) ([]string, error) {
+			return nil, fmt.Errorf("GetDbList failure")
+		})
+		defer patches.Reset()
+
+		if got := configuredDbSet("asic0"); got != nil {
+			t.Fatalf("expected nil set on GetDbList failure, got: %#v", got)
 		}
 	})
 }

--- a/sonic_data_client/db_client.go
+++ b/sonic_data_client/db_client.go
@@ -546,8 +546,15 @@ func useRedisTcpClient() error {
 	}
 	for _, dbNamespace := range AllNamespaces {
 		Target2RedisDb[dbNamespace] = make(map[string]*redis.Client)
+		configured := configuredDbSet(dbNamespace)
 		for dbName, dbn := range spb.Target_value {
 			if dbName != "OTHERS" {
+				if configured != nil {
+					if _, ok := configured[dbName]; !ok {
+						log.V(2).Infof("Skipping %s in namespace %s: not configured on this platform", dbName, dbNamespace)
+						continue
+					}
+				}
 				addr, err := sdcfg.GetDbTcpAddr(dbName, dbNamespace)
 				if err != nil {
 					log.Warningf("Skipping %s in namespace %s: %v", dbName, dbNamespace, err)
@@ -573,6 +580,24 @@ func init() {
 	initRedisDbClients()
 }
 
+// configuredDbSet returns the set of DB names defined in the device's
+// SONiC database_config.json for the given namespace.
+func configuredDbSet(dbNamespace string) map[string]struct{} {
+	dbList, err := sdcfg.GetDbList(dbNamespace)
+	if err != nil {
+		log.V(2).Infof("GetDbList failed for namespace %s: %v", dbNamespace, err)
+		return nil
+	}
+	if len(dbList) == 0 {
+		return nil
+	}
+	set := make(map[string]struct{}, len(dbList))
+	for _, name := range dbList {
+		set[name] = struct{}{}
+	}
+	return set
+}
+
 func initRedisDbClients() {
 	AllNamespaces, err := sdcfg.GetDbAllNamespaces()
 	if err != nil {
@@ -581,8 +606,15 @@ func initRedisDbClients() {
 	}
 	for _, dbNamespace := range AllNamespaces {
 		Target2RedisDb[dbNamespace] = make(map[string]*redis.Client)
+		configured := configuredDbSet(dbNamespace)
 		for dbName, dbn := range spb.Target_value {
 			if dbName != "OTHERS" {
+				if configured != nil {
+					if _, ok := configured[dbName]; !ok {
+						log.V(2).Infof("Skipping %s in namespace %s: not configured on this platform", dbName, dbNamespace)
+						continue
+					}
+				}
 				addr, err := sdcfg.GetDbSock(dbName, dbNamespace)
 				if err != nil {
 					log.Warningf("Skipping %s in namespace %s: %v", dbName, dbNamespace, err)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
`initRedisDbClients()` and `useRedisTcpClient()` iterate over every entry in the `spb.Target_value` proto enum and call `sdcfg.GetDbSock` / `sdcfg.GetDbTcpAddr` for each one. When a `Target` enum value corresponds to a DB that is not present in the device's database_config.json (e.g. DPU_COUNTERS_DB on a non-smartswitch / non-DPU platform), the underlying `SonicDBConfig::getDbInfo` call logs an ERR-level message to syslog:

 ```
ERR gnmi#telemetry: :- getDbInfo: Failed to find DPU_COUNTERS_DB database in : key
 ERR gnmi#dialout_client_cli: :- getDbInfo: Failed to find DPU_COUNTERS_DB database in : key
```

This was introduced as a side-effect of adding `DPU_COUNTERS_DB = 18` to the `Target` enum. Since `DPU_COUNTERS_DB` is only configured on smartswitch / DPU platforms, every other platform now emits these benign ERR logs every time `gnmi / dialout_client_cli` starts up.
#### How I did it
- Added a helper `configuredDbSet(dbNamespace)` that returns the set of DB names actually present in `database_config.json` for the given namespace.
 - In both `useRedisTcpClient()` (TCP path) and `initRedisDbClients()` (UNIX socket path), look up the configured DB set before iterating `spb.Target_value`. If a Target enum entry isn't in the configured set, skip it with a `V(2)` info log instead of calling `sdcfg.GetDbSock` / `sdcfg.GetDbTcpAddr` and triggering the ERR.
 - If `GetDbList` itself fails or returns empty, the helper returns nil and behaviour falls back to the original "try them all" path, so this is a strictly additive guard.
#### How to verify it
with this change, the test passed https://elastictest.org/scheduler/testplan/6a0ff4fe5ec6b5a1f3a20c7a?searchTestCase=rota&testcase=telemetry%2Ftest_telemetry_cert_rotation.py&type=console
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

