### PR TITLE
Add support for InterfaceCounter vpath

### DIFF
--- a/gnmi_server/poll_mode_test.go
+++ b/gnmi_server/poll_mode_test.go
@@ -2935,3 +2935,108 @@ func TestPollCountersDBWildcardEthernetMissingThenPartialAdded(t *testing.T) {
 		})
 	}
 }
+
+// TestPollInterfaceCountersVPath is an E2E poll-mode test for the
+// [COUNTERS_DB INTERFACE_COUNTERS] virtual path. It starts a gNMI server,
+// populates COUNTERS_DB via prepareDb (which loads counter data for Ethernet1
+// and Ethernet68), subscribes in Poll mode to [INTERFACE_COUNTERS], polls
+// multiple times, and compares the received notifications against the
+// COUNTERS:Ethernet_wildcard_expected.txt fixture (keyed by SONiC port name).
+func TestPollInterfaceCountersVPath(t *testing.T) {
+	s := createServer(t, 8081)
+	go runServer(t, s)
+	defer s.ForceStop()
+
+	ns, _ := sdcfg.GetDbDefaultNamespace()
+	prepareDb(t, ns)
+
+	fileName := "../testdata/COUNTERS:Ethernet_wildcard_expected.txt"
+	interfaceCountersExpectedByte, err := ioutil.ReadFile(fileName)
+	if err != nil {
+		t.Fatalf("read file %v err: %v", fileName, err)
+	}
+	var interfaceCountersExpectedJson interface{}
+	if err := json.Unmarshal(interfaceCountersExpectedByte, &interfaceCountersExpectedJson); err != nil {
+		t.Fatalf("unmarshal %v err: %v", fileName, err)
+	}
+
+	tests := []struct {
+		desc     string
+		q        client.Query
+		wantNoti []client.Notification
+		poll     int
+	}{
+		{
+			desc: "poll INTERFACE_COUNTERS",
+			poll: 3,
+			q: client.Query{
+				Target:  "COUNTERS_DB",
+				Type:    client.Poll,
+				Queries: []client.Path{{"INTERFACE_COUNTERS"}},
+				TLS:     &tls.Config{InsecureSkipVerify: true},
+			},
+			wantNoti: []client.Notification{
+				client.Connected{},
+				client.Update{Path: []string{"COUNTERS_DB", "INTERFACE_COUNTERS"}, TS: time.Unix(0, 200), Val: interfaceCountersExpectedJson},
+				client.Sync{},
+				client.Update{Path: []string{"COUNTERS_DB", "INTERFACE_COUNTERS"}, TS: time.Unix(0, 200), Val: interfaceCountersExpectedJson},
+				client.Sync{},
+				client.Update{Path: []string{"COUNTERS_DB", "INTERFACE_COUNTERS"}, TS: time.Unix(0, 200), Val: interfaceCountersExpectedJson},
+				client.Sync{},
+				client.Update{Path: []string{"COUNTERS_DB", "INTERFACE_COUNTERS"}, TS: time.Unix(0, 200), Val: interfaceCountersExpectedJson},
+				client.Sync{},
+			},
+		},
+	}
+
+	var mutexGotNoti sync.Mutex
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			q := tt.q
+			q.Addrs = []string{"127.0.0.1:8081"}
+			c := client.New()
+			var gotNoti []client.Notification
+
+			q.NotificationHandler = func(n client.Notification) error {
+				mutexGotNoti.Lock()
+				if nn, ok := n.(client.Update); ok {
+					nn.TS = time.Unix(0, 200)
+					gotNoti = append(gotNoti, nn)
+				} else {
+					gotNoti = append(gotNoti, n)
+				}
+				mutexGotNoti.Unlock()
+				return nil
+			}
+
+			wg := new(sync.WaitGroup)
+			wg.Add(1)
+
+			go func() {
+				defer wg.Done()
+				if err := c.Subscribe(context.Background(), q); err != nil {
+					t.Errorf("c.Subscribe(): got error %v, expected nil", err)
+				}
+			}()
+
+			wg.Wait()
+
+			for i := 0; i < tt.poll; i++ {
+				err := c.Poll()
+				if err != nil {
+					t.Errorf("c.Poll(): got error %v, expected nil", err)
+				}
+			}
+
+			mutexGotNoti.Lock()
+			if diff := pretty.Compare(tt.wantNoti, gotNoti); diff != "" {
+				t.Log("\n Want: \n", tt.wantNoti)
+				t.Log("\n Got : \n", gotNoti)
+				t.Errorf("unexpected updates:\n%s", diff)
+			}
+			mutexGotNoti.Unlock()
+			c.Close()
+		})
+	}
+}

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -427,6 +427,66 @@ func TestPFCWDErrors(t *testing.T) {
 	}
 }
 
+// TestGnmiGetInterfaceCountersVPath is an E2E Get-mode test for the
+// [COUNTERS_DB INTERFACE_COUNTERS] virtual path. It starts a gNMI server,
+// populates COUNTERS_DB via prepareDb (which loads counter data for
+// Ethernet1 and Ethernet68), issues a unary Get for [INTERFACE_COUNTERS],
+// and compares the returned JSON_IETF value against the
+// COUNTERS:Ethernet_wildcard_expected.txt fixture (keyed by SONiC port name).
+func TestGnmiGetInterfaceCountersVPath(t *testing.T) {
+	s := createServer(t, 8081)
+	go runServer(t, s)
+	defer s.ForceStop()
+
+	ns, _ := sdcfg.GetDbDefaultNamespace()
+	prepareDb(t, ns)
+
+	fileName := "../testdata/COUNTERS:Ethernet_wildcard_expected.txt"
+	interfaceCountersExpectedByte, err := ioutil.ReadFile(fileName)
+	if err != nil {
+		t.Fatalf("read file %v err: %v", fileName, err)
+	}
+
+	tlsConfig := &tls.Config{InsecureSkipVerify: true}
+	opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
+	targetAddr := "127.0.0.1:8081"
+	conn, err := grpc.Dial(targetAddr, opts...)
+	if err != nil {
+		t.Fatalf("Dialing to %q failed: %v", targetAddr, err)
+	}
+	defer conn.Close()
+
+	gClient := pb.NewGNMIClient(conn)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	tds := []struct {
+		desc        string
+		pathTarget  string
+		textPbPath  string
+		wantRetCode codes.Code
+		wantRespVal interface{}
+		valTest     bool
+	}{
+		{
+			desc:       "get INTERFACE_COUNTERS",
+			pathTarget: "COUNTERS_DB",
+			textPbPath: `
+					elem: <name: "INTERFACE_COUNTERS" >
+				`,
+			wantRetCode: codes.OK,
+			wantRespVal: interfaceCountersExpectedByte,
+			valTest:     true,
+		},
+	}
+
+	for _, td := range tds {
+		t.Run(td.desc, func(t *testing.T) {
+			runTestGet(t, ctx, gClient, td.pathTarget, td.textPbPath, td.wantRetCode, td.wantRespVal, td.valTest)
+		})
+	}
+}
+
 // runTestGet requests a path from the server by Get grpc call, and compares if
 // the return code and response value are expected.
 func runTestGet(t *testing.T, ctx context.Context, gClient pb.GNMIClient, pathTarget string,

--- a/sonic_data_client/virtual_db.go
+++ b/sonic_data_client/virtual_db.go
@@ -92,6 +92,9 @@ var (
 		{ // stats for one or all Ethernet ports
 			path:      []string{"COUNTERS_DB", "COUNTERS", "Ethernet*"},
 			transFunc: v2rTranslate(v2rEthPortStats),
+		}, { // per-interface counters keyed by SONiC interface name
+			path:      []string{"COUNTERS_DB", "INTERFACE_COUNTERS"},
+			transFunc: v2rTranslate(v2rInterfaceCountersStats),
 		}, { // specific field stats for one or all Ethernet ports
 			path:      []string{"COUNTERS_DB", "COUNTERS", "Ethernet*", "*"},
 			transFunc: v2rTranslate(v2rEthPortFieldStats),
@@ -729,6 +732,33 @@ func v2rEthPortStats(paths []string) ([]tablePath, error) {
 		}}
 	}
 	log.V(6).Infof("v2rEthPortStats: %v", tblPaths)
+	return tblPaths, nil
+}
+
+// v2rInterfaceCountersStats resolves the virtual path
+// [COUNTERS_DB INTERFACE_COUNTERS] to per-interface counter entries from the
+// underlying COUNTERS table, keyed by SONiC interface name (e.g. "Ethernet0").
+func v2rInterfaceCountersStats(paths []string) ([]tablePath, error) {
+	clearMappingsMu.RLock()
+	defer clearMappingsMu.RUnlock()
+	var tblPaths []tablePath
+	for port, oid := range countersPortNameMap {
+		namespace, ok := port2namespaceMap[port]
+		if !ok {
+			return nil, fmt.Errorf("%v does not have namespace associated", port)
+		}
+		separator, _ := GetTableKeySeparator(paths[DbIdx], namespace)
+		tblPath := tablePath{
+			dbNamespace:  namespace,
+			dbName:       paths[DbIdx],
+			tableName:    "COUNTERS", // INTERFACE_COUNTERS is virtual; data lives in COUNTERS
+			tableKey:     oid,
+			delimitor:    separator,
+			jsonTableKey: port,
+		}
+		tblPaths = append(tblPaths, tblPath)
+	}
+	log.V(6).Infof("v2rInterfaceCountersStats: %v", tblPaths)
 	return tblPaths, nil
 }
 

--- a/sonic_data_client/virtual_db_test.go
+++ b/sonic_data_client/virtual_db_test.go
@@ -1,7 +1,9 @@
 package client
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
 	"sort"
 	"sync"
 	"testing"
@@ -574,4 +576,206 @@ func TestResetRedisClients(t *testing.T) {
 
 	// Reset again to clean up for other tests
 	ResetRedisClients()
+}
+
+// --------------------------------------------------------------------------
+// Tests for v2rInterfaceCountersStats (virtual_db.go)
+// --------------------------------------------------------------------------
+
+func TestV2rInterfaceCountersStats(t *testing.T) {
+	sdcfg.Init()
+	restore := setupPortMaps(t)
+	defer restore()
+
+	paths := []string{"COUNTERS_DB", "INTERFACE_COUNTERS"}
+	tblPaths, err := v2rInterfaceCountersStats(paths)
+	if err != nil {
+		t.Fatalf("v2rInterfaceCountersStats returned error: %v", err)
+	}
+	if len(tblPaths) != 2 {
+		t.Fatalf("expected 2 table paths, got %d", len(tblPaths))
+	}
+
+	// Sort for deterministic comparison (map iteration order is random).
+	sort.Slice(tblPaths, func(i, j int) bool {
+		return tblPaths[i].jsonTableKey < tblPaths[j].jsonTableKey
+	})
+
+	// Ethernet0
+	tp := tblPaths[0]
+	if tp.dbName != "COUNTERS_DB" {
+		t.Errorf("dbName = %q, want COUNTERS_DB", tp.dbName)
+	}
+	if tp.tableName != "COUNTERS" {
+		t.Errorf("tableName = %q, want COUNTERS (real backing table)", tp.tableName)
+	}
+	if tp.tableKey != "oid:0x1000000000001" {
+		t.Errorf("tableKey = %q, want oid:0x1000000000001", tp.tableKey)
+	}
+	if tp.jsonTableKey != "Ethernet0" {
+		t.Errorf("jsonTableKey = %q, want Ethernet0", tp.jsonTableKey)
+	}
+
+	// Ethernet68
+	tp = tblPaths[1]
+	if tp.tableName != "COUNTERS" {
+		t.Errorf("tableName = %q, want COUNTERS", tp.tableName)
+	}
+	if tp.tableKey != "oid:0x1000000000039" {
+		t.Errorf("tableKey = %q, want oid:0x1000000000039", tp.tableKey)
+	}
+	if tp.jsonTableKey != "Ethernet68" {
+		t.Errorf("jsonTableKey = %q, want Ethernet68", tp.jsonTableKey)
+	}
+}
+
+func TestV2rInterfaceCountersStats_EmptyMap(t *testing.T) {
+	sdcfg.Init()
+	restore := setupPortMaps(t)
+	defer restore()
+
+	countersPortNameMap = map[string]string{}
+	port2namespaceMap = map[string]string{}
+
+	paths := []string{"COUNTERS_DB", "INTERFACE_COUNTERS"}
+	tblPaths, err := v2rInterfaceCountersStats(paths)
+	if err != nil {
+		t.Fatalf("expected no error with empty map, got: %v", err)
+	}
+	if len(tblPaths) != 0 {
+		t.Errorf("expected 0 table paths, got %d", len(tblPaths))
+	}
+}
+
+func TestV2rInterfaceCountersStats_MissingNamespace(t *testing.T) {
+	sdcfg.Init()
+	restore := setupPortMaps(t)
+	defer restore()
+
+	// Add a port to the OID map without a namespace entry.
+	countersPortNameMap["Ethernet99"] = "oid:0x1000000000099"
+
+	paths := []string{"COUNTERS_DB", "INTERFACE_COUNTERS"}
+	_, err := v2rInterfaceCountersStats(paths)
+	if err == nil {
+		t.Fatal("expected error for port missing namespace, got nil")
+	}
+}
+
+// TestV2rInterfaceCountersTriePath verifies that the trie maps the virtual
+// path [COUNTERS_DB INTERFACE_COUNTERS] to v2rInterfaceCountersStats.
+func TestV2rInterfaceCountersTriePath(t *testing.T) {
+	sdcfg.Init()
+	restore := setupPortMaps(t)
+	defer restore()
+
+	tblPaths, err := lookupV2R([]string{"COUNTERS_DB", "INTERFACE_COUNTERS"})
+	if err != nil {
+		t.Fatalf("lookupV2R failed for INTERFACE_COUNTERS: %v", err)
+	}
+	if len(tblPaths) != 2 {
+		t.Fatalf("expected 2 table paths from trie lookup, got %d", len(tblPaths))
+	}
+	for _, tp := range tblPaths {
+		if tp.tableName != "COUNTERS" {
+			t.Errorf("tableName = %q, want COUNTERS", tp.tableName)
+		}
+		if tp.jsonTableKey != "Ethernet0" && tp.jsonTableKey != "Ethernet68" {
+			t.Errorf("jsonTableKey = %q, want Ethernet0 or Ethernet68", tp.jsonTableKey)
+		}
+	}
+}
+
+// TestV2rInterfaceCountersStats_FromTestdata loads the real COUNTERS_PORT_NAME_MAP
+// fixture from testdata/ and verifies v2rInterfaceCountersStats produces one
+// tablePath per port in the map, each pointing at the COUNTERS table by oid and
+// keyed in JSON by the SONiC interface name (no alias translation).
+func TestV2rInterfaceCountersStats_FromTestdata(t *testing.T) {
+	sdcfg.Init()
+
+	// Read the same fixture used by the gnmi_server integration tests.
+	raw, err := os.ReadFile("../testdata/COUNTERS_PORT_NAME_MAP.txt")
+	if err != nil {
+		t.Fatalf("failed to read COUNTERS_PORT_NAME_MAP.txt: %v", err)
+	}
+	portMap := map[string]string{}
+	if err := json.Unmarshal(raw, &portMap); err != nil {
+		t.Fatalf("failed to parse COUNTERS_PORT_NAME_MAP.txt: %v", err)
+	}
+	if len(portMap) == 0 {
+		t.Fatal("COUNTERS_PORT_NAME_MAP.txt produced empty map")
+	}
+
+	// Swap in the testdata-backed maps; restore on exit.
+	origPortNameMap := countersPortNameMap
+	origPort2NsMap := port2namespaceMap
+	defer func() {
+		countersPortNameMap = origPortNameMap
+		port2namespaceMap = origPort2NsMap
+	}()
+
+	countersPortNameMap = make(map[string]string, len(portMap))
+	port2namespaceMap = make(map[string]string, len(portMap))
+	for port, oid := range portMap {
+		countersPortNameMap[port] = oid
+		port2namespaceMap[port] = ""
+	}
+
+	paths := []string{"COUNTERS_DB", "INTERFACE_COUNTERS"}
+	tblPaths, err := v2rInterfaceCountersStats(paths)
+	if err != nil {
+		t.Fatalf("v2rInterfaceCountersStats returned error: %v", err)
+	}
+	if len(tblPaths) != len(portMap) {
+		t.Fatalf("expected %d table paths (one per port in fixture), got %d",
+			len(portMap), len(tblPaths))
+	}
+
+	// Index returned paths by SONiC interface name for easy lookup.
+	got := make(map[string]tablePath, len(tblPaths))
+	for _, tp := range tblPaths {
+		if _, dup := got[tp.jsonTableKey]; dup {
+			t.Errorf("duplicate jsonTableKey %q in result", tp.jsonTableKey)
+		}
+		got[tp.jsonTableKey] = tp
+	}
+
+	for port, wantOid := range portMap {
+		tp, ok := got[port]
+		if !ok {
+			t.Errorf("port %q missing from result", port)
+			continue
+		}
+		if tp.dbName != "COUNTERS_DB" {
+			t.Errorf("port %q: dbName = %q, want COUNTERS_DB", port, tp.dbName)
+		}
+		// INTERFACE_COUNTERS is virtual; data lives in the real COUNTERS table.
+		if tp.tableName != "COUNTERS" {
+			t.Errorf("port %q: tableName = %q, want COUNTERS", port, tp.tableName)
+		}
+		if tp.tableKey != wantOid {
+			t.Errorf("port %q: tableKey = %q, want %q", port, tp.tableKey, wantOid)
+		}
+		if tp.jsonTableKey != port {
+			t.Errorf("jsonTableKey = %q, want %q (SONiC name, no alias)",
+				tp.jsonTableKey, port)
+		}
+	}
+
+	// Spot-check a few well-known entries from the fixture so a future change
+	// to the testdata file doesn't silently weaken the assertion.
+	for port, wantOid := range map[string]string{
+		"Ethernet0":  "oid:0x1000000000002",
+		"Ethernet1":  "oid:0x1000000000003",
+		"Ethernet68": "oid:0x1000000000039",
+	} {
+		tp, ok := got[port]
+		if !ok {
+			t.Errorf("expected port %q from fixture not present in result", port)
+			continue
+		}
+		if tp.tableKey != wantOid {
+			t.Errorf("port %q: tableKey = %q, want %q", port, tp.tableKey, wantOid)
+		}
+	}
 }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Adding dedicated counter query which could return interface name as key without * in the path

#### How I did it
Create vpath for interface counter

#### How to verify it
<img width="2534" height="752" alt="image" src="https://github.com/user-attachments/assets/6e5b445d-2ee3-4335-99f3-670822fb0b6c" />


#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

