### PR TITLE
[gnoi] SetPackage: use absolute path for sonic-installer

### DIFF
--- a/pkg/gnoi/system/system.go
+++ b/pkg/gnoi/system/system.go
@@ -144,7 +144,7 @@ func installPackage(ctx context.Context, filename string) error {
 	opts := &exec.RunHostCommandOptions{
 		Timeout: 10 * time.Minute, // Allow up to 10 minutes for installation
 	}
-	result, err := exec.RunHostCommand(ctx, "sonic-installer", []string{"install", "-y", filename}, opts)
+	result, err := exec.RunHostCommand(ctx, "/usr/local/bin/sonic-installer", []string{"install", "-y", filename}, opts)
 	if err != nil {
 		return fmt.Errorf("failed to run sonic-installer install: %v", err)
 	}
@@ -158,26 +158,26 @@ func installPackage(ctx context.Context, filename string) error {
 	return nil
 }
 
-// getBinaryVersion extracts the version string from a SONiC image using sonic-installer binary_version.
+// getBinaryVersion extracts the version string from a SONiC image using sonic-installer binary-version.
 func getBinaryVersion(ctx context.Context, filename string) (string, error) {
 	log.V(1).Infof("Resolving binary version for: %s", filename)
 
 	opts := &exec.RunHostCommandOptions{
 		Timeout: 1 * time.Minute,
 	}
-	result, err := exec.RunHostCommand(ctx, "sonic-installer", []string{"binary_version", filename}, opts)
+	result, err := exec.RunHostCommand(ctx, "/usr/local/bin/sonic-installer", []string{"binary-version", filename}, opts)
 	if err != nil {
-		return "", fmt.Errorf("failed to run sonic-installer binary_version: %v", err)
+		return "", fmt.Errorf("failed to run sonic-installer binary-version: %v", err)
 	}
 
 	if result.Error != nil {
-		return "", fmt.Errorf("sonic-installer binary_version failed with exit code %d: %s",
+		return "", fmt.Errorf("sonic-installer binary-version failed with exit code %d: %s",
 			result.ExitCode, result.Stderr)
 	}
 
 	version := strings.TrimSpace(result.Stdout)
 	if version == "" {
-		return "", fmt.Errorf("sonic-installer binary_version returned empty output for %s", filename)
+		return "", fmt.Errorf("sonic-installer binary-version returned empty output for %s", filename)
 	}
 
 	log.V(1).Infof("Resolved binary version: %s", version)
@@ -193,7 +193,7 @@ func activatePackage(ctx context.Context, version string) error {
 	opts := &exec.RunHostCommandOptions{
 		Timeout: 2 * time.Minute, // Allow up to 2 minutes for setting default
 	}
-	result, err := exec.RunHostCommand(ctx, "sonic-installer", []string{"set-default", version}, opts)
+	result, err := exec.RunHostCommand(ctx, "/usr/local/bin/sonic-installer", []string{"set-default", version}, opts)
 	if err != nil {
 		return fmt.Errorf("failed to run sonic-installer set-default: %v", err)
 	}

--- a/pkg/gnoi/system/system_monkey_test.go
+++ b/pkg/gnoi/system/system_monkey_test.go
@@ -16,7 +16,7 @@ func TestHandleSetPackage_SuccessWithoutActivation(t *testing.T) {
 
 	// Mock exec.RunHostCommand to return successful installation
 	patches.ApplyFunc(exec.RunHostCommand, func(ctx context.Context, cmd string, args []string, opts *exec.RunHostCommandOptions) (*exec.CommandResult, error) {
-		if cmd == "sonic-installer" && len(args) >= 1 && args[0] == "install" {
+		if cmd == "/usr/local/bin/sonic-installer" && len(args) >= 1 && args[0] == "install" {
 			return &exec.CommandResult{
 				Stdout:   "Installation completed successfully",
 				Stderr:   "",
@@ -52,10 +52,10 @@ func TestHandleSetPackage_ActivateWithAutoResolvedVersion(t *testing.T) {
 	patches := gomonkey.NewPatches()
 	defer patches.Reset()
 
-	// Mock exec.RunHostCommand to handle binary_version, install, and set-default
+	// Mock exec.RunHostCommand to handle binary-version, install, and set-default
 	patches.ApplyFunc(exec.RunHostCommand, func(ctx context.Context, cmd string, args []string, opts *exec.RunHostCommandOptions) (*exec.CommandResult, error) {
-		if cmd == "sonic-installer" {
-			if len(args) >= 1 && args[0] == "binary_version" {
+		if cmd == "/usr/local/bin/sonic-installer" {
+			if len(args) >= 1 && args[0] == "binary-version" {
 				return &exec.CommandResult{
 					Stdout:   "SONiC-OS-4.2.0-Enterprise\n",
 					ExitCode: 0,
@@ -104,10 +104,10 @@ func TestHandleSetPackage_AutoResolveVersionFails(t *testing.T) {
 	patches := gomonkey.NewPatches()
 	defer patches.Reset()
 
-	// Mock: binary_version fails — should reject before install
+	// Mock: binary-version fails — should reject before install
 	patches.ApplyFunc(exec.RunHostCommand, func(ctx context.Context, cmd string, args []string, opts *exec.RunHostCommandOptions) (*exec.CommandResult, error) {
-		if cmd == "sonic-installer" && len(args) >= 1 && args[0] == "binary_version" {
-			return nil, fmt.Errorf("binary_version command failed")
+		if cmd == "/usr/local/bin/sonic-installer" && len(args) >= 1 && args[0] == "binary-version" {
+			return nil, fmt.Errorf("binary-version command failed")
 		}
 		return nil, fmt.Errorf("unexpected command (install should not be called): %s %v", cmd, args)
 	})
@@ -125,7 +125,7 @@ func TestHandleSetPackage_AutoResolveVersionFails(t *testing.T) {
 
 	_, err := HandleSetPackage(ctx, req)
 	if err == nil {
-		t.Fatal("HandleSetPackage() should return error when binary_version fails")
+		t.Fatal("HandleSetPackage() should return error when binary-version fails")
 	}
 	if !containsSubstring(err.Error(), "failed to resolve version from image") {
 		t.Errorf("HandleSetPackage() error = %v, should contain 'failed to resolve version from image'", err)
@@ -136,10 +136,10 @@ func TestHandleSetPackage_EmptyVersionNoActivate(t *testing.T) {
 	patches := gomonkey.NewPatches()
 	defer patches.Reset()
 
-	// Mock: binary_version and install succeed, set-default should NOT be called
+	// Mock: binary-version and install succeed, set-default should NOT be called
 	patches.ApplyFunc(exec.RunHostCommand, func(ctx context.Context, cmd string, args []string, opts *exec.RunHostCommandOptions) (*exec.CommandResult, error) {
-		if cmd == "sonic-installer" {
-			if len(args) >= 1 && args[0] == "binary_version" {
+		if cmd == "/usr/local/bin/sonic-installer" {
+			if len(args) >= 1 && args[0] == "binary-version" {
 				return &exec.CommandResult{
 					Stdout:   "SONiC-OS-4.2.0-Enterprise\n",
 					ExitCode: 0,
@@ -183,7 +183,7 @@ func TestGetBinaryVersion_Success(t *testing.T) {
 	defer patches.Reset()
 
 	patches.ApplyFunc(exec.RunHostCommand, func(ctx context.Context, cmd string, args []string, opts *exec.RunHostCommandOptions) (*exec.CommandResult, error) {
-		if cmd == "sonic-installer" && len(args) >= 1 && args[0] == "binary_version" {
+		if cmd == "/usr/local/bin/sonic-installer" && len(args) >= 1 && args[0] == "binary-version" {
 			return &exec.CommandResult{
 				Stdout:   "SONiC-OS-4.2.0-Enterprise\n",
 				ExitCode: 0,
@@ -236,8 +236,8 @@ func TestGetBinaryVersion_CommandError(t *testing.T) {
 	if err == nil {
 		t.Fatal("getBinaryVersion() should return error when command fails")
 	}
-	if !containsSubstring(err.Error(), "failed to run sonic-installer binary_version") {
-		t.Errorf("getBinaryVersion() error = %v, should contain 'failed to run sonic-installer binary_version'", err)
+	if !containsSubstring(err.Error(), "failed to run sonic-installer binary-version") {
+		t.Errorf("getBinaryVersion() error = %v, should contain 'failed to run sonic-installer binary-version'", err)
 	}
 }
 
@@ -247,7 +247,7 @@ func TestHandleSetPackage_SuccessWithActivation(t *testing.T) {
 
 	// Mock exec.RunHostCommand to handle both install and set-default commands
 	patches.ApplyFunc(exec.RunHostCommand, func(ctx context.Context, cmd string, args []string, opts *exec.RunHostCommandOptions) (*exec.CommandResult, error) {
-		if cmd == "sonic-installer" {
+		if cmd == "/usr/local/bin/sonic-installer" {
 			if len(args) >= 1 && args[0] == "install" {
 				return &exec.CommandResult{
 					Stdout:   "Installation completed successfully",
@@ -325,7 +325,7 @@ func TestHandleSetPackage_ActivateCommandError(t *testing.T) {
 
 	// Mock exec.RunHostCommand: install succeeds, set-default fails
 	patches.ApplyFunc(exec.RunHostCommand, func(ctx context.Context, cmd string, args []string, opts *exec.RunHostCommandOptions) (*exec.CommandResult, error) {
-		if cmd == "sonic-installer" {
+		if cmd == "/usr/local/bin/sonic-installer" {
 			if len(args) >= 1 && args[0] == "install" {
 				return &exec.CommandResult{
 					Stdout:   "Installation completed successfully",


### PR DESCRIPTION
nsenter does not inherit the host PATH when executing commands from within the container. Use /usr/local/bin/sonic-installer as the full path to ensure the command is found.

Also use 'binary-version' subcommand instead of deprecated 'binary_version' which fails on newer sonic-installer versions.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
nsenter does not inherit the host PATH when executing commands from within the container, causing sonic-installer to not be found. Also, the binary_version subcommand is deprecated and fails on newer sonic-installer versions

#### How I did it
Use absolute path /usr/local/bin/sonic-installer instead of relying on PATH
Use binary-version subcommand instead of deprecated binary_version

#### How to verify it
Run SetPackage gNOI RPC from a container context and verify sonic-installer is invoked successfully.

Device running SONiC-OS-20251110.30:

admin@bjw3-can-7060-7:/tmp$ sudo sonic-installer list
Current: SONiC-OS-20251110.30
Next: SONiC-OS-20251110.30
Available:
SONiC-OS-20250510.30
SONiC-OS-20251110.30

Called SetPackag with no version information
admin@bjw3-can-7060-7:/tmp$ grpcurl -plaintext -d '{

"package": {
"filename": "/tmp/sonic-aboot-broadcom.swi",
"activate": true
}
}' localhost:50052 gnoi.system.System/SetPackage
{}

Version auto-resolved from imag
admin@bjw3-can-7060-7:/tmp$ sudo sonic-installer list
Current: SONiC-OS-20251110.30
Next: SONiC-OS-20250510.37
Available:
SONiC-OS-20250510.30
SONiC-OS-20250510.37
SONiC-OS-20251110.30

sudo reboot

Device booted into SONiC-OS-20250510.37
admin@bjw3-can-7060-7:~$ sudo sonic-installer list
Current: SONiC-OS-20250510.37
Next: SONiC-OS-20250510.37
Available:
SONiC-OS-20250510.30
SONiC-OS-20250510.37
SONiC-OS-20251110.30

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

