### PR TITLE
telemetry: default --bind_address to loopback when --noTLS has none

### DIFF
--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -237,8 +237,11 @@ func setupFlags(fs *flag.FlagSet) (*TelemetryConfig, *gnmi.Config, error) {
 	}
 
 	if *telemetryCfg.NoTLS {
-		ip := net.ParseIP(*telemetryCfg.BindAddress)
-		if ip == nil || !ip.IsLoopback() {
+		if *telemetryCfg.BindAddress == "" {
+			// Default the cleartext listener to loopback.
+			*telemetryCfg.BindAddress = "127.0.0.1"
+			log.Warning("--noTLS set without --bind_address; defaulting to 127.0.0.1 (loopback only)")
+		} else if ip := net.ParseIP(*telemetryCfg.BindAddress); ip == nil || !ip.IsLoopback() {
 			return nil, nil, fmt.Errorf(
 				"--noTLS requires --bind_address to be a loopback address (e.g. 127.0.0.1 or ::1) " +
 					"to prevent cleartext gRPC exposure over the network")

--- a/telemetry/telemetry_test.go
+++ b/telemetry/telemetry_test.go
@@ -1473,7 +1473,8 @@ func TestCertAuthDisabledWhenNoCaCert(t *testing.T) {
 }
 
 func TestNoTLSRequiresLoopbackAddress(t *testing.T) {
-	// --noTLS must be rejected unless --bind_address is a loopback address.
+	// --noTLS rejects an explicitly non-loopback --bind_address. An empty
+	// --bind_address defaults to loopback (see TestNoTLSDefaultsToLoopback).
 	originalArgs := os.Args
 	defer func() { os.Args = originalArgs }()
 
@@ -1482,7 +1483,7 @@ func TestNoTLSRequiresLoopbackAddress(t *testing.T) {
 		args    []string
 		wantErr bool
 	}{
-		{"empty bind_address", []string{"cmd", "-port", "8080", "-noTLS"}, true},
+		{"empty bind_address", []string{"cmd", "-port", "8080", "-noTLS"}, false},
 		{"non-loopback", []string{"cmd", "-port", "8080", "-noTLS", "-bind_address", "10.0.0.1"}, true},
 		{"loopback ipv4", []string{"cmd", "-port", "8080", "-noTLS", "-bind_address", "127.0.0.1"}, false},
 		{"loopback ipv4 alt", []string{"cmd", "-port", "8080", "-noTLS", "-bind_address", "127.0.0.2"}, false},
@@ -1500,6 +1501,26 @@ func TestNoTLSRequiresLoopbackAddress(t *testing.T) {
 				t.Errorf("unexpected error for args %v: %v", tt.args, err)
 			}
 		})
+	}
+}
+
+func TestNoTLSDefaultsToLoopback(t *testing.T) {
+	// --noTLS without --bind_address starts successfully and binds loopback.
+	originalArgs := os.Args
+	defer func() { os.Args = originalArgs }()
+
+	fs := flag.NewFlagSet("testNoTLSDefaultsToLoopback", flag.ContinueOnError)
+	os.Args = []string{"cmd", "-port", "8080", "-noTLS"}
+
+	telemetryCfg, gnmiCfg, err := setupFlags(fs)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if got := *telemetryCfg.BindAddress; got != "127.0.0.1" {
+		t.Errorf("Expected BindAddress to default to 127.0.0.1, got %q", got)
+	}
+	if got := gnmiCfg.BindAddress; got != "127.0.0.1" {
+		t.Errorf("Expected gnmi.Config.BindAddress to default to 127.0.0.1, got %q", got)
 	}
 }
 


### PR DESCRIPTION
#### Why I did it

#709 (re-land of #652) made `setupFlags()` **reject** `--noTLS` unless `--bind_address` is an explicit loopback address. But the default SONiC start path (`dockers/docker-sonic-gnmi/gnmi-native.sh`) appends `--noTLS` with **no** `--bind_address` whenever no telemetry certs are configured in ConfigDB — which is the case on a stock image (KVM/vs, and any box without certs). As a result `/usr/sbin/telemetry` exits immediately at startup and `gnmi-native` never runs:

```
ERR gnmi#supervisor-proc-exit-listener-rs: Process 'gnmi-native' is not running in namespace 'host'
```

This regresses the whole gNMI/telemetry test cluster (`telemetry/test_telemetry`, `gnmi/test_gnmi_appldb`, `gnmi/test_gnmi_smartswitch`, `zmq/test_gnmi_zmq`, `autorestart/test_container_autorestart`) the moment the submodule is bumped (e.g. sonic-buildimage PR #28084), because the server now requires explicit config just to start.

#### How I did it

Make the `--noTLS` path **secure-by-default instead of crash-by-default** in `telemetry/telemetry.go`:

- When `--noTLS` is set and `--bind_address` is **empty**, default it to `127.0.0.1` (loopback) and log a warning — the server starts and cleartext gRPC is confined to localhost.
- When `--noTLS` is set with an **explicit non-loopback** address, still return an error — the original cleartext-exposure guard is preserved for the genuinely unsafe misconfiguration (`--noTLS --bind_address 0.0.0.0`).

`gnmi_server/server.go` already handles an empty/loopback `BindAddress` correctly, so no change is needed there.

#### How to verify it

- `TestNoTLSDefaultsToLoopback` (new): `--noTLS` with no `--bind_address` succeeds and resolves `BindAddress` to `127.0.0.1` on both `TelemetryConfig` and `gnmi.Config`.
- `TestNoTLSRequiresLoopbackAddress` (updated): empty `--bind_address` now expects success (defaulted), non-loopback still errors, loopback v4/v6 succeed.
- End-to-end: a sonic-buildimage submodule bump to this commit should bring `gnmi-native` up on a stock image and clear the telemetry/gnmi LogAnalyzer failures.

#### Description for the changelog

telemetry: default `--bind_address` to loopback when `--noTLS` is set without an address, so the server starts under the default (no-cert) configuration while still rejecting cleartext gRPC on a routable address.
