### PR TITLE
ci: migrate libyang1 deb install to libyang3

### DIFF
--- a/.azure/templates/install-dependencies.yml
+++ b/.azure/templates/install-dependencies.yml
@@ -52,9 +52,8 @@ steps:
     path: $(Build.ArtifactStagingDirectory)/download
     artifact: ${{ parameters.commonLibArtifact }}
     patterns: |
-      target/debs/trixie/libyang_1.0*.deb
-      target/debs/trixie/libyang-*_1.0*.deb
       target/debs/trixie/libyang3_*.deb
+      target/debs/trixie/libyang-dev_3*.deb
       target/debs/trixie/libpcre3_*.deb
       target/debs/trixie/libpcre3-dev_*.deb
       target/debs/trixie/libpcre16-3_*.deb


### PR DESCRIPTION
#### Why I did it

sonic-buildimage no longer builds the libyang1 debs (`libyang_1.0.73`, `libyang-cpp`, `python3-yang`); it now builds only libyang3. The sonic-gnmi CI downloads and installs libyang debs from the `sonic-buildimage.common_libs` build artifact, and the libyang1-versioned download patterns no longer match any produced artifact, which would break the dependency-install step.

#### How I did it

Updated the libyang download filter list in `.azure/templates/install-dependencies.yml`:

- Removed `target/debs/trixie/libyang_1.0*.deb` (the v1 runtime library); the libyang3 runtime is already covered by the existing `target/debs/trixie/libyang3_*.deb` pattern.
- Replaced `target/debs/trixie/libyang-*_1.0*.deb` (which matched the now-removed `libyang-cpp` and the v1 `libyang-dev`) with the versionless `target/debs/trixie/libyang-dev_*.deb` (now v3), dropping `libyang-cpp` entirely.

All patterns are versionless globs. The install step already uses a generic `find ... -name '*.deb'` invocation, so it installs whatever was downloaded and needed no change.

Left unchanged:
- `doc/telemetry-dev-env/Dockerfile` builds libyang 1.0.184 from CESNET source for the developer environment; it is not a sonic-buildimage build asset.
- `Makefile` comments referencing libyang memory leaks are descriptive only and unrelated to the deb migration.

#### How to verify it

- Run the sonic-gnmi Azure CI; the "Download libyang and libnl from common_libs" step resolves the new versionless libyang3 patterns, and the "Install libyang and libnl debs" step installs them successfully.
- Confirm no remaining libyang1 deb references or hardcoded versions: `grep -rnI 'libyang_1.0\|libyang-.*_1.0' .azure/`

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog

ci: migrate libyang1 deb install to libyang3 (part of sonic-net/sonic-buildimage#22385)

#### Link to config_db schema for YANG module changes

N/A
