### PR TITLE
[ci]: Update CodeQL action to v4

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -33,11 +33,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Checkout sonic-mgmt-common repository which is used by sonic-gnmi
     - name: Checkout sonic-mgmt-common repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: sonic-net/sonic-mgmt-common
         path: sonic-mgmt-common
@@ -51,12 +51,12 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2.1.29
+      uses: github/codeql-action/init@v4
       with:
         config-file: ./.github/codeql/codeql-config.yml
         languages: ${{ matrix.language }}
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2.1.29
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"


### PR DESCRIPTION
## What

Update the CodeQL workflow (`.github/workflows/codeql-analysis.yml`):

- `github/codeql-action/init@v2.1.29` → `@v4`
- `github/codeql-action/analyze@v2.1.29` → `@v4`
- `actions/checkout@v3` → `@v4` (both checkout steps in the CodeQL job)

## Why

CodeQL action v2 is unsupported and v3 is deprecated. Pinning to the stale `v2.1.29` meant scans ran on an outdated CodeQL engine and missed newer query packs. Bumping to v4 runs analysis on the current engine — the same modern scanning that surfaced the high-severity findings in #694 on an updated copy of this repo — so this repo's scans can catch more types of issues.

The supporting `actions/checkout` steps are bumped to v4 as well because CodeQL v4 runs on the Node 24 runtime, and the old Node 16 checkout would otherwise emit deprecation warnings.

No other workflow syntax changes are required for the v4 migration; the config in `.github/codeql/codeql-config.yml` (`security-and-quality`, `security-extended`) is unchanged.

Fixes #695

## Notes

This PR only modernizes the scanner. The actual code vulnerabilities reported in #694 are a separate fix effort tracked under that issue.