### PR TITLE
telemetry: enforce --noTLS requires loopback --bind_address

### DIFF
--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -249,6 +250,15 @@ func setupFlags(fs *flag.FlagSet) (*TelemetryConfig, *gnmi.Config, error) {
 	case *telemetryCfg.LogLevel < 0:
 		*telemetryCfg.LogLevel = 2
 		log.Infof("Log level must be greater than 0, setting to default value of 2")
+	}
+
+	if *telemetryCfg.NoTLS {
+		ip := net.ParseIP(*telemetryCfg.BindAddress)
+		if ip == nil || !ip.IsLoopback() {
+			return nil, nil, fmt.Errorf(
+				"--noTLS requires --bind_address to be a loopback address (e.g. 127.0.0.1 or ::1) " +
+					"to prevent cleartext gRPC exposure over the network")
+		}
 	}
 
 	if !*telemetryCfg.NoTLS && !*telemetryCfg.Insecure {

--- a/telemetry/telemetry_test.go
+++ b/telemetry/telemetry_test.go
@@ -1472,6 +1472,37 @@ func TestCertAuthDisabledWhenNoCaCert(t *testing.T) {
 	}
 }
 
+func TestNoTLSRequiresLoopbackAddress(t *testing.T) {
+	// --noTLS must be rejected unless --bind_address is a loopback address.
+	originalArgs := os.Args
+	defer func() { os.Args = originalArgs }()
+
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr bool
+	}{
+		{"empty bind_address", []string{"cmd", "-port", "8080", "-noTLS"}, true},
+		{"non-loopback", []string{"cmd", "-port", "8080", "-noTLS", "-bind_address", "10.0.0.1"}, true},
+		{"loopback ipv4", []string{"cmd", "-port", "8080", "-noTLS", "-bind_address", "127.0.0.1"}, false},
+		{"loopback ipv4 alt", []string{"cmd", "-port", "8080", "-noTLS", "-bind_address", "127.0.0.2"}, false},
+		{"loopback ipv6", []string{"cmd", "-port", "8080", "-noTLS", "-bind_address", "::1"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := flag.NewFlagSet("test", flag.ContinueOnError)
+			os.Args = tt.args
+			_, _, err := setupFlags(fs)
+			if tt.wantErr && err == nil {
+				t.Errorf("expected error for args %v, got nil", tt.args)
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error for args %v: %v", tt.args, err)
+			}
+		})
+	}
+}
+
 func TestMain(m *testing.M) {
 	defer test_utils.MemLeakCheck()
 	m.Run()


### PR DESCRIPTION
#### Why I did it

`--noTLS` disables TLS entirely and exposes cleartext gRPC. Without a bind restriction, this can accidentally expose the gNMI endpoint over the network on unconfigured devices.

Enforce that `--noTLS` requires `--bind_address` to be a loopback address (127.0.0.1 or ::1). Operators using `--noTLS` in isolated environments must pass `--bind_address 127.0.0.1` explicitly — the `telemetry.sh` and `gnmi-native.sh` scripts in sonic-buildimage already do this (since sonic-net/sonic-buildimage#28110).

Re-adds the enforcement removed in #711, which was removed prematurely before all sonic-buildimage usages were updated.

#### How I did it

- `telemetry/telemetry.go`: re-add `net.ParseIP` / `IsLoopback` check in `setupFlags`; return error if `--noTLS` is set without a loopback `--bind_address`
- `telemetry/telemetry_test.go`: re-add `TestNoTLSRequiresLoopbackAddress` covering empty, non-loopback, IPv4 loopback, and IPv6 loopback cases

#### How to verify it

```
# Should fail:
telemetry -noTLS -port 8080
telemetry -noTLS -bind_address 10.0.0.1 -port 8080

# Should succeed:
telemetry -noTLS -bind_address 127.0.0.1 -port 8080
telemetry -noTLS -bind_address ::1 -port 8080
```

Unit test `TestNoTLSRequiresLoopbackAddress` covers all cases.