### PR TITLE
telemetry: remove --noTLS loopback address enforcement

### DIFF
--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"net"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -234,15 +233,6 @@ func setupFlags(fs *flag.FlagSet) (*TelemetryConfig, *gnmi.Config, error) {
 	switch {
 	case *telemetryCfg.Port <= 0 && *telemetryCfg.UnixSocket == "":
 		return nil, nil, fmt.Errorf("port must be > 0 (or specify --unix_socket).")
-	}
-
-	if *telemetryCfg.NoTLS {
-		ip := net.ParseIP(*telemetryCfg.BindAddress)
-		if ip == nil || !ip.IsLoopback() {
-			return nil, nil, fmt.Errorf(
-				"--noTLS requires --bind_address to be a loopback address (e.g. 127.0.0.1 or ::1) " +
-					"to prevent cleartext gRPC exposure over the network")
-		}
 	}
 
 	switch {

--- a/telemetry/telemetry_test.go
+++ b/telemetry/telemetry_test.go
@@ -1472,37 +1472,6 @@ func TestCertAuthDisabledWhenNoCaCert(t *testing.T) {
 	}
 }
 
-func TestNoTLSRequiresLoopbackAddress(t *testing.T) {
-	// --noTLS must be rejected unless --bind_address is a loopback address.
-	originalArgs := os.Args
-	defer func() { os.Args = originalArgs }()
-
-	tests := []struct {
-		name    string
-		args    []string
-		wantErr bool
-	}{
-		{"empty bind_address", []string{"cmd", "-port", "8080", "-noTLS"}, true},
-		{"non-loopback", []string{"cmd", "-port", "8080", "-noTLS", "-bind_address", "10.0.0.1"}, true},
-		{"loopback ipv4", []string{"cmd", "-port", "8080", "-noTLS", "-bind_address", "127.0.0.1"}, false},
-		{"loopback ipv4 alt", []string{"cmd", "-port", "8080", "-noTLS", "-bind_address", "127.0.0.2"}, false},
-		{"loopback ipv6", []string{"cmd", "-port", "8080", "-noTLS", "-bind_address", "::1"}, false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			fs := flag.NewFlagSet("test", flag.ContinueOnError)
-			os.Args = tt.args
-			_, _, err := setupFlags(fs)
-			if tt.wantErr && err == nil {
-				t.Errorf("expected error for args %v, got nil", tt.args)
-			}
-			if !tt.wantErr && err != nil {
-				t.Errorf("unexpected error for args %v: %v", tt.args, err)
-			}
-		})
-	}
-}
-
 func TestMain(m *testing.M) {
 	defer test_utils.MemLeakCheck()
 	m.Run()


### PR DESCRIPTION
The --bind_address flag added in #709 is useful optional hardening, but the enforcement that requires --bind_address to be a loopback address when --noTLS is active is too strict.

Operators may legitimately use --noTLS without --bind_address in isolated networks, container environments, or lab setups. Enforcing loopback-only breaks backward compatibility.

This PR removes the enforcement block and the test that covered it. The --bind_address flag itself is retained -- operators can still restrict the listener to localhost when desired.