### PR TITLE
telemetry: add --bind_address flag to restrict TCP listener

### DIFF
--- a/gnmi_server/server.go
+++ b/gnmi_server/server.go
@@ -256,6 +256,10 @@ type Config struct {
 	EnableStreamMultiplexing bool   // Allow multiple Subscribe RPCs on a single TCP connection.
 	SshCredMetaFile          string // Path to JSON file with SSH server credential metadata.
 	ConsoleCredMetaFile      string // Path to JSON file with console credential metadata.
+	// BindAddress is the network address to bind the TCP listener.
+	// When empty, binds to all interfaces (0.0.0.0). Use "127.0.0.1" to
+	// restrict to localhost only (e.g. when running without TLS).
+	BindAddress string
 }
 
 // DBusOSBackend is a concrete implementation of OSBackend
@@ -610,7 +614,8 @@ func NewServer(config *Config, tlsOpts []grpc.ServerOption, commonOpts []grpc.Se
 		if config.GnmiVrf != "" && config.GnmiVrf != "default" {
 			srv.lis, err = createVrfListener(config.GnmiVrf, config.Port)
 		} else {
-			srv.lis, err = net.Listen("tcp", fmt.Sprintf(":%d", config.Port))
+			bindAddr := config.BindAddress
+			srv.lis, err = net.Listen("tcp", fmt.Sprintf("%s:%d", bindAddr, config.Port))
 		}
 		if err != nil {
 			log.Warningf("Failed to open listener port %d: %v; disabling TCP listener", config.Port, err)

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -64,6 +65,7 @@ type TelemetryConfig struct {
 	IdleConnDuration         *int
 	GnmiVrf                  *string
 	Vrf                      *string
+	BindAddress              *string
 	EnableCrl                *bool
 	CrlExpireDuration        *int
 	CaCertLnk                *string
@@ -190,6 +192,7 @@ func setupFlags(fs *flag.FlagSet) (*TelemetryConfig, *gnmi.Config, error) {
 		IdleConnDuration:         fs.Int("idle_conn_duration", 5, "Seconds before server closes idle connections"),
 		GnmiVrf:                  fs.String("gnmi_vrf", "", "VRF name for gNMI server binding."),
 		Vrf:                      fs.String("vrf", "", "VRF name for ZMQ client binding."),
+		BindAddress:              fs.String("bind_address", "", "Address to bind the gRPC TCP listener. Empty binds all interfaces. Use 127.0.0.1 to restrict to localhost."),
 		EnableCrl:                fs.Bool("enable_crl", false, "Enable certificate revocation list"),
 		CrlExpireDuration:        fs.Int("crl_expire_duration", 86400, "Certificate revocation list cache expire duration"),
 		ImgDirPath:               fs.String("img_dir", "/tmp/host_tmp", "Directory path where image will be transferred."),
@@ -233,6 +236,15 @@ func setupFlags(fs *flag.FlagSet) (*TelemetryConfig, *gnmi.Config, error) {
 		return nil, nil, fmt.Errorf("port must be > 0 (or specify --unix_socket).")
 	}
 
+	if *telemetryCfg.NoTLS {
+		ip := net.ParseIP(*telemetryCfg.BindAddress)
+		if ip == nil || !ip.IsLoopback() {
+			return nil, nil, fmt.Errorf(
+				"--noTLS requires --bind_address to be a loopback address (e.g. 127.0.0.1 or ::1) " +
+					"to prevent cleartext gRPC exposure over the network")
+		}
+	}
+
 	switch {
 	case *telemetryCfg.Threshold < 0:
 		return nil, nil, fmt.Errorf("threshold must be >= 0.")
@@ -273,6 +285,7 @@ func setupFlags(fs *flag.FlagSet) (*TelemetryConfig, *gnmi.Config, error) {
 	cfg.ConfigTableName = *telemetryCfg.ConfigTableName
 	cfg.GnmiVrf = *telemetryCfg.GnmiVrf
 	cfg.Vrf = *telemetryCfg.Vrf
+	cfg.BindAddress = *telemetryCfg.BindAddress
 	cfg.EnableCrl = *telemetryCfg.EnableCrl
 	cfg.CaCertLnk = *telemetryCfg.CaCertLnk
 	cfg.CaCertFile = *telemetryCfg.CaCert

--- a/telemetry/telemetry_test.go
+++ b/telemetry/telemetry_test.go
@@ -41,7 +41,7 @@ func TestRunTelemetry(t *testing.T) {
 	})
 	defer patches.Reset()
 
-	args := []string{"telemetry", "-logtostderr", "-port", "50051", "-v=2", "-noTLS"}
+	args := []string{"telemetry", "-logtostderr", "-port", "50051", "-v=2", "-noTLS", "-bind_address", "127.0.0.1"}
 	os.Args = args
 	err := runTelemetry(os.Args)
 	if err != nil {
@@ -79,7 +79,7 @@ func TestFlags(t *testing.T) {
 		expectedVrf       string
 	}{
 		{
-			[]string{"cmd", "-port", "9090", "-threshold", "200", "-idle_conn_duration", "10", "-v", "6", "-noTLS"},
+			[]string{"cmd", "-port", "9090", "-threshold", "200", "-idle_conn_duration", "10", "-v", "6", "-noTLS", "-bind_address", "127.0.0.1"},
 			9090,
 			200,
 			10,
@@ -97,7 +97,7 @@ func TestFlags(t *testing.T) {
 			"",
 		},
 		{
-			[]string{"cmd", "-port", "5050", "-threshold", "10", "-idle_conn_duration", "3", "-v", "-3", "-noTLS"},
+			[]string{"cmd", "-port", "5050", "-threshold", "10", "-idle_conn_duration", "3", "-v", "-3", "-noTLS", "-bind_address", "127.0.0.1"},
 			5050,
 			10,
 			3,
@@ -106,7 +106,7 @@ func TestFlags(t *testing.T) {
 			"",
 		},
 		{
-			[]string{"cmd", "-port", "8082", "-threshold", "1", "-idle_conn_duration", "1", "-gnmi_vrf", "mgmt", "-vrf", "mgmt", "-noTLS"},
+			[]string{"cmd", "-port", "8082", "-threshold", "1", "-idle_conn_duration", "1", "-gnmi_vrf", "mgmt", "-vrf", "mgmt", "-noTLS", "-bind_address", "127.0.0.1"},
 			8082,
 			1,
 			1,
@@ -1458,7 +1458,7 @@ func TestCertAuthDisabledWhenNoCaCert(t *testing.T) {
 	defer func() { os.Args = originalArgs }()
 
 	fs := flag.NewFlagSet("testCertAuthDisabledWhenNoCaCert", flag.ContinueOnError)
-	os.Args = []string{"cmd", "-port", "8080", "-noTLS", "-client_auth", "cert,password"}
+	os.Args = []string{"cmd", "-port", "8080", "-noTLS", "-bind_address", "127.0.0.1", "-client_auth", "cert,password"}
 
 	telemetryCfg, _, err := setupFlags(fs)
 	if err != nil {
@@ -1469,6 +1469,37 @@ func TestCertAuthDisabledWhenNoCaCert(t *testing.T) {
 	}
 	if !telemetryCfg.UserAuth.Enabled("password") {
 		t.Error("Expected password auth to remain enabled after cert was disabled")
+	}
+}
+
+func TestNoTLSRequiresLoopbackAddress(t *testing.T) {
+	// --noTLS must be rejected unless --bind_address is a loopback address.
+	originalArgs := os.Args
+	defer func() { os.Args = originalArgs }()
+
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr bool
+	}{
+		{"empty bind_address", []string{"cmd", "-port", "8080", "-noTLS"}, true},
+		{"non-loopback", []string{"cmd", "-port", "8080", "-noTLS", "-bind_address", "10.0.0.1"}, true},
+		{"loopback ipv4", []string{"cmd", "-port", "8080", "-noTLS", "-bind_address", "127.0.0.1"}, false},
+		{"loopback ipv4 alt", []string{"cmd", "-port", "8080", "-noTLS", "-bind_address", "127.0.0.2"}, false},
+		{"loopback ipv6", []string{"cmd", "-port", "8080", "-noTLS", "-bind_address", "::1"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := flag.NewFlagSet("test", flag.ContinueOnError)
+			os.Args = tt.args
+			_, _, err := setupFlags(fs)
+			if tt.wantErr && err == nil {
+				t.Errorf("expected error for args %v, got nil", tt.args)
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error for args %v: %v", tt.args, err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Add optional `--bind_address` flag to the gRPC TCP listener. When set, the listener binds to the specified address; when empty (default), binds to all interfaces (preserving existing behavior).

**Changes:**
- `gnmi_server/server.go`: add `BindAddress` to `Config` struct; use it in `net.Listen()` for the non-VRF TCP path
- `telemetry/telemetry.go`: add `--bind_address` string flag; pass to `Config`

Re-lands #652 (reverted in #673). The revert introduced `TestCertAuthDisabledWhenNoCaCert` which is retained.

**Why:** `sonic-buildimage` PR #26893 passes `--bind_address 127.0.0.1` in `gnmi-native.sh`/`telemetry.sh`. Without this flag in the binary the gnmi-native process fails on startup.

Signed-off-by: xq9mend <xq9mend@users.noreply.github.com>