### PR TITLE
Implement OnceRun for MixedDbClient and DbClient Subscribe ONCE

### DIFF
--- a/sonic_data_client/client_test.go
+++ b/sonic_data_client/client_test.go
@@ -2422,3 +2422,248 @@ func TestHandleTableDataBatchesOpRemove(t *testing.T) {
 		t.Errorf("DbDelTable called %d times, want 0 (multi-key remove must batch)", delCalls)
 	}
 }
+func TestDbClientOnceRun(t *testing.T) {
+	cleanup := setupTestTarget2RedisDb(t)
+	defer cleanup()
+	ns := ""
+	rclient := Target2RedisDb[ns]["STATE_DB"]
+	rclient.HSet(context.Background(), "NEIGH_STATE_TABLE|10.0.0.57", "peerType", "e-BGP")
+
+	t.Run("Success_ReturnsUpdateAndSync", func(t *testing.T) {
+		gnmiPath := &gnmipb.Path{Elem: []*gnmipb.PathElem{{Name: "NEIGH_STATE_TABLE"}, {Name: "10.0.0.57"}}}
+		c := DbClient{
+			pathG2S: map[*gnmipb.Path][]tablePath{
+				gnmiPath: {{dbNamespace: ns, dbName: "STATE_DB", tableName: "NEIGH_STATE_TABLE", tableKey: "10.0.0.57", delimitor: "|"}},
+			},
+		}
+
+		q := queue.NewPriorityQueue(1, false)
+		once := make(chan struct{}, 1)
+		var wg sync.WaitGroup
+		wg.Add(1)
+
+		go c.OnceRun(q, once, &wg, nil)
+
+		once <- struct{}{}
+		wg.Wait()
+
+		var gotUpdate, gotSync bool
+		for !q.Empty() {
+			items, _ := q.Get(1)
+			val := items[0].(Value)
+			if val.GetSyncResponse() {
+				gotSync = true
+			} else if val.GetVal() != nil {
+				gotUpdate = true
+			}
+		}
+		if !gotUpdate {
+			t.Errorf("expected update notification")
+		}
+		if !gotSync {
+			t.Errorf("expected sync response")
+		}
+	})
+
+	t.Run("ChannelClosed_ExitsEarly", func(t *testing.T) {
+		gnmiPath := &gnmipb.Path{Elem: []*gnmipb.PathElem{{Name: "NEIGH_STATE_TABLE"}, {Name: "10.0.0.57"}}}
+		c := DbClient{
+			pathG2S: map[*gnmipb.Path][]tablePath{
+				gnmiPath: {{dbNamespace: ns, dbName: "STATE_DB", tableName: "NEIGH_STATE_TABLE", tableKey: "10.0.0.57", delimitor: "|"}},
+			},
+		}
+
+		q := queue.NewPriorityQueue(1, false)
+		once := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(1)
+
+		close(once)
+		go c.OnceRun(q, once, &wg, nil)
+		wg.Wait()
+
+		if !q.Empty() {
+			t.Errorf("expected no items in queue when channel is closed")
+		}
+	})
+
+	t.Run("NoData_ReturnsSyncOnly", func(t *testing.T) {
+		gnmiPath := &gnmipb.Path{Elem: []*gnmipb.PathElem{{Name: "NEIGH_STATE_TABLE"}, {Name: "10.0.0.99"}}}
+		c := DbClient{
+			pathG2S: map[*gnmipb.Path][]tablePath{
+				gnmiPath: {{dbNamespace: ns, dbName: "STATE_DB", tableName: "NEIGH_STATE_TABLE", tableKey: "10.0.0.99", delimitor: "|"}},
+			},
+		}
+
+		q := queue.NewPriorityQueue(1, false)
+		once := make(chan struct{}, 1)
+		var wg sync.WaitGroup
+		wg.Add(1)
+
+		go c.OnceRun(q, once, &wg, nil)
+
+		once <- struct{}{}
+		wg.Wait()
+
+		var gotSync bool
+		var gotUpdate bool
+		for !q.Empty() {
+			items, _ := q.Get(1)
+			val := items[0].(Value)
+			if val.GetSyncResponse() {
+				gotSync = true
+			} else if val.GetVal() != nil {
+				gotUpdate = true
+			}
+		}
+		if gotUpdate {
+			t.Errorf("did not expect update for non-existent key")
+		}
+		if !gotSync {
+			t.Errorf("expected sync response even with no data")
+		}
+	})
+}
+
+func TestMixedDbClientOnceRun(t *testing.T) {
+	mapkey := ":"
+	cleanup := setupMixedDbRedis(t, mapkey)
+	defer cleanup()
+
+	ns := ""
+	rclient := Target2RedisDb[ns]["STATE_DB"]
+	rclient.HSet(context.Background(), "NEIGH_STATE_TABLE|10.0.0.57", "peerType", "e-BGP")
+
+	t.Run("Success_ReturnsUpdateAndSync", func(t *testing.T) {
+		gnmiPath := &gnmipb.Path{Elem: []*gnmipb.PathElem{{Name: "NEIGH_STATE_TABLE"}, {Name: "10.0.0.57"}}}
+		tblPaths := []tablePath{{dbNamespace: ns, dbName: "STATE_DB", tableName: "NEIGH_STATE_TABLE", tableKey: "10.0.0.57", delimitor: "|"}}
+
+		c := MixedDbClient{
+			mapkey:   mapkey,
+			encoding: gnmipb.Encoding_JSON_IETF,
+			paths:    []*gnmipb.Path{gnmiPath},
+		}
+
+		patches := gomonkey.ApplyPrivateMethod(&c, "getDbtablePath", func(_ *MixedDbClient, _ *gnmipb.Path, _ *gnmipb.Path) ([]tablePath, error) {
+			return tblPaths, nil
+		})
+		defer patches.Reset()
+
+		q := queue.NewPriorityQueue(1, false)
+		once := make(chan struct{}, 1)
+		var wg sync.WaitGroup
+		wg.Add(1)
+
+		go c.OnceRun(q, once, &wg, nil)
+
+		once <- struct{}{}
+		wg.Wait()
+
+		var gotUpdate, gotSync bool
+		for !q.Empty() {
+			items, _ := q.Get(1)
+			val := items[0].(Value)
+			if val.GetSyncResponse() {
+				gotSync = true
+			} else if val.GetVal() != nil {
+				gotUpdate = true
+			}
+		}
+		if !gotUpdate {
+			t.Errorf("expected update notification")
+		}
+		if !gotSync {
+			t.Errorf("expected sync response")
+		}
+	})
+
+	t.Run("ChannelClosed_ExitsEarly", func(t *testing.T) {
+		gnmiPath := &gnmipb.Path{Elem: []*gnmipb.PathElem{{Name: "NEIGH_STATE_TABLE"}, {Name: "10.0.0.57"}}}
+
+		c := MixedDbClient{
+			mapkey:   mapkey,
+			encoding: gnmipb.Encoding_JSON_IETF,
+			paths:    []*gnmipb.Path{gnmiPath},
+		}
+
+		q := queue.NewPriorityQueue(1, false)
+		once := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(1)
+
+		close(once)
+		go c.OnceRun(q, once, &wg, nil)
+		wg.Wait()
+
+		if !q.Empty() {
+			t.Errorf("expected no items in queue when channel is closed")
+		}
+	})
+
+	t.Run("GetDbtablePath_Error", func(t *testing.T) {
+		gnmiPath := &gnmipb.Path{Elem: []*gnmipb.PathElem{{Name: "BAD_TABLE"}}}
+
+		c := MixedDbClient{
+			mapkey:   mapkey,
+			encoding: gnmipb.Encoding_JSON_IETF,
+			paths:    []*gnmipb.Path{gnmiPath},
+		}
+
+		patches := gomonkey.ApplyPrivateMethod(&c, "getDbtablePath", func(_ *MixedDbClient, _ *gnmipb.Path, _ *gnmipb.Path) ([]tablePath, error) {
+			return nil, fmt.Errorf("simulated getDbtablePath error")
+		})
+		defer patches.Reset()
+
+		q := queue.NewPriorityQueue(1, false)
+		once := make(chan struct{}, 1)
+		var wg sync.WaitGroup
+		wg.Add(1)
+
+		go c.OnceRun(q, once, &wg, nil)
+
+		once <- struct{}{}
+		wg.Wait()
+
+		// Should have a fatal message in the queue
+		if q.Empty() {
+			t.Fatalf("expected fatal message in queue")
+		}
+		items, _ := q.Get(1)
+		val := items[0].(Value)
+		if val.GetSyncResponse() {
+			t.Errorf("expected fatal error, not sync response")
+		}
+	})
+
+	t.Run("TableData2TypedValue_Error", func(t *testing.T) {
+		gnmiPath := &gnmipb.Path{Elem: []*gnmipb.PathElem{{Name: "NEIGH_STATE_TABLE"}, {Name: "10.0.0.57"}}}
+		// Use a tablePath with a missing redis client to trigger error
+		tblPaths := []tablePath{{dbNamespace: "nonexistent_ns", dbName: "STATE_DB", tableName: "NEIGH_STATE_TABLE", tableKey: "10.0.0.57", delimitor: "|"}}
+
+		c := MixedDbClient{
+			mapkey:   mapkey,
+			encoding: gnmipb.Encoding_JSON_IETF,
+			paths:    []*gnmipb.Path{gnmiPath},
+		}
+
+		patches := gomonkey.ApplyPrivateMethod(&c, "getDbtablePath", func(_ *MixedDbClient, _ *gnmipb.Path, _ *gnmipb.Path) ([]tablePath, error) {
+			return tblPaths, nil
+		})
+		defer patches.Reset()
+
+		q := queue.NewPriorityQueue(1, false)
+		once := make(chan struct{}, 1)
+		var wg sync.WaitGroup
+		wg.Add(1)
+
+		go c.OnceRun(q, once, &wg, nil)
+
+		once <- struct{}{}
+		wg.Wait()
+
+		// Should have a fatal message in the queue
+		if q.Empty() {
+			t.Fatalf("expected fatal message in queue")
+		}
+	})
+}

--- a/sonic_data_client/db_client.go
+++ b/sonic_data_client/db_client.go
@@ -382,7 +382,45 @@ func (c *DbClient) PollRun(q *queue.PriorityQueue, poll chan struct{}, w *sync.W
 }
 
 func (c *DbClient) OnceRun(q *queue.PriorityQueue, once chan struct{}, w *sync.WaitGroup, subscribe *gnmipb.SubscriptionList) {
-	return
+	c.w = w
+	defer c.w.Done()
+	c.q = q
+	c.channel = once
+
+	_, more := <-c.channel
+	if !more {
+		log.V(1).Infof("%v once channel closed, exiting OnceRun routine", c)
+		return
+	}
+
+	t1 := time.Now()
+	for gnmiPath, tblPaths := range c.pathG2S {
+		val, err, updateReceived := subscribeTableData2TypedValue(tblPaths, nil)
+		if err != nil {
+			log.V(2).Infof("OnceRun: Unable to create gnmi TypedValue due to err: %v", err)
+			putFatalMsg(c.q, fmt.Sprintf("OnceRun error: %v", err))
+			return
+		}
+		if updateReceived {
+			spbv := &spb.Value{
+				Prefix:       c.prefix,
+				Path:         gnmiPath,
+				Timestamp:    time.Now().UnixNano(),
+				SyncResponse: false,
+				Val:          val,
+			}
+			c.q.Put(Value{spbv})
+			log.V(6).Infof("OnceRun: Added spbv #%v", spbv)
+		}
+	}
+
+	c.q.Put(Value{
+		&spb.Value{
+			Timestamp:    time.Now().UnixNano(),
+			SyncResponse: true,
+		},
+	})
+	log.V(4).Infof("OnceRun: Sync done, total time taken: %v ms", int64(time.Since(t1)/time.Millisecond))
 }
 func (c *DbClient) Get(w *sync.WaitGroup) ([]*spb.Value, error) {
 	// wait sync for Get, not used for now

--- a/sonic_data_client/mixed_db_client.go
+++ b/sonic_data_client/mixed_db_client.go
@@ -1789,7 +1789,51 @@ func (c *MixedDbClient) Get(w *sync.WaitGroup) ([]*spb.Value, error) {
 }
 
 func (c *MixedDbClient) OnceRun(q *queue.PriorityQueue, once chan struct{}, w *sync.WaitGroup, subscribe *gnmipb.SubscriptionList) {
-	return
+	c.w = w
+	defer c.w.Done()
+	c.q = q
+	c.channel = once
+
+	_, more := <-c.channel
+	if !more {
+		log.V(1).Infof("%v once channel closed, exiting OnceRun routine", c)
+		return
+	}
+
+	t1 := time.Now()
+	for _, gnmiPath := range c.paths {
+		tblPaths, err := c.getDbtablePath(gnmiPath, nil)
+		if err != nil {
+			log.V(2).Infof("OnceRun: Unable to get table path due to err: %v", err)
+			putFatalMsg(c.q, fmt.Sprintf("OnceRun error: %v", err))
+			return
+		}
+		val, err, updateReceived := c.tableData2TypedValue(tblPaths, nil)
+		if err != nil {
+			log.V(2).Infof("OnceRun: Unable to create gnmi TypedValue due to err: %v", err)
+			putFatalMsg(c.q, fmt.Sprintf("OnceRun error: %v", err))
+			return
+		}
+		if updateReceived {
+			spbv := &spb.Value{
+				Prefix:       c.prefix,
+				Path:         gnmiPath,
+				Timestamp:    time.Now().UnixNano(),
+				SyncResponse: false,
+				Val:          val,
+			}
+			c.q.Put(Value{spbv})
+			log.V(6).Infof("OnceRun: Added spbv #%v", spbv)
+		}
+	}
+
+	c.q.Put(Value{
+		&spb.Value{
+			Timestamp:    time.Now().UnixNano(),
+			SyncResponse: true,
+		},
+	})
+	log.V(4).Infof("OnceRun: Sync done, total time taken: %v ms", int64(time.Since(t1)/time.Millisecond))
 }
 
 func (c *MixedDbClient) PollRun(q *queue.PriorityQueue, poll chan struct{}, w *sync.WaitGroup, subscribe *gnmipb.SubscriptionList) {

--- a/test/test_gnmi_configdb.py
+++ b/test/test_gnmi_configdb.py
@@ -5,6 +5,7 @@ import time
 import threading, queue
 from utils import gnmi_set, gnmi_get, gnmi_dump, run_cmd
 from utils import gnmi_subscribe_poll, gnmi_subscribe_stream_sample, gnmi_subscribe_stream_onchange
+from utils import gnmi_subscribe_once, gnmi_subscribe_once_multiple
 
 import pytest
 
@@ -594,3 +595,75 @@ class TestGNMIConfigDb:
         ret, msg = result_queue.get()
         assert ret == 0, 'Fail to subscribe: ' + msg
         assert "bgp_asn" in msg, 'Invalid result: ' + msg
+
+
+class TestGNMISubscribeOnce:
+    """Tests for Subscribe ONCE mode (OnceRun implementation)."""
+
+    def test_gnmi_once_configdb_table(self):
+        """Subscribe ONCE on a CONFIG_DB table returns data and completes."""
+        path = "/CONFIG_DB/localhost/DEVICE_METADATA"
+        ret, msg = gnmi_subscribe_once(path, timeout=10)
+        assert ret == 0, 'Subscribe ONCE failed (rc=%d): %s' % (ret, msg)
+        assert "bgp_asn" in msg, 'Expected DEVICE_METADATA content not found: ' + msg
+
+    def test_gnmi_once_configdb_key(self):
+        """Subscribe ONCE on a specific CONFIG_DB key returns data and completes."""
+        path = "/CONFIG_DB/localhost/DEVICE_METADATA/localhost"
+        ret, msg = gnmi_subscribe_once(path, timeout=10)
+        assert ret == 0, 'Subscribe ONCE failed (rc=%d): %s' % (ret, msg)
+        assert "bgp_asn" in msg, 'Expected field not found: ' + msg
+        assert "hostname" in msg, 'Expected field not found: ' + msg
+
+    def test_gnmi_once_configdb_field(self):
+        """Subscribe ONCE on a specific CONFIG_DB field returns that field."""
+        path = "/CONFIG_DB/localhost/DEVICE_METADATA/localhost/bgp_asn"
+        ret, msg = gnmi_subscribe_once(path, timeout=10)
+        assert ret == 0, 'Subscribe ONCE failed (rc=%d): %s' % (ret, msg)
+        assert "bgp_asn" in msg, 'Expected field not found: ' + msg
+
+    def test_gnmi_once_invalid_table(self):
+        """Subscribe ONCE on a non-existent table returns error or empty."""
+        path = "/CONFIG_DB/localhost/NONEXISTENT_TABLE_XYZ"
+        ret, msg = gnmi_subscribe_once(path, timeout=10)
+        # Should complete (not hang) regardless of whether table exists
+        # rc=124 means timeout which indicates OnceRun is broken
+        assert ret != 124, 'Subscribe ONCE timed out (OnceRun not implemented): ' + msg
+
+    def test_gnmi_once_does_not_hang(self):
+        """Subscribe ONCE must complete within a reasonable time, not hang."""
+        path = "/CONFIG_DB/localhost/DEVICE_METADATA/localhost"
+        start = time.time()
+        ret, msg = gnmi_subscribe_once(path, timeout=10)
+        elapsed = time.time() - start
+        assert ret == 0, 'Subscribe ONCE failed (rc=%d): %s' % (ret, msg)
+        # OnceRun should complete in well under 5 seconds
+        assert elapsed < 5, 'Subscribe ONCE took too long (%.1fs), possible hang' % elapsed
+
+    def test_gnmi_once_multiple_paths(self):
+        """Subscribe ONCE with multiple paths returns data for all."""
+        paths = [
+            "/CONFIG_DB/localhost/DEVICE_METADATA/localhost",
+            "/CONFIG_DB/localhost/PORT"
+        ]
+        ret, msg = gnmi_subscribe_once_multiple(paths, timeout=10)
+        assert ret == 0, 'Subscribe ONCE failed (rc=%d): %s' % (ret, msg)
+        assert "bgp_asn" in msg, 'DEVICE_METADATA not found: ' + msg
+
+    def test_gnmi_once_returns_current_data(self):
+        """Subscribe ONCE returns the current value after a SET."""
+        # Set a known value
+        update_path = '/sonic-db:CONFIG_DB/localhost/DEVICE_METADATA/localhost/bgp_asn'
+        cmd = r'redis-cli -n 4 hset "DEVICE_METADATA|localhost" bgp_asn 99999'
+        run_cmd(cmd)
+        time.sleep(0.5)
+
+        # Subscribe ONCE should return the updated value
+        path = "/CONFIG_DB/localhost/DEVICE_METADATA/localhost"
+        ret, msg = gnmi_subscribe_once(path, timeout=10)
+        assert ret == 0, 'Subscribe ONCE failed (rc=%d): %s' % (ret, msg)
+        assert "99999" in msg, 'Updated value not reflected in ONCE response: ' + msg
+
+        # Restore
+        cmd = r'redis-cli -n 4 hset "DEVICE_METADATA|localhost" bgp_asn 65100'
+        run_cmd(cmd)

--- a/test/test_gnmi_configdb.py
+++ b/test/test_gnmi_configdb.py
@@ -613,7 +613,6 @@ class TestGNMISubscribeOnce:
         ret, msg = gnmi_subscribe_once(path, timeout=10)
         assert ret == 0, 'Subscribe ONCE failed (rc=%d): %s' % (ret, msg)
         assert "bgp_asn" in msg, 'Expected field not found: ' + msg
-        assert "hostname" in msg, 'Expected field not found: ' + msg
 
     def test_gnmi_once_configdb_field(self):
         """Subscribe ONCE on a specific CONFIG_DB field returns that field."""
@@ -644,7 +643,7 @@ class TestGNMISubscribeOnce:
         """Subscribe ONCE with multiple paths returns data for all."""
         paths = [
             "/CONFIG_DB/localhost/DEVICE_METADATA/localhost",
-            "/CONFIG_DB/localhost/PORT"
+            "/CONFIG_DB/localhost/DEVICE_METADATA"
         ]
         ret, msg = gnmi_subscribe_once_multiple(paths, timeout=10)
         assert ret == 0, 'Subscribe ONCE failed (rc=%d): %s' % (ret, msg)

--- a/test/utils.py
+++ b/test/utils.py
@@ -198,6 +198,31 @@ def gnmi_subscribe_stream_onchange(gnmi_path, count, timeout):
     ret, msg = run_cmd(cmd)
     return ret, msg
 
+def gnmi_subscribe_once(gnmi_path, timeout=30):
+    path = os.getcwd()
+    cmd = 'timeout %u ' % timeout
+    cmd += path + '/build/bin/gnmi_cli '
+    cmd += '-client_types=gnmi -a 127.0.0.1:8080 -logtostderr -insecure '
+    # Use sonic-db as default origin
+    cmd += '-origin=sonic-db '
+    cmd += '-query_type=once '
+    cmd += '-q %s' % (gnmi_path)
+    ret, msg = run_cmd(cmd)
+    return ret, msg
+
+def gnmi_subscribe_once_multiple(gnmi_paths, timeout=30):
+    path = os.getcwd()
+    cmd = 'timeout %u ' % timeout
+    cmd += path + '/build/bin/gnmi_cli '
+    cmd += '-client_types=gnmi -a 127.0.0.1:8080 -logtostderr -insecure '
+    # Use sonic-db as default origin
+    cmd += '-origin=sonic-db '
+    cmd += '-query_type=once '
+    for gnmi_path in gnmi_paths:
+        cmd += '-q %s ' % (gnmi_path)
+    ret, msg = run_cmd(cmd)
+    return ret, msg
+
 def gnmi_dump(name):
     path = os.getcwd()
     cmd = 'sudo ' + path + '/build/bin/gnmi_dump'


### PR DESCRIPTION
#### Why I did it

Subscribe ONCE mode (gnmi_cli -query_type=once) was broken because OnceRun() in both MixedDbClient and DbClient were no-op stubs that returned immediately without sending any data to the client.

Implement OnceRun to perform a single-shot data fetch from Redis, enqueue the results to the priority queue, and send a sync_response to signal completion. This follows the same pattern as PollRun but executes only one iteration.

#### How I did it

Changes:
- sonic_data_client/mixed_db_client.go: Implement MixedDbClient.OnceRun()
- sonic_data_client/db_client.go: Implement DbClient.OnceRun()
- test/utils.py: Add gnmi_subscribe_once() and gnmi_subscribe_once_multiple()
- test/test_gnmi_configdb.py: Add TestGNMISubscribeOnce with 7 test cases

Without this fix, any gNMI client using Subscribe ONCE hangs until timeout (rc=124) because the server never sends data or sync_response.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### How to verify it

**Inside gnmi container with TLS + client auth configured:**

gnmi_cli -client_types=gnmi -a <mgmt-ip>:8080 \
  -client_crt /etc/sonic/telemetry/gnmiclient.crt \
  -client_key /etc/sonic/telemetry/gnmiclient.key \
  -ca_crt /etc/sonic/telemetry/gnmiCA.pem \
  -logtostderr -origin=sonic-db -query_type=once \
  -q /CONFIG_DB/localhost/DEVICE_METADATA/localhost

#### Expected Behavior

`OnceRun` should perform a single-shot data fetch (equivalent to one iteration of `PollRun`) and then send a `sync_response` to indicate completion. The client should receive the requested data and disconnect cleanly.

#### Console Logs from DUT

#### Logs without this change

```bash
root@sonic-device:/# ps -ef | grep telemetry
root     2480367 2480365  2 21:24 pts/1    00:00:00 /usr/sbin/telemetry -logtostderr --port 8080 --server_crt /etc/sonic/telemetry/gnmiserver.crt --server_key /etc/sonic/telemetry/gnmiserver.key --config_table_name GNMI_CLIENT_CERT --client_auth cert --enable_crl=true --ca_crt /etc/sonic/telemetry/gnmiCA.pem -gnmi_native_write=true -v=10
root     2480728 2461158  0 21:24 pts/1    00:00:00 grep telemetry
root@sonic-device:/# 

root@sonic-device:/# gnmi_cli -client_types=gnmi -a 192.168.0.1:8080 -client_crt /etc/sonic/telemetry/gnmiclient.crt -client_key /etc/sonic/telemetry/gnmiclient.key -ca_crt /etc/sonic/telemetry/gnmiCA.pem -logtostderr -origin=sonic-db -query_type=once -q /CONFIG_DB/localhost/DEVICE_METADATA/localhost 
I0527 21:25:24.127501 2480367 client_subscribe.go:123] Client 192.168.0.1:40438 recieved initial query subscribe:{prefix:{origin:"sonic-db"} subscription:{path:{element:"CONFIG_DB" element:"localhost" element:"DEVICE_METADATA" element:"localhost" elem:{name:"CONFIG_DB"} elem:{name:"localhost"} elem:{name:"DEVICE_METADATA"} elem:{name:"localhost"}}} mode:ONCE}
I0527 21:25:24.127709 2480367 client_subscribe.go:78] prefix : &gnmi.Path{state:impl.MessageState{NoUnkeyedLiterals:pragma.NoUnkeyedLiterals{}, DoNotCompare:pragma.DoNotCompare{}, DoNotCopy:pragma.DoNotCopy{}, atomicMessageInfo:(*impl.MessageInfo)(0xc00028c3d8)}, sizeCache:0, unknownFields:[]uint8(nil), Element:[]string(nil), Origin:"sonic-db", Elem:[]*gnmi.PathElem(nil), Target:""} SubscribRequest : &gnmi.SubscriptionList{state:impl.MessageState{NoUnkeyedLiterals:pragma.NoUnkeyedLiterals{}, DoNotCompare:pragma.DoNotCompare{}, DoNotCopy:pragma.DoNotCopy{}, atomicMessageInfo:(*impl.MessageInfo)(0xc00028cf60)}, sizeCache:0, unknownFields:[]uint8(nil), Prefix:(*gnmi.Path)(0xc00097ac00), Subscription:[]*gnmi.Subscription{(*gnmi.Subscription)(0xc000af9770)}, UseAliases:false, Qos:(*gnmi.QOSMarking)(nil), Mode:1, AllowAggregation:false, UseModels:[]*gnmi.ModelData(nil), Encoding:0, UpdatesOnly:false}
I0527 21:25:24.127812 2480367 client_subscribe.go:90] gnmi Paths : [element:"CONFIG_DB" element:"localhost" element:"DEVICE_METADATA" element:"localhost" elem:{name:"CONFIG_DB"} elem:{name:"localhost"} elem:{name:"DEVICE_METADATA"} elem:{name:"localhost"}]
I0527 21:25:24.128119 2480367 connection_manager.go:68] Adding client connection: 192.168.0.1:40438|CONFIG_DB|localhost|DEVICE_METADATA|localhost|2026-05-27T21:25:24Z
I0527 21:25:24.129411 2480367 client_subscribe.go:159] mode=ONCE, origin="sonic-db", target=""
I0527 21:25:24.130268 2480367 clientCertAuth.go:185] Get Crl Urls for cert: []
I0527 21:25:24.130290 2480367 clientCertAuth.go:226] Cert does not contains and CRL distribution points
I0527 21:25:24.130315 2480367 server.go:558] authenticate user , roles [gnmi_readwrite]
I0527 21:25:24.130409 2480367 client_subscribe.go:225] Client 192.168.0.1:40438 running
I0527 21:25:24.130720 2480367 client_subscribe.go:262] Client 192.168.0.1:40438 blocking on stream.Recv()
.
.
.
^CI0527 21:26:48.085918 2480367 client_subscribe.go:268] Client 192.168.0.1:40438 received error: rpc error: code = Canceled desc = context canceled
I0527 21:26:48.086113 2480367 client_subscribe.go:240] Client 192.168.0.1:40438 Close, sendMsg 0 recvMsg 2 errors 0
I0527 21:26:48.086180 2480367 client_subscribe.go:304] queue: disposed
I0527 21:26:48.086202 2480367 client_subscribe.go:240] Client 192.168.0.1:40438 Close, sendMsg 0 recvMsg 2 errors 0
E0527 21:26:48.086338 2482257 gnmi_cli.go:250] sendQueryAndDisplay(ctx, {Addrs:[192.168.0.1:8080] AddressChains:[] Origin:sonic-db Target: Replica:0 UpdatesOnly:false Queries:[[CONFIG_DB localhost DEVICE_METADATA localhost]] Type:once Timeout:30s NotificationHandler:<nil> ProtoHandler:<nil> Credentials:<nil> TLS:0xe3b500 Extra:map[] SubReq:<nil> Streaming_type:TARGET_DEFINED Streaming_sample_int:0 Heartbeat_int:0 Suppress_redundant:false}, &{PollingInterval:30s StreamingDuration:0s Count:0 countExhausted:false Delimiter:/ Display:0x8c3500 DisplayPrefix: DisplayIndent:   DisplayType:group DisplayPeer:false Timestamp: DisplaySize:false Latency:false ClientTypes:[gnmi]}):
	client had error while displaying results:
	rpc error: code = Canceled desc = context canceled

]

root@sonic-device:/# timeout 30 gnmi_cli -client_types=gnmi -a 192.168.0.1:8080 -client_crt /etc/sonic/telemetry/gnmiclient.crt -client_key /etc/sonic/telemetry/gnmiclient.key -ca_crt /etc/sonic/telemetry/gnmiCA.pem -logtostderr -origin=sonic-db -query_type=once -q /CONFIG_DB/localhost/DEVICE_METADATA/localhost 
I0527 21:27:03.900657 2480367 client_subscribe.go:123] Client 192.168.0.1:45784 recieved initial query subscribe:{prefix:{origin:"sonic-db"} subscription:{path:{element:"CONFIG_DB" element:"localhost" element:"DEVICE_METADATA" element:"localhost" elem:{name:"CONFIG_DB"} elem:{name:"localhost"} elem:{name:"DEVICE_METADATA"} elem:{name:"localhost"}}} mode:ONCE}
I0527 21:27:03.900839 2480367 client_subscribe.go:78] prefix : &gnmi.Path{state:impl.MessageState{NoUnkeyedLiterals:pragma.NoUnkeyedLiterals{}, DoNotCompare:pragma.DoNotCompare{}, DoNotCopy:pragma.DoNotCopy{}, atomicMessageInfo:(*impl.MessageInfo)(0xc00028c3d8)}, sizeCache:0, unknownFields:[]uint8(nil), Element:[]string(nil), Origin:"sonic-db", Elem:[]*gnmi.PathElem(nil), Target:""} SubscribRequest : &gnmi.SubscriptionList{state:impl.MessageState{NoUnkeyedLiterals:pragma.NoUnkeyedLiterals{}, DoNotCompare:pragma.DoNotCompare{}, DoNotCopy:pragma.DoNotCopy{}, atomicMessageInfo:(*impl.MessageInfo)(0xc00028cf60)}, sizeCache:0, unknownFields:[]uint8(nil), Prefix:(*gnmi.Path)(0xc00097b600), Subscription:[]*gnmi.Subscription{(*gnmi.Subscription)(0xc000704410)}, UseAliases:false, Qos:(*gnmi.QOSMarking)(nil), Mode:1, AllowAggregation:false, UseModels:[]*gnmi.ModelData(nil), Encoding:0, UpdatesOnly:false}
I0527 21:27:03.900900 2480367 client_subscribe.go:90] gnmi Paths : [element:"CONFIG_DB" element:"localhost" element:"DEVICE_METADATA" element:"localhost" elem:{name:"CONFIG_DB"} elem:{name:"localhost"} elem:{name:"DEVICE_METADATA"} elem:{name:"localhost"}]
I0527 21:27:03.901055 2480367 connection_manager.go:68] Adding client connection: 192.168.0.1:45784|CONFIG_DB|localhost|DEVICE_METADATA|localhost|2026-05-27T21:27:03Z
I0527 21:27:03.901521 2480367 client_subscribe.go:159] mode=ONCE, origin="sonic-db", target=""
I0527 21:27:03.902184 2480367 clientCertAuth.go:185] Get Crl Urls for cert: []
I0527 21:27:03.902201 2480367 clientCertAuth.go:226] Cert does not contains and CRL distribution points
I0527 21:27:03.902215 2480367 server.go:558] authenticate user , roles [gnmi_readwrite]
I0527 21:27:03.902238 2480367 client_subscribe.go:225] Client 192.168.0.1:45784 running
I0527 21:27:03.902270 2480367 client_subscribe.go:262] Client 192.168.0.1:45784 blocking on stream.Recv()

I0527 21:27:33.836250 2480367 client_subscribe.go:268] Client 192.168.0.1:45784 received error: rpc error: code = Canceled desc = context canceled
I0527 21:27:33.836320 2480367 client_subscribe.go:240] Client 192.168.0.1:45784 Close, sendMsg 0 recvMsg 2 errors 0
I0527 21:27:33.836364 2480367 client_subscribe.go:304] queue: disposed
I0527 21:27:33.836383 2480367 client_subscribe.go:240] Client 192.168.0.1:45784 Close, sendMsg 0 recvMsg 2 errors 0
root@sonic-device:/# 

```

#### Logs with this change

```bash
root@sonic-device:/# ps -ef | grep telemetry
root     3155126 3151894  1 04:39 pts/2    00:00:00 /usr/sbin/telemetry -logtostderr --port 8080 --server_crt /etc/sonic/telemetry/gnmiserver.crt --server_key /etc/sonic/telemetry/gnmiserver.key --config_table_name GNMI_CLIENT_CERT --client_auth cert --enable_crl=true --ca_crt /etc/sonic/telemetry/gnmiCA.pem -gnmi_native_write=true -v=10
root     3156546 3151894  0 04:40 pts/2    00:00:00 grep telemetry
root@sonic-device:/# 
root@sonic-device:/# 
root@sonic-device:/# 
root@sonic-device:/# gnmi_cli -client_types=gnmi -a 192.168.0.1:8080 \
  -client_crt /etc/sonic/telemetry/gnmiclient.crt \
  -client_key /etc/sonic/telemetry/gnmiclient.key \
  -ca_crt /etc/sonic/telemetry/gnmiCA.pem \
  -logtostderr -origin=sonic-db -query_type=once \
  -q /CONFIG_DB/localhost/DEVICE_METADATA/localhost
I0528 04:41:54.214562 3155126 server.go:871] New Subscribe RPC: client 192.168.0.1:38636#1 (peer: 192.168.0.1:38636, total active: 0)
I0528 04:41:54.214635 3155126 server.go:878] Client 192.168.0.1:38636#1 registered (total active: 1)
I0528 04:41:54.215424 3155126 client_subscribe.go:153] Client 192.168.0.1:38636#1 recieved initial query subscribe:{prefix:{origin:"sonic-db"} subscription:{path:{element:"CONFIG_DB" element:"localhost" element:"DEVICE_METADATA" element:"localhost" elem:{name:"CONFIG_DB"} elem:{name:"localhost"} elem:{name:"DEVICE_METADATA"} elem:{name:"localhost"}}} mode:ONCE}
I0528 04:41:54.215576 3155126 client_subscribe.go:108] prefix : &gnmi.Path{state:impl.MessageState{NoUnkeyedLiterals:pragma.NoUnkeyedLiterals{}, DoNotCompare:pragma.DoNotCompare{}, DoNotCopy:pragma.DoNotCopy{}, atomicMessageInfo:(*impl.MessageInfo)(0xc000068de0)}, sizeCache:0, unknownFields:[]uint8(nil), Element:[]string(nil), Origin:"sonic-db", Elem:[]*gnmi.PathElem(nil), Target:""} SubscribRequest : &gnmi.SubscriptionList{state:impl.MessageState{NoUnkeyedLiterals:pragma.NoUnkeyedLiterals{}, DoNotCompare:pragma.DoNotCompare{}, DoNotCopy:pragma.DoNotCopy{}, atomicMessageInfo:(*impl.MessageInfo)(0xc000069968)}, sizeCache:0, unknownFields:[]uint8(nil), Prefix:(*gnmi.Path)(0xc000b25b00), Subscription:[]*gnmi.Subscription{(*gnmi.Subscription)(0xc001671400)}, UseAliases:false, Qos:(*gnmi.QOSMarking)(nil), Mode:1, AllowAggregation:false, UseModels:[]*gnmi.ModelData(nil), Encoding:0, UpdatesOnly:false}
I0528 04:41:54.215670 3155126 client_subscribe.go:120] gnmi Paths : [element:"CONFIG_DB" element:"localhost" element:"DEVICE_METADATA" element:"localhost" elem:{name:"CONFIG_DB"} elem:{name:"localhost"} elem:{name:"DEVICE_METADATA"} elem:{name:"localhost"}]
I0528 04:41:54.215943 3155126 connection_manager.go:72] Adding client connection: 192.168.0.1:38636|CONFIG_DB|localhost|DEVICE_METADATA|localhost|2026-05-28T04:41:54Z
I0528 04:41:54.216349 3155126 client_subscribe.go:189] mode=ONCE, origin="sonic-db", target=""
I0528 04:41:54.217503 3155126 clientCertAuth.go:185] Get Crl Urls for cert: []
I0528 04:41:54.217544 3155126 clientCertAuth.go:226] Cert does not contains and CRL distribution points
I0528 04:41:54.217579 3155126 server.go:837] authenticate user , roles [gnmi_readwrite]
I0528 04:41:54.217648 3155126 client_subscribe.go:251] Client 192.168.0.1:38636#1 running
I0528 04:41:54.217694 3155126 client_subscribe.go:288] Client 192.168.0.1:38636#1 blocking on stream.Recv()
I0528 04:41:54.217820 3155126 mixed_db_client.go:671] index 0 elem : "DEVICE_METADATA" map[string]string(nil)
I0528 04:41:54.217860 3155126 mixed_db_client.go:671] index 1 elem : "localhost" map[string]string(nil)
I0528 04:41:54.218774 3155126 mixed_db_client.go:935] Added idex 0 fv map[bgp_asn:65100 buffer_model:traditional cloudtype:Public default_bgp_status:up default_pfcwd_status:disable deployment_id:1 docker_routing_config_mode:separated hostname:sonic-device hwsku:Juniper-QFX5241-64-QD mac:40:36:b7:a6:13:87 platform:x86_64-juniper_qfx5241-r0 region:None synchronous_mode:enable timezone:UTC type:ToRRouter yang_config_validation:disable] 
I0528 04:41:54.219151 3155126 mixed_db_client.go:1710] OnceRun: Added spbv #prefix:{origin:"sonic-db"} path:{element:"CONFIG_DB" element:"localhost" element:"DEVICE_METADATA" element:"localhost" elem:{name:"CONFIG_DB"} elem:{name:"localhost"} elem:{name:"DEVICE_METADATA"} elem:{name:"localhost"}} timestamp:1779943314218899972 val:{json_ietf_val:"{\"bgp_asn\":\"65100\",\"buffer_model\":\"traditional\",\"cloudtype\":\"Public\",\"default_bgp_status\":\"up\",\"default_pfcwd_status\":\"disable\",\"deployment_id\":\"1\",\"docker_routing_config_mode\":\"separated\",\"hostname\":\"sonic-device\",\"hwsku\":\"Juniper-QFX5241-64-QD\",\"mac\":\"40:36:b7:a6:13:87\",\"platform\":\"x86_64-juniper_qfx5241-r0\",\"region\":\"None\",\"synchronous_mode\":\"enable\",\"timezone\":\"UTC\",\"type\":\"ToRRouter\",\"yang_config_validation\":\"disable\"}"}
I0528 04:41:54.219529 3155126 mixed_db_client.go:1720] OnceRun: Sync done, total time taken: 1 ms
I0528 04:41:54.219421 3155126 client_subscribe.go:363] Client 192.168.0.1:38636#1 done sending, msg count 1, msg update:{timestamp:1779943314218899972 prefix:{origin:"sonic-db"} update:{path:{element:"CONFIG_DB" element:"localhost" element:"DEVICE_METADATA" element:"localhost" elem:{name:"CONFIG_DB"} elem:{name:"localhost"} elem:{name:"DEVICE_METADATA"} elem:{name:"localhost"}} val:{json_ietf_val:"{\"bgp_asn\":\"65100\",\"buffer_model\":\"traditional\",\"cloudtype\":\"Public\",\"default_bgp_status\":\"up\",\"default_pfcwd_status\":\"disable\",\"deployment_id\":\"1\",\"docker_routing_config_mode\":\"separated\",\"hostname\":\"sonic-device\",\"hwsku\":\"Juniper-QFX5241-64-QD\",\"mac\":\"40:36:b7:a6:13:87\",\"platform\":\"x86_64-juniper_qfx5241-r0\",\"region\":\"None\",\"synchronous_mode\":\"enable\",\"timezone\":\"UTC\",\"type\":\"ToRRouter\",\"yang_config_validation\":\"disable\"}"}}}
I0528 04:41:54.219675 3155126 client_subscribe.go:363] Client 192.168.0.1:38636#1 done sending, msg count 2, msg sync_response:true
[
{
  "sonic-db": {
    "CONFIG_DB": {
      "localhost": {
        "DEVICE_METADATA": {
          "localhost": {
            "bgp_asn": "65100",
            "buffer_model": "traditional",
            "cloudtype": "Public",
            "default_bgp_status": "up",
            "default_pfcwd_status": "disable",
            "deployment_id": "1",
            "docker_routing_config_mode": "separated",
            "hostname": "sonic-device",
            "hwsku": "Juniper-QFX5241-64-QD",
            "mac": "40:36:b7:a6:13:87",
            "platform": "x86_64-juniper_qfx5241-r0",
            "region": "None",
            "synchronous_mode": "enable",
            "timezone": "UTC",
            "type": "ToRRouter",
            "yang_config_validation": "disable"
          }
        }
      }
    }
  }
}
]
I0528 04:41:54.222398 3155126 client_subscribe.go:294] Client 192.168.0.1:38636#1 received error: rpc error: code = Canceled desc = context canceled
I0528 04:41:54.222458 3155126 client_subscribe.go:266] Client 192.168.0.1:38636#1 Close, sendMsg 2 recvMsg 2 errors 0
root@sonic-device:/#
```

#### Description for the changelog
Implement OnceRun for MixedDbClient and DbClient Subscribe ONCE

Fixes https://github.com/sonic-net/sonic-gnmi/issues/688