### PR TITLE
Add Gnmi Audit-Logging to Get() and Set()

### DIFF
--- a/gnmi_server/server.go
+++ b/gnmi_server/server.go
@@ -954,11 +954,11 @@ func IsNativeOrigin(origin string) bool {
 func (s *Server) Get(ctx context.Context, req *gnmipb.GetRequest) (resp *gnmipb.GetResponse, err error) {
 	// GNMI-AUDIT logging
 	start := time.Now()
-	user := extractUser(ctx)
-	peer := extractPeer(ctx)
+	auditUser := extractUser(ctx)
+	auditPeer := extractPeer(ctx)
 
 	log.Infof("[GNMI-AUDIT] GetRequest user=%s peer=%s prefix=%v paths=%v type=%v",
-			user, peer, req.GetPrefix(), req.GetPath(), req.GetType())
+			auditUser, auditPeer, req.GetPrefix(), req.GetPath(), req.GetType())
 
 	// defer logs automatically when function returns
 	defer func() {
@@ -966,10 +966,10 @@ func (s *Server) Get(ctx context.Context, req *gnmipb.GetRequest) (resp *gnmipb.
 
 		if err != nil {
 			log.Errorf("[GNMI-AUDIT] GetResponse user=%s peer=%s status=FAIL err=%v duration=%v",
-					user, peer, err, duration)
+					auditUser, auditPeer, err, duration)
 		} else {
 			log.Infof("[GNMI-AUDIT] GetResponse user=%s peer=%s status=OK duration=%v",
-					user, peer, duration)
+					auditUser, auditPeer, duration)
 		}
 	}()
 
@@ -982,14 +982,14 @@ func (s *Server) Get(ctx context.Context, req *gnmipb.GetRequest) (resp *gnmipb.
 	// gNMI path based authorization
 	if s.config.PathzPolicy && len(req.GetPath()) != 0 {
 		newPaths := []*gnmipb.Path{}
-		pathzUser, userErr := getUsername(ctx)
-		if userErr != nil {
-			log.V(1).Infof("GetRequest User not found: %s", userErr.Error())
-			return nil, userErr
+		user, err := getUsername(ctx)
+		if err != nil {
+			log.V(1).Infof("GetRequest User not found: %s", err.Error())
+			return nil, err
 		}
 		for _, path := range req.GetPath() {
 			// Only process the authorized paths in the request.
-			s.gnsiPathz.pathzProcessor.AuthorizeWithPrefix(pathzUser, req.GetPrefix(), path, gnsi_pathz_pb.Mode_MODE_READ)
+			s.gnsiPathz.pathzProcessor.AuthorizeWithPrefix(user, req.GetPrefix(), path, gnsi_pathz_pb.Mode_MODE_READ)
 		}
 		if len(newPaths) == 0 {
 			return nil, status.Error(codes.PermissionDenied, "Unauthorized request. Rejected by pathz policy.")
@@ -1115,20 +1115,20 @@ func saveOnSetDisabled() error { return nil }
 func (s *Server) Set(ctx context.Context, req *gnmipb.SetRequest) (resp *gnmipb.SetResponse, err error) {
 	// GNMI-AUDIT logging
 	start := time.Now()
-	user := extractUser(ctx) // from auth metadata
-	peer := extractPeer(ctx) // client address
+	auditUser := extractUser(ctx) // from auth metadata
+	auditPeer := extractPeer(ctx) // client address
 
 	log.Infof("[GNMI-AUDIT] SetRequest user=%s peer=%s prefix=%v updates=%d replaces=%d deletes=%d",
-		user, peer, req.GetPrefix(), len(req.GetUpdate()), len(req.GetReplace()), len(req.GetDelete()))
+		auditUser, auditPeer, req.GetPrefix(), len(req.GetUpdate()), len(req.GetReplace()), len(req.GetDelete()))
 
 	defer func() {
 		duration := time.Since(start)
 		if err != nil {
 			log.Errorf("[GNMI-AUDIT] SetResponse user=%s peer=%s status=FAIL err=%v duration=%v",
-				user, peer, err, duration)
+				auditUser, auditPeer, err, duration)
 		} else {
 			log.Infof("[GNMI-AUDIT] SetResponse user=%s peer=%s status=OK duration=%v",
-				user, peer, duration)
+				auditUser, auditPeer, duration)
 		}
 	}()
 
@@ -1144,20 +1144,20 @@ func (s *Server) Set(ctx context.Context, req *gnmipb.SetRequest) (resp *gnmipb.
 	}
 	// gNMI path based authorization
 	if s.config.PathzPolicy {
-		pathzUser, userErr := getUsername(ctx)
-		if userErr != nil {
-			log.V(1).Infof("SetRequest User not found: %s", userErr.Error())
-			return nil, userErr
+		user, err := getUsername(ctx)
+		if err != nil {
+			log.V(1).Infof("SetRequest User not found: %s", err.Error())
+			return nil, err
 		}
 		permitted := true
 		for _, path := range req.GetDelete() {
-			s.gnsiPathz.pathzProcessor.AuthorizeWithPrefix(pathzUser, req.GetPrefix(), path, gnsi_pathz_pb.Mode_MODE_WRITE)
+			s.gnsiPathz.pathzProcessor.AuthorizeWithPrefix(user, req.GetPrefix(), path, gnsi_pathz_pb.Mode_MODE_WRITE)
 		}
 		for _, update := range req.GetReplace() {
-			s.gnsiPathz.pathzProcessor.AuthorizeWithPrefix(pathzUser, req.GetPrefix(), update.GetPath(), gnsi_pathz_pb.Mode_MODE_WRITE)
+			s.gnsiPathz.pathzProcessor.AuthorizeWithPrefix(user, req.GetPrefix(), update.GetPath(), gnsi_pathz_pb.Mode_MODE_WRITE)
 		}
 		for _, update := range req.GetUpdate() {
-			s.gnsiPathz.pathzProcessor.AuthorizeWithPrefix(pathzUser, req.GetPrefix(), update.GetPath(), gnsi_pathz_pb.Mode_MODE_WRITE)
+			s.gnsiPathz.pathzProcessor.AuthorizeWithPrefix(user, req.GetPrefix(), update.GetPath(), gnsi_pathz_pb.Mode_MODE_WRITE)
 		}
 		if !permitted {
 			return nil, status.Error(codes.PermissionDenied, "Unauthorized request. Rejected by pathz policy.")

--- a/gnmi_server/server.go
+++ b/gnmi_server/server.go
@@ -1144,20 +1144,20 @@ func (s *Server) Set(ctx context.Context, req *gnmipb.SetRequest) (resp *gnmipb.
 	}
 	// gNMI path based authorization
 	if s.config.PathzPolicy {
-		user, err := getUsername(ctx)
-		if err != nil {
-			log.V(1).Infof("SetRequest User not found: %s", err.Error())
-			return nil, err
+		pathzUser, userErr := getUsername(ctx)
+		if userErr != nil {
+			log.V(1).Infof("SetRequest User not found: %s", userErr.Error())
+			return nil, userErr
 		}
 		permitted := true
 		for _, path := range req.GetDelete() {
-			s.gnsiPathz.pathzProcessor.AuthorizeWithPrefix(user, req.GetPrefix(), path, gnsi_pathz_pb.Mode_MODE_WRITE)
+			s.gnsiPathz.pathzProcessor.AuthorizeWithPrefix(pathzUser, req.GetPrefix(), path, gnsi_pathz_pb.Mode_MODE_WRITE)
 		}
 		for _, update := range req.GetReplace() {
-			s.gnsiPathz.pathzProcessor.AuthorizeWithPrefix(user, req.GetPrefix(), update.GetPath(), gnsi_pathz_pb.Mode_MODE_WRITE)
+			s.gnsiPathz.pathzProcessor.AuthorizeWithPrefix(pathzUser, req.GetPrefix(), update.GetPath(), gnsi_pathz_pb.Mode_MODE_WRITE)
 		}
 		for _, update := range req.GetUpdate() {
-			s.gnsiPathz.pathzProcessor.AuthorizeWithPrefix(user, req.GetPrefix(), update.GetPath(), gnsi_pathz_pb.Mode_MODE_WRITE)
+			s.gnsiPathz.pathzProcessor.AuthorizeWithPrefix(pathzUser, req.GetPrefix(), update.GetPath(), gnsi_pathz_pb.Mode_MODE_WRITE)
 		}
 		if !permitted {
 			return nil, status.Error(codes.PermissionDenied, "Unauthorized request. Rejected by pathz policy.")

--- a/gnmi_server/server.go
+++ b/gnmi_server/server.go
@@ -1112,29 +1112,10 @@ func SaveOnSetEnabled() error {
 // SaveOnSetDisabeld does nothing.
 func saveOnSetDisabled() error { return nil }
 
-func (s *Server) Set(ctx context.Context, req *gnmipb.SetRequest) (resp *gnmipb.SetResponse, err error) {
-	// GNMI-AUDIT logging
-	start := time.Now()
-	auditUser := extractUser(ctx) // from auth metadata
-	auditPeer := extractPeer(ctx) // client address
-
-	log.Infof("[GNMI-AUDIT] SetRequest user=%s peer=%s prefix=%v updates=%d replaces=%d deletes=%d",
-		auditUser, auditPeer, req.GetPrefix(), len(req.GetUpdate()), len(req.GetReplace()), len(req.GetDelete()))
-
-	defer func() {
-		duration := time.Since(start)
-		if err != nil {
-			log.Errorf("[GNMI-AUDIT] SetResponse user=%s peer=%s status=FAIL err=%v duration=%v",
-				auditUser, auditPeer, err, duration)
-		} else {
-			log.Infof("[GNMI-AUDIT] SetResponse user=%s peer=%s status=OK duration=%v",
-				auditUser, auditPeer, duration)
-		}
-	}()
-
-	err = s.ReqFromMaster(req, &s.masterEID)
-	if err != nil {
-		return nil, err
+func (s *Server) Set(ctx context.Context, req *gnmipb.SetRequest) (*gnmipb.SetResponse, error) {
+	e := s.ReqFromMaster(req, &s.masterEID)
+	if e != nil {
+		return nil, e
 	}
 
 	common_utils.IncCounter(common_utils.GNMI_SET)
@@ -1175,6 +1156,7 @@ func (s *Server) Set(ctx context.Context, req *gnmipb.SetRequest) (resp *gnmipb.
 	encoding := gnmipb.Encoding_JSON_IETF
 
 	var dc sdc.Client
+	var err error
 	paths := req.GetDelete()
 	for _, path := range req.GetReplace() {
 		paths = append(paths, path.GetPath())
@@ -1272,7 +1254,7 @@ func (s *Server) Set(ctx context.Context, req *gnmipb.SetRequest) (resp *gnmipb.
 		s.SaveStartupConfig()
 	}
 
-	resp = &gnmipb.SetResponse{
+	resp := &gnmipb.SetResponse{
 		Prefix:   req.GetPrefix(),
 		Response: results,
 	}

--- a/gnmi_server/server.go
+++ b/gnmi_server/server.go
@@ -950,7 +950,28 @@ func IsNativeOrigin(origin string) bool {
 }
 
 // Get implements the Get RPC in gNMI spec.
-func (s *Server) Get(ctx context.Context, req *gnmipb.GetRequest) (*gnmipb.GetResponse, error) {
+func (s *Server) Get(ctx context.Context, req *gnmipb.GetRequest) (resp *gnmipb.GetResponse, err error) {
+	// GNMI-AUDIT logging
+	start := time.Now()
+	user := extractUser(ctx)
+	peer := extractPeer(ctx)
+
+	log.Infof("[GNMI-AUDIT] GetRequest user=%s peer=%s prefix=%v paths=%v type=%v",
+			user, peer, req.GetPrefix(), req.GetPath(), req.GetType())
+
+	// defer logs automatically when function returns
+	defer func() {
+		duration := time.Since(start)
+
+		if err != nil {
+			log.Errorf("[GNMI-AUDIT] GetResponse user=%s peer=%s status=FAIL err=%v duration=%v",
+					user, peer, err, duration)
+		} else {
+			log.Infof("[GNMI-AUDIT] GetResponse user=%s peer=%s status=OK duration=%v",
+					user, peer, duration)
+		}
+	}()
+
 	common_utils.IncCounter(common_utils.GNMI_GET)
 
 	if req.GetType() != gnmipb.GetRequest_ALL {
@@ -1091,8 +1112,19 @@ func SaveOnSetEnabled() error {
 func saveOnSetDisabled() error { return nil }
 
 func (s *Server) Set(ctx context.Context, req *gnmipb.SetRequest) (*gnmipb.SetResponse, error) {
+	// GNMI-AUDIT logging
+	start := time.Now()
+	user := extractUser(ctx) // from auth metadata
+	peer := extractPeer(ctx) // client address
+
+	log.Infof("[GNMI-AUDIT] SetRequest user=%s peer=%s prefix=%v updates=%d replaces=%d deletes=%d",
+		user, peer, req.GetPrefix(), len(req.GetUpdate()), len(req.GetReplace()), len(req.GetDelete()))
+
 	e := s.ReqFromMaster(req, &s.masterEID)
 	if e != nil {
+		duration := time.Since(start)
+		log.Errorf("[GNMI-AUDIT] SetResponse user=%s peer=%s status=FAIL err=%v duration=%v",
+			user, peer, e, duration)
 		return nil, e
 	}
 
@@ -1232,11 +1264,21 @@ func (s *Server) Set(ctx context.Context, req *gnmipb.SetRequest) (*gnmipb.SetRe
 		s.SaveStartupConfig()
 	}
 
-	return &gnmipb.SetResponse{
+	resp := &gnmipb.SetResponse{
 		Prefix:   req.GetPrefix(),
 		Response: results,
-	}, err
+	}
 
+	duration := time.Since(start)
+
+	if err != nil {
+		log.Errorf("[GNMI-AUDIT] SetResponse user=%s peer=%s status=FAIL err=%v duration=%v",
+			user, peer, err, duration)
+	} else {
+		log.Infof("[GNMI-AUDIT] SetResponse user=%s peer=%s status=OK duration=%v",
+			user, peer, duration)
+	}
+	return resp, err
 }
 
 func (s *Server) Capabilities(ctx context.Context, req *gnmipb.CapabilityRequest) (*gnmipb.CapabilityResponse, error) {

--- a/gnmi_server/server.go
+++ b/gnmi_server/server.go
@@ -1272,11 +1272,10 @@ func (s *Server) Set(ctx context.Context, req *gnmipb.SetRequest) (resp *gnmipb.
 		s.SaveStartupConfig()
 	}
 
-	resp = &gnmipb.SetResponse{
+	return &gnmipb.SetResponse{
 		Prefix:   req.GetPrefix(),
 		Response: results,
-	}
-	return resp, err
+	}, err
 }
 
 func (s *Server) Capabilities(ctx context.Context, req *gnmipb.CapabilityRequest) (*gnmipb.CapabilityResponse, error) {

--- a/gnmi_server/server.go
+++ b/gnmi_server/server.go
@@ -958,7 +958,7 @@ func (s *Server) Get(ctx context.Context, req *gnmipb.GetRequest) (resp *gnmipb.
 	auditPeer := extractPeer(ctx)
 
 	log.Infof("[GNMI-AUDIT] GetRequest user=%s peer=%s prefix=%v paths=%v type=%v",
-			auditUser, auditPeer, req.GetPrefix(), req.GetPath(), req.GetType())
+		auditUser, auditPeer, req.GetPrefix(), req.GetPath(), req.GetType())
 
 	defer logGnmiAuditResponse("Get", auditUser, auditPeer, start, &err)
 

--- a/gnmi_server/server.go
+++ b/gnmi_server/server.go
@@ -1112,7 +1112,7 @@ func SaveOnSetEnabled() error {
 // SaveOnSetDisabeld does nothing.
 func saveOnSetDisabled() error { return nil }
 
-func (s *Server) Set(ctx context.Context, req *gnmipb.SetRequest) (resp *gnmipb.SetResponse, err error) {
+func (s *Server) Set(ctx context.Context, req *gnmipb.SetRequest) (resp *gnmipb.SetResponse, retErr error) {
 	start := time.Now()
 	auditUser := extractUser(ctx)
 	auditPeer := extractPeer(ctx)
@@ -1122,9 +1122,9 @@ func (s *Server) Set(ctx context.Context, req *gnmipb.SetRequest) (resp *gnmipb.
 
 	defer func() {
 		duration := time.Since(start)
-		if err != nil {
+		if retErr != nil {
 			log.Errorf("[GNMI-AUDIT] SetResponse user=%s peer=%s status=FAIL err=%v duration=%v",
-				auditUser, auditPeer, err, duration)
+				auditUser, auditPeer, retErr, duration)
 		} else {
 			log.Infof("[GNMI-AUDIT] SetResponse user=%s peer=%s status=OK duration=%v",
 				auditUser, auditPeer, duration)
@@ -1143,20 +1143,20 @@ func (s *Server) Set(ctx context.Context, req *gnmipb.SetRequest) (resp *gnmipb.
 	}
 	// gNMI path based authorization
 	if s.config.PathzPolicy {
-		pathzUser, userErr := getUsername(ctx)
-		if userErr != nil {
-			log.V(1).Infof("SetRequest User not found: %s", userErr.Error())
-			return nil, userErr
+		user, err := getUsername(ctx)
+		if err != nil {
+			log.V(1).Infof("SetRequest User not found: %s", err.Error())
+			return nil, err
 		}
 		permitted := true
 		for _, path := range req.GetDelete() {
-			s.gnsiPathz.pathzProcessor.AuthorizeWithPrefix(pathzUser, req.GetPrefix(), path, gnsi_pathz_pb.Mode_MODE_WRITE)
+			s.gnsiPathz.pathzProcessor.AuthorizeWithPrefix(user, req.GetPrefix(), path, gnsi_pathz_pb.Mode_MODE_WRITE)
 		}
 		for _, update := range req.GetReplace() {
-			s.gnsiPathz.pathzProcessor.AuthorizeWithPrefix(pathzUser, req.GetPrefix(), update.GetPath(), gnsi_pathz_pb.Mode_MODE_WRITE)
+			s.gnsiPathz.pathzProcessor.AuthorizeWithPrefix(user, req.GetPrefix(), update.GetPath(), gnsi_pathz_pb.Mode_MODE_WRITE)
 		}
 		for _, update := range req.GetUpdate() {
-			s.gnsiPathz.pathzProcessor.AuthorizeWithPrefix(pathzUser, req.GetPrefix(), update.GetPath(), gnsi_pathz_pb.Mode_MODE_WRITE)
+			s.gnsiPathz.pathzProcessor.AuthorizeWithPrefix(user, req.GetPrefix(), update.GetPath(), gnsi_pathz_pb.Mode_MODE_WRITE)
 		}
 		if !permitted {
 			return nil, status.Error(codes.PermissionDenied, "Unauthorized request. Rejected by pathz policy.")
@@ -1174,6 +1174,7 @@ func (s *Server) Set(ctx context.Context, req *gnmipb.SetRequest) (resp *gnmipb.
 	encoding := gnmipb.Encoding_JSON_IETF
 
 	var dc sdc.Client
+	var err error
 	paths := req.GetDelete()
 	for _, path := range req.GetReplace() {
 		paths = append(paths, path.GetPath())
@@ -1196,13 +1197,13 @@ func (s *Server) Set(ctx context.Context, req *gnmipb.SetRequest) (resp *gnmipb.
 
 		// Fast path: bypass validation for allowed tables/SKUs
 		allUpdates := append(req.GetReplace(), req.GetUpdate()...)
-		if bypassResp, used, bypassErr := bypass.TrySet(ctx, prefix, req.GetDelete(), allUpdates); used {
-			if bypassErr != nil {
+		if resp, used, err := bypass.TrySet(ctx, prefix, req.GetDelete(), allUpdates); used {
+			if err != nil {
 				common_utils.IncCounter(common_utils.GNMI_SET_FAIL)
-				return nil, status.Error(codes.Internal, bypassErr.Error())
+				return nil, status.Error(codes.Internal, err.Error())
 			}
 			common_utils.IncCounter(common_utils.GNMI_SET_BYPASS)
-			return bypassResp, nil
+			return resp, nil
 		}
 
 		var targetDbName string

--- a/gnmi_server/server.go
+++ b/gnmi_server/server.go
@@ -960,18 +960,7 @@ func (s *Server) Get(ctx context.Context, req *gnmipb.GetRequest) (resp *gnmipb.
 	log.Infof("[GNMI-AUDIT] GetRequest user=%s peer=%s prefix=%v paths=%v type=%v",
 			auditUser, auditPeer, req.GetPrefix(), req.GetPath(), req.GetType())
 
-	// defer logs automatically when function returns
-	defer func() {
-		duration := time.Since(start)
-
-		if err != nil {
-			log.Errorf("[GNMI-AUDIT] GetResponse user=%s peer=%s status=FAIL err=%v duration=%v",
-					auditUser, auditPeer, err, duration)
-		} else {
-			log.Infof("[GNMI-AUDIT] GetResponse user=%s peer=%s status=OK duration=%v",
-					auditUser, auditPeer, duration)
-		}
-	}()
+	defer logGnmiAuditResponse("Get", auditUser, auditPeer, start, &err)
 
 	common_utils.IncCounter(common_utils.GNMI_GET)
 
@@ -1120,16 +1109,7 @@ func (s *Server) Set(ctx context.Context, req *gnmipb.SetRequest) (resp *gnmipb.
 	log.Infof("[GNMI-AUDIT] SetRequest user=%s peer=%s prefix=%v updates=%d replaces=%d deletes=%d",
 		auditUser, auditPeer, req.GetPrefix(), len(req.GetUpdate()), len(req.GetReplace()), len(req.GetDelete()))
 
-	defer func() {
-		duration := time.Since(start)
-		if retErr != nil {
-			log.Errorf("[GNMI-AUDIT] SetResponse user=%s peer=%s status=FAIL err=%v duration=%v",
-				auditUser, auditPeer, retErr, duration)
-		} else {
-			log.Infof("[GNMI-AUDIT] SetResponse user=%s peer=%s status=OK duration=%v",
-				auditUser, auditPeer, duration)
-		}
-	}()
+	defer logGnmiAuditResponse("Set", auditUser, auditPeer, start, &retErr)
 
 	e := s.ReqFromMaster(req, &s.masterEID)
 	if e != nil {
@@ -1348,6 +1328,18 @@ func extractPeer(ctx context.Context) string {
 	}
 
 	return "unknown"
+}
+
+func logGnmiAuditResponse(method, user, peerAddr string, start time.Time, errPtr *error) {
+	duration := time.Since(start)
+
+	if errPtr != nil && *errPtr != nil {
+		log.Errorf("[GNMI-AUDIT] %sResponse user=%s peer=%s status=FAIL err=%v duration=%v",
+			method, user, peerAddr, *errPtr, duration)
+	} else {
+		log.Infof("[GNMI-AUDIT] %sResponse user=%s peer=%s status=OK duration=%v",
+			method, user, peerAddr, duration)
+	}
 }
 
 // Obtain the user name as the last element of the SPIFFE ID.

--- a/gnmi_server/server.go
+++ b/gnmi_server/server.go
@@ -1112,7 +1112,7 @@ func SaveOnSetEnabled() error {
 // SaveOnSetDisabeld does nothing.
 func saveOnSetDisabled() error { return nil }
 
-func (s *Server) Set(ctx context.Context, req *gnmipb.SetRequest) (*gnmipb.SetResponse, error) {
+func (s *Server) Set(ctx context.Context, req *gnmipb.SetRequest) (resp *gnmipb.SetResponse, err error) {
 	start := time.Now()
 	auditUser := extractUser(ctx)
 	auditPeer := extractPeer(ctx)
@@ -1120,166 +1120,161 @@ func (s *Server) Set(ctx context.Context, req *gnmipb.SetRequest) (*gnmipb.SetRe
 	log.Infof("[GNMI-AUDIT] SetRequest user=%s peer=%s prefix=%v updates=%d replaces=%d deletes=%d",
 		auditUser, auditPeer, req.GetPrefix(), len(req.GetUpdate()), len(req.GetReplace()), len(req.GetDelete()))
 
-	resp, err := func() (*gnmipb.SetResponse, error) {
-		ctx := ctx
-
-		e := s.ReqFromMaster(req, &s.masterEID)
-		if e != nil {
-			return nil, e
-		}
-
-		common_utils.IncCounter(common_utils.GNMI_SET)
-		if s.config.EnableTranslibWrite == false && s.config.EnableNativeWrite == false {
-			common_utils.IncCounter(common_utils.GNMI_SET_FAIL)
-			return nil, grpc.Errorf(codes.Unimplemented, "GNMI is in read-only mode")
-		}
-		// gNMI path based authorization
-		if s.config.PathzPolicy {
-			pathzUser, userErr := getUsername(ctx)
-			if userErr != nil {
-				log.V(1).Infof("SetRequest User not found: %s", userErr.Error())
-				return nil, userErr
-			}
-			permitted := true
-			for _, path := range req.GetDelete() {
-				s.gnsiPathz.pathzProcessor.AuthorizeWithPrefix(pathzUser, req.GetPrefix(), path, gnsi_pathz_pb.Mode_MODE_WRITE)
-			}
-			for _, update := range req.GetReplace() {
-				s.gnsiPathz.pathzProcessor.AuthorizeWithPrefix(pathzUser, req.GetPrefix(), update.GetPath(), gnsi_pathz_pb.Mode_MODE_WRITE)
-			}
-			for _, update := range req.GetUpdate() {
-				s.gnsiPathz.pathzProcessor.AuthorizeWithPrefix(pathzUser, req.GetPrefix(), update.GetPath(), gnsi_pathz_pb.Mode_MODE_WRITE)
-			}
-			if !permitted {
-				return nil, status.Error(codes.PermissionDenied, "Unauthorized request. Rejected by pathz policy.")
-			}
-		}
-		var results []*gnmipb.UpdateResult
-
-		/* Fetch the prefix. */
-		prefix := req.GetPrefix()
-		origin := ""
-		if prefix != nil {
-			origin = prefix.Origin
-		}
-		extensions := req.GetExtension()
-		encoding := gnmipb.Encoding_JSON_IETF
-
-		var dc sdc.Client
-		var err error
-		paths := req.GetDelete()
-		for _, path := range req.GetReplace() {
-			paths = append(paths, path.GetPath())
-		}
-		for _, path := range req.GetUpdate() {
-			paths = append(paths, path.GetPath())
-		}
-		if origin == "" {
-			origin, err = ParseOrigin(paths)
-			if err != nil {
-				return nil, err
-			}
-		}
-		authTarget := "gnmi"
-		if check := IsNativeOrigin(origin); check {
-			if s.config.EnableNativeWrite == false {
-				common_utils.IncCounter(common_utils.GNMI_SET_FAIL)
-				return nil, grpc.Errorf(codes.Unimplemented, "GNMI native write is disabled")
-			}
-
-			// Fast path: bypass validation for allowed tables/SKUs
-			allUpdates := append(req.GetReplace(), req.GetUpdate()...)
-			if bypassResp, used, bypassErr := bypass.TrySet(ctx, prefix, req.GetDelete(), allUpdates); used {
-				if bypassErr != nil {
-					common_utils.IncCounter(common_utils.GNMI_SET_FAIL)
-					return nil, status.Error(codes.Internal, bypassErr.Error())
-				}
-				common_utils.IncCounter(common_utils.GNMI_SET_BYPASS)
-				return bypassResp, nil
-			}
-
-			var targetDbName string
-			dc, err = sdc.NewMixedDbClient(paths, prefix, origin, encoding, s.config.ZmqPort, s.config.Vrf, &targetDbName)
-			authTarget = "gnmi_" + targetDbName
+	defer func() {
+		duration := time.Since(start)
+		if err != nil {
+			log.Errorf("[GNMI-AUDIT] SetResponse user=%s peer=%s status=FAIL err=%v duration=%v",
+				auditUser, auditPeer, err, duration)
 		} else {
-			if s.config.EnableTranslibWrite == false {
-				common_utils.IncCounter(common_utils.GNMI_SET_FAIL)
-				return nil, grpc.Errorf(codes.Unimplemented, "Translib write is disabled")
-			}
-			/* Create Transl client. */
-			dc, err = sdc.NewTranslClient(prefix, nil, ctx, extensions)
+			log.Infof("[GNMI-AUDIT] SetResponse user=%s peer=%s status=OK duration=%v",
+				auditUser, auditPeer, duration)
 		}
-
-		if err != nil {
-			common_utils.IncCounter(common_utils.GNMI_SET_FAIL)
-			return nil, status.Error(codes.NotFound, err.Error())
-		}
-		defer dc.Close()
-
-		ctx, err = authenticate(s.config, ctx, authTarget, true)
-		if err != nil {
-			common_utils.IncCounter(common_utils.GNMI_SET_FAIL)
-			return nil, err
-		}
-		/* DELETE */
-		for _, path := range req.GetDelete() {
-			log.V(2).Infof("Delete path: %v", path)
-
-			res := gnmipb.UpdateResult{
-				Path: path,
-				Op:   gnmipb.UpdateResult_DELETE,
-			}
-
-			/* Add to Set response results. */
-			results = append(results, &res)
-		}
-
-		/* REPLACE */
-		for _, path := range req.GetReplace() {
-			log.V(2).Infof("Replace path: %v ", path)
-
-			res := gnmipb.UpdateResult{
-				Path: path.GetPath(),
-				Op:   gnmipb.UpdateResult_REPLACE,
-			}
-			/* Add to Set response results. */
-			results = append(results, &res)
-		}
-
-		/* UPDATE */
-		for _, path := range req.GetUpdate() {
-			log.V(2).Infof("Update path: %v ", path)
-
-			res := gnmipb.UpdateResult{
-				Path: path.GetPath(),
-				Op:   gnmipb.UpdateResult_UPDATE,
-			}
-			/* Add to Set response results. */
-			results = append(results, &res)
-		}
-		err = dc.Set(req.GetDelete(), req.GetReplace(), req.GetUpdate())
-		if err != nil {
-			common_utils.IncCounter(common_utils.GNMI_SET_FAIL)
-		} else {
-			s.SaveStartupConfig()
-		}
-
-		resp := &gnmipb.SetResponse{
-			Prefix:   req.GetPrefix(),
-			Response: results,
-		}
-		return resp, err
 	}()
 
-	duration := time.Since(start)
-	if err != nil {
-		log.Errorf("[GNMI-AUDIT] SetResponse user=%s peer=%s status=FAIL err=%v duration=%v",
-			auditUser, auditPeer, err, duration)
-	} else {
-		log.Infof("[GNMI-AUDIT] SetResponse user=%s peer=%s status=OK duration=%v",
-			auditUser, auditPeer, duration)
+	e := s.ReqFromMaster(req, &s.masterEID)
+	if e != nil {
+		return nil, e
 	}
 
+	common_utils.IncCounter(common_utils.GNMI_SET)
+	if s.config.EnableTranslibWrite == false && s.config.EnableNativeWrite == false {
+		common_utils.IncCounter(common_utils.GNMI_SET_FAIL)
+		return nil, grpc.Errorf(codes.Unimplemented, "GNMI is in read-only mode")
+	}
+	// gNMI path based authorization
+	if s.config.PathzPolicy {
+		pathzUser, userErr := getUsername(ctx)
+		if userErr != nil {
+			log.V(1).Infof("SetRequest User not found: %s", userErr.Error())
+			return nil, userErr
+		}
+		permitted := true
+		for _, path := range req.GetDelete() {
+			s.gnsiPathz.pathzProcessor.AuthorizeWithPrefix(pathzUser, req.GetPrefix(), path, gnsi_pathz_pb.Mode_MODE_WRITE)
+		}
+		for _, update := range req.GetReplace() {
+			s.gnsiPathz.pathzProcessor.AuthorizeWithPrefix(pathzUser, req.GetPrefix(), update.GetPath(), gnsi_pathz_pb.Mode_MODE_WRITE)
+		}
+		for _, update := range req.GetUpdate() {
+			s.gnsiPathz.pathzProcessor.AuthorizeWithPrefix(pathzUser, req.GetPrefix(), update.GetPath(), gnsi_pathz_pb.Mode_MODE_WRITE)
+		}
+		if !permitted {
+			return nil, status.Error(codes.PermissionDenied, "Unauthorized request. Rejected by pathz policy.")
+		}
+	}
+	var results []*gnmipb.UpdateResult
+
+	/* Fetch the prefix. */
+	prefix := req.GetPrefix()
+	origin := ""
+	if prefix != nil {
+		origin = prefix.Origin
+	}
+	extensions := req.GetExtension()
+	encoding := gnmipb.Encoding_JSON_IETF
+
+	var dc sdc.Client
+	paths := req.GetDelete()
+	for _, path := range req.GetReplace() {
+		paths = append(paths, path.GetPath())
+	}
+	for _, path := range req.GetUpdate() {
+		paths = append(paths, path.GetPath())
+	}
+	if origin == "" {
+		origin, err = ParseOrigin(paths)
+		if err != nil {
+			return nil, err
+		}
+	}
+	authTarget := "gnmi"
+	if check := IsNativeOrigin(origin); check {
+		if s.config.EnableNativeWrite == false {
+			common_utils.IncCounter(common_utils.GNMI_SET_FAIL)
+			return nil, grpc.Errorf(codes.Unimplemented, "GNMI native write is disabled")
+		}
+
+		// Fast path: bypass validation for allowed tables/SKUs
+		allUpdates := append(req.GetReplace(), req.GetUpdate()...)
+		if bypassResp, used, bypassErr := bypass.TrySet(ctx, prefix, req.GetDelete(), allUpdates); used {
+			if bypassErr != nil {
+				common_utils.IncCounter(common_utils.GNMI_SET_FAIL)
+				return nil, status.Error(codes.Internal, bypassErr.Error())
+			}
+			common_utils.IncCounter(common_utils.GNMI_SET_BYPASS)
+			return bypassResp, nil
+		}
+
+		var targetDbName string
+		dc, err = sdc.NewMixedDbClient(paths, prefix, origin, encoding, s.config.ZmqPort, s.config.Vrf, &targetDbName)
+		authTarget = "gnmi_" + targetDbName
+	} else {
+		if s.config.EnableTranslibWrite == false {
+			common_utils.IncCounter(common_utils.GNMI_SET_FAIL)
+			return nil, grpc.Errorf(codes.Unimplemented, "Translib write is disabled")
+		}
+		/* Create Transl client. */
+		dc, err = sdc.NewTranslClient(prefix, nil, ctx, extensions)
+	}
+
+	if err != nil {
+		common_utils.IncCounter(common_utils.GNMI_SET_FAIL)
+		return nil, status.Error(codes.NotFound, err.Error())
+	}
+	defer dc.Close()
+
+	ctx, err = authenticate(s.config, ctx, authTarget, true)
+	if err != nil {
+		common_utils.IncCounter(common_utils.GNMI_SET_FAIL)
+		return nil, err
+	}
+	/* DELETE */
+	for _, path := range req.GetDelete() {
+		log.V(2).Infof("Delete path: %v", path)
+
+		res := gnmipb.UpdateResult{
+			Path: path,
+			Op:   gnmipb.UpdateResult_DELETE,
+		}
+
+		/* Add to Set response results. */
+		results = append(results, &res)
+	}
+
+	/* REPLACE */
+	for _, path := range req.GetReplace() {
+		log.V(2).Infof("Replace path: %v ", path)
+
+		res := gnmipb.UpdateResult{
+			Path: path.GetPath(),
+			Op:   gnmipb.UpdateResult_REPLACE,
+		}
+		/* Add to Set response results. */
+		results = append(results, &res)
+	}
+
+	/* UPDATE */
+	for _, path := range req.GetUpdate() {
+		log.V(2).Infof("Update path: %v ", path)
+
+		res := gnmipb.UpdateResult{
+			Path: path.GetPath(),
+			Op:   gnmipb.UpdateResult_UPDATE,
+		}
+		/* Add to Set response results. */
+		results = append(results, &res)
+	}
+	err = dc.Set(req.GetDelete(), req.GetReplace(), req.GetUpdate())
+	if err != nil {
+		common_utils.IncCounter(common_utils.GNMI_SET_FAIL)
+	} else {
+		s.SaveStartupConfig()
+	}
+
+	resp = &gnmipb.SetResponse{
+		Prefix:   req.GetPrefix(),
+		Response: results,
+	}
 	return resp, err
 }
 

--- a/gnmi_server/server.go
+++ b/gnmi_server/server.go
@@ -981,14 +981,14 @@ func (s *Server) Get(ctx context.Context, req *gnmipb.GetRequest) (resp *gnmipb.
 	// gNMI path based authorization
 	if s.config.PathzPolicy && len(req.GetPath()) != 0 {
 		newPaths := []*gnmipb.Path{}
-		user, err := getUsername(ctx)
-		if err != nil {
-			log.V(1).Infof("GetRequest User not found: %s", err.Error())
-			return nil, err
+		pathzUser, userErr := getUsername(ctx)
+		if userErr != nil {
+			log.V(1).Infof("GetRequest User not found: %s", userErr.Error())
+			return nil, userErr
 		}
 		for _, path := range req.GetPath() {
 			// Only process the authorized paths in the request.
-			s.gnsiPathz.pathzProcessor.AuthorizeWithPrefix(user, req.GetPrefix(), path, gnsi_pathz_pb.Mode_MODE_READ)
+			s.gnsiPathz.pathzProcessor.AuthorizeWithPrefix(pathzUser, req.GetPrefix(), path, gnsi_pathz_pb.Mode_MODE_READ)
 		}
 		if len(newPaths) == 0 {
 			return nil, status.Error(codes.PermissionDenied, "Unauthorized request. Rejected by pathz policy.")
@@ -996,7 +996,8 @@ func (s *Server) Get(ctx context.Context, req *gnmipb.GetRequest) (resp *gnmipb.
 		req.Path = newPaths
 	}
 
-	if err := s.checkEncodingAndModel(req.GetEncoding(), req.GetUseModels()); err != nil {
+	err = s.checkEncodingAndModel(req.GetEncoding(), req.GetUseModels())
+	if err != nil {
 		common_utils.IncCounter(common_utils.GNMI_GET_FAIL)
 		return nil, status.Error(codes.Unimplemented, err.Error())
 	}
@@ -1015,7 +1016,6 @@ func (s *Server) Get(ctx context.Context, req *gnmipb.GetRequest) (resp *gnmipb.
 	log.V(2).Infof("GetRequest paths: %v", paths)
 
 	var dc sdc.Client
-	var err error
 	// Handle OPERATIONAL target directly without SONiC routing
 	if target == "OPERATIONAL" {
 		return s.handleOperationalGet(ctx, req, paths, prefix)
@@ -1111,7 +1111,7 @@ func SaveOnSetEnabled() error {
 // SaveOnSetDisabeld does nothing.
 func saveOnSetDisabled() error { return nil }
 
-func (s *Server) Set(ctx context.Context, req *gnmipb.SetRequest) (*gnmipb.SetResponse, error) {
+func (s *Server) Set(ctx context.Context, req *gnmipb.SetRequest) (resp *gnmipb.SetResponse, err error) {
 	// GNMI-AUDIT logging
 	start := time.Now()
 	user := extractUser(ctx) // from auth metadata
@@ -1120,12 +1120,20 @@ func (s *Server) Set(ctx context.Context, req *gnmipb.SetRequest) (*gnmipb.SetRe
 	log.Infof("[GNMI-AUDIT] SetRequest user=%s peer=%s prefix=%v updates=%d replaces=%d deletes=%d",
 		user, peer, req.GetPrefix(), len(req.GetUpdate()), len(req.GetReplace()), len(req.GetDelete()))
 
-	e := s.ReqFromMaster(req, &s.masterEID)
-	if e != nil {
+	defer func() {
 		duration := time.Since(start)
-		log.Errorf("[GNMI-AUDIT] SetResponse user=%s peer=%s status=FAIL err=%v duration=%v",
-			user, peer, e, duration)
-		return nil, e
+		if err != nil {
+			log.Errorf("[GNMI-AUDIT] SetResponse user=%s peer=%s status=FAIL err=%v duration=%v",
+				user, peer, err, duration)
+		} else {
+			log.Infof("[GNMI-AUDIT] SetResponse user=%s peer=%s status=OK duration=%v",
+				user, peer, duration)
+		}
+	}()
+
+	err = s.ReqFromMaster(req, &s.masterEID)
+	if err != nil {
+		return nil, err
 	}
 
 	common_utils.IncCounter(common_utils.GNMI_SET)
@@ -1135,20 +1143,20 @@ func (s *Server) Set(ctx context.Context, req *gnmipb.SetRequest) (*gnmipb.SetRe
 	}
 	// gNMI path based authorization
 	if s.config.PathzPolicy {
-		user, err := getUsername(ctx)
-		if err != nil {
-			log.V(1).Infof("SetRequest User not found: %s", err.Error())
-			return nil, err
+		pathzUser, userErr := getUsername(ctx)
+		if userErr != nil {
+			log.V(1).Infof("SetRequest User not found: %s", userErr.Error())
+			return nil, userErr
 		}
 		permitted := true
 		for _, path := range req.GetDelete() {
-			s.gnsiPathz.pathzProcessor.AuthorizeWithPrefix(user, req.GetPrefix(), path, gnsi_pathz_pb.Mode_MODE_WRITE)
+			s.gnsiPathz.pathzProcessor.AuthorizeWithPrefix(pathzUser, req.GetPrefix(), path, gnsi_pathz_pb.Mode_MODE_WRITE)
 		}
 		for _, update := range req.GetReplace() {
-			s.gnsiPathz.pathzProcessor.AuthorizeWithPrefix(user, req.GetPrefix(), update.GetPath(), gnsi_pathz_pb.Mode_MODE_WRITE)
+			s.gnsiPathz.pathzProcessor.AuthorizeWithPrefix(pathzUser, req.GetPrefix(), update.GetPath(), gnsi_pathz_pb.Mode_MODE_WRITE)
 		}
 		for _, update := range req.GetUpdate() {
-			s.gnsiPathz.pathzProcessor.AuthorizeWithPrefix(user, req.GetPrefix(), update.GetPath(), gnsi_pathz_pb.Mode_MODE_WRITE)
+			s.gnsiPathz.pathzProcessor.AuthorizeWithPrefix(pathzUser, req.GetPrefix(), update.GetPath(), gnsi_pathz_pb.Mode_MODE_WRITE)
 		}
 		if !permitted {
 			return nil, status.Error(codes.PermissionDenied, "Unauthorized request. Rejected by pathz policy.")
@@ -1166,7 +1174,6 @@ func (s *Server) Set(ctx context.Context, req *gnmipb.SetRequest) (*gnmipb.SetRe
 	encoding := gnmipb.Encoding_JSON_IETF
 
 	var dc sdc.Client
-	var err error
 	paths := req.GetDelete()
 	for _, path := range req.GetReplace() {
 		paths = append(paths, path.GetPath())
@@ -1189,13 +1196,13 @@ func (s *Server) Set(ctx context.Context, req *gnmipb.SetRequest) (*gnmipb.SetRe
 
 		// Fast path: bypass validation for allowed tables/SKUs
 		allUpdates := append(req.GetReplace(), req.GetUpdate()...)
-		if resp, used, err := bypass.TrySet(ctx, prefix, req.GetDelete(), allUpdates); used {
-			if err != nil {
+		if bypassResp, used, bypassErr := bypass.TrySet(ctx, prefix, req.GetDelete(), allUpdates); used {
+			if bypassErr != nil {
 				common_utils.IncCounter(common_utils.GNMI_SET_FAIL)
-				return nil, status.Error(codes.Internal, err.Error())
+				return nil, status.Error(codes.Internal, bypassErr.Error())
 			}
 			common_utils.IncCounter(common_utils.GNMI_SET_BYPASS)
-			return resp, nil
+			return bypassResp, nil
 		}
 
 		var targetDbName string
@@ -1264,19 +1271,9 @@ func (s *Server) Set(ctx context.Context, req *gnmipb.SetRequest) (*gnmipb.SetRe
 		s.SaveStartupConfig()
 	}
 
-	resp := &gnmipb.SetResponse{
+	resp = &gnmipb.SetResponse{
 		Prefix:   req.GetPrefix(),
 		Response: results,
-	}
-
-	duration := time.Since(start)
-
-	if err != nil {
-		log.Errorf("[GNMI-AUDIT] SetResponse user=%s peer=%s status=FAIL err=%v duration=%v",
-			user, peer, err, duration)
-	} else {
-		log.Infof("[GNMI-AUDIT] SetResponse user=%s peer=%s status=OK duration=%v",
-			user, peer, duration)
 	}
 	return resp, err
 }

--- a/gnmi_server/server.go
+++ b/gnmi_server/server.go
@@ -1256,6 +1256,7 @@ func (s *Server) Set(ctx context.Context, req *gnmipb.SetRequest) (resp *gnmipb.
 		Prefix:   req.GetPrefix(),
 		Response: results,
 	}, err
+
 }
 
 func (s *Server) Capabilities(ctx context.Context, req *gnmipb.CapabilityRequest) (*gnmipb.CapabilityResponse, error) {

--- a/gnmi_server/server.go
+++ b/gnmi_server/server.go
@@ -1113,151 +1113,173 @@ func SaveOnSetEnabled() error {
 func saveOnSetDisabled() error { return nil }
 
 func (s *Server) Set(ctx context.Context, req *gnmipb.SetRequest) (*gnmipb.SetResponse, error) {
-	e := s.ReqFromMaster(req, &s.masterEID)
-	if e != nil {
-		return nil, e
-	}
+	start := time.Now()
+	auditUser := extractUser(ctx)
+	auditPeer := extractPeer(ctx)
 
-	common_utils.IncCounter(common_utils.GNMI_SET)
-	if s.config.EnableTranslibWrite == false && s.config.EnableNativeWrite == false {
-		common_utils.IncCounter(common_utils.GNMI_SET_FAIL)
-		return nil, grpc.Errorf(codes.Unimplemented, "GNMI is in read-only mode")
-	}
-	// gNMI path based authorization
-	if s.config.PathzPolicy {
-		pathzUser, userErr := getUsername(ctx)
-		if userErr != nil {
-			log.V(1).Infof("SetRequest User not found: %s", userErr.Error())
-			return nil, userErr
-		}
-		permitted := true
-		for _, path := range req.GetDelete() {
-			s.gnsiPathz.pathzProcessor.AuthorizeWithPrefix(pathzUser, req.GetPrefix(), path, gnsi_pathz_pb.Mode_MODE_WRITE)
-		}
-		for _, update := range req.GetReplace() {
-			s.gnsiPathz.pathzProcessor.AuthorizeWithPrefix(pathzUser, req.GetPrefix(), update.GetPath(), gnsi_pathz_pb.Mode_MODE_WRITE)
-		}
-		for _, update := range req.GetUpdate() {
-			s.gnsiPathz.pathzProcessor.AuthorizeWithPrefix(pathzUser, req.GetPrefix(), update.GetPath(), gnsi_pathz_pb.Mode_MODE_WRITE)
-		}
-		if !permitted {
-			return nil, status.Error(codes.PermissionDenied, "Unauthorized request. Rejected by pathz policy.")
-		}
-	}
-	var results []*gnmipb.UpdateResult
+	log.Infof("[GNMI-AUDIT] SetRequest user=%s peer=%s prefix=%v updates=%d replaces=%d deletes=%d",
+		auditUser, auditPeer, req.GetPrefix(), len(req.GetUpdate()), len(req.GetReplace()), len(req.GetDelete()))
 
-	/* Fetch the prefix. */
-	prefix := req.GetPrefix()
-	origin := ""
-	if prefix != nil {
-		origin = prefix.Origin
-	}
-	extensions := req.GetExtension()
-	encoding := gnmipb.Encoding_JSON_IETF
+	resp, err := func() (*gnmipb.SetResponse, error) {
+		ctx := ctx
 
-	var dc sdc.Client
-	var err error
-	paths := req.GetDelete()
-	for _, path := range req.GetReplace() {
-		paths = append(paths, path.GetPath())
-	}
-	for _, path := range req.GetUpdate() {
-		paths = append(paths, path.GetPath())
-	}
-	if origin == "" {
-		origin, err = ParseOrigin(paths)
+		e := s.ReqFromMaster(req, &s.masterEID)
+		if e != nil {
+			return nil, e
+		}
+
+		common_utils.IncCounter(common_utils.GNMI_SET)
+		if s.config.EnableTranslibWrite == false && s.config.EnableNativeWrite == false {
+			common_utils.IncCounter(common_utils.GNMI_SET_FAIL)
+			return nil, grpc.Errorf(codes.Unimplemented, "GNMI is in read-only mode")
+		}
+		// gNMI path based authorization
+		if s.config.PathzPolicy {
+			pathzUser, userErr := getUsername(ctx)
+			if userErr != nil {
+				log.V(1).Infof("SetRequest User not found: %s", userErr.Error())
+				return nil, userErr
+			}
+			permitted := true
+			for _, path := range req.GetDelete() {
+				s.gnsiPathz.pathzProcessor.AuthorizeWithPrefix(pathzUser, req.GetPrefix(), path, gnsi_pathz_pb.Mode_MODE_WRITE)
+			}
+			for _, update := range req.GetReplace() {
+				s.gnsiPathz.pathzProcessor.AuthorizeWithPrefix(pathzUser, req.GetPrefix(), update.GetPath(), gnsi_pathz_pb.Mode_MODE_WRITE)
+			}
+			for _, update := range req.GetUpdate() {
+				s.gnsiPathz.pathzProcessor.AuthorizeWithPrefix(pathzUser, req.GetPrefix(), update.GetPath(), gnsi_pathz_pb.Mode_MODE_WRITE)
+			}
+			if !permitted {
+				return nil, status.Error(codes.PermissionDenied, "Unauthorized request. Rejected by pathz policy.")
+			}
+		}
+		var results []*gnmipb.UpdateResult
+
+		/* Fetch the prefix. */
+		prefix := req.GetPrefix()
+		origin := ""
+		if prefix != nil {
+			origin = prefix.Origin
+		}
+		extensions := req.GetExtension()
+		encoding := gnmipb.Encoding_JSON_IETF
+
+		var dc sdc.Client
+		var err error
+		paths := req.GetDelete()
+		for _, path := range req.GetReplace() {
+			paths = append(paths, path.GetPath())
+		}
+		for _, path := range req.GetUpdate() {
+			paths = append(paths, path.GetPath())
+		}
+		if origin == "" {
+			origin, err = ParseOrigin(paths)
+			if err != nil {
+				return nil, err
+			}
+		}
+		authTarget := "gnmi"
+		if check := IsNativeOrigin(origin); check {
+			if s.config.EnableNativeWrite == false {
+				common_utils.IncCounter(common_utils.GNMI_SET_FAIL)
+				return nil, grpc.Errorf(codes.Unimplemented, "GNMI native write is disabled")
+			}
+
+			// Fast path: bypass validation for allowed tables/SKUs
+			allUpdates := append(req.GetReplace(), req.GetUpdate()...)
+			if bypassResp, used, bypassErr := bypass.TrySet(ctx, prefix, req.GetDelete(), allUpdates); used {
+				if bypassErr != nil {
+					common_utils.IncCounter(common_utils.GNMI_SET_FAIL)
+					return nil, status.Error(codes.Internal, bypassErr.Error())
+				}
+				common_utils.IncCounter(common_utils.GNMI_SET_BYPASS)
+				return bypassResp, nil
+			}
+
+			var targetDbName string
+			dc, err = sdc.NewMixedDbClient(paths, prefix, origin, encoding, s.config.ZmqPort, s.config.Vrf, &targetDbName)
+			authTarget = "gnmi_" + targetDbName
+		} else {
+			if s.config.EnableTranslibWrite == false {
+				common_utils.IncCounter(common_utils.GNMI_SET_FAIL)
+				return nil, grpc.Errorf(codes.Unimplemented, "Translib write is disabled")
+			}
+			/* Create Transl client. */
+			dc, err = sdc.NewTranslClient(prefix, nil, ctx, extensions)
+		}
+
 		if err != nil {
+			common_utils.IncCounter(common_utils.GNMI_SET_FAIL)
+			return nil, status.Error(codes.NotFound, err.Error())
+		}
+		defer dc.Close()
+
+		ctx, err = authenticate(s.config, ctx, authTarget, true)
+		if err != nil {
+			common_utils.IncCounter(common_utils.GNMI_SET_FAIL)
 			return nil, err
 		}
-	}
-	authTarget := "gnmi"
-	if check := IsNativeOrigin(origin); check {
-		if s.config.EnableNativeWrite == false {
-			common_utils.IncCounter(common_utils.GNMI_SET_FAIL)
-			return nil, grpc.Errorf(codes.Unimplemented, "GNMI native write is disabled")
-		}
+		/* DELETE */
+		for _, path := range req.GetDelete() {
+			log.V(2).Infof("Delete path: %v", path)
 
-		// Fast path: bypass validation for allowed tables/SKUs
-		allUpdates := append(req.GetReplace(), req.GetUpdate()...)
-		if bypassResp, used, bypassErr := bypass.TrySet(ctx, prefix, req.GetDelete(), allUpdates); used {
-			if bypassErr != nil {
-				common_utils.IncCounter(common_utils.GNMI_SET_FAIL)
-				return nil, status.Error(codes.Internal, bypassErr.Error())
+			res := gnmipb.UpdateResult{
+				Path: path,
+				Op:   gnmipb.UpdateResult_DELETE,
 			}
-			common_utils.IncCounter(common_utils.GNMI_SET_BYPASS)
-			return bypassResp, nil
+
+			/* Add to Set response results. */
+			results = append(results, &res)
 		}
 
-		var targetDbName string
-		dc, err = sdc.NewMixedDbClient(paths, prefix, origin, encoding, s.config.ZmqPort, s.config.Vrf, &targetDbName)
-		authTarget = "gnmi_" + targetDbName
-	} else {
-		if s.config.EnableTranslibWrite == false {
+		/* REPLACE */
+		for _, path := range req.GetReplace() {
+			log.V(2).Infof("Replace path: %v ", path)
+
+			res := gnmipb.UpdateResult{
+				Path: path.GetPath(),
+				Op:   gnmipb.UpdateResult_REPLACE,
+			}
+			/* Add to Set response results. */
+			results = append(results, &res)
+		}
+
+		/* UPDATE */
+		for _, path := range req.GetUpdate() {
+			log.V(2).Infof("Update path: %v ", path)
+
+			res := gnmipb.UpdateResult{
+				Path: path.GetPath(),
+				Op:   gnmipb.UpdateResult_UPDATE,
+			}
+			/* Add to Set response results. */
+			results = append(results, &res)
+		}
+		err = dc.Set(req.GetDelete(), req.GetReplace(), req.GetUpdate())
+		if err != nil {
 			common_utils.IncCounter(common_utils.GNMI_SET_FAIL)
-			return nil, grpc.Errorf(codes.Unimplemented, "Translib write is disabled")
+		} else {
+			s.SaveStartupConfig()
 		}
-		/* Create Transl client. */
-		dc, err = sdc.NewTranslClient(prefix, nil, ctx, extensions)
-	}
 
+		resp := &gnmipb.SetResponse{
+			Prefix:   req.GetPrefix(),
+			Response: results,
+		}
+		return resp, err
+	}()
+
+	duration := time.Since(start)
 	if err != nil {
-		common_utils.IncCounter(common_utils.GNMI_SET_FAIL)
-		return nil, status.Error(codes.NotFound, err.Error())
-	}
-	defer dc.Close()
-
-	ctx, err = authenticate(s.config, ctx, authTarget, true)
-	if err != nil {
-		common_utils.IncCounter(common_utils.GNMI_SET_FAIL)
-		return nil, err
-	}
-	/* DELETE */
-	for _, path := range req.GetDelete() {
-		log.V(2).Infof("Delete path: %v", path)
-
-		res := gnmipb.UpdateResult{
-			Path: path,
-			Op:   gnmipb.UpdateResult_DELETE,
-		}
-
-		/* Add to Set response results. */
-		results = append(results, &res)
-	}
-
-	/* REPLACE */
-	for _, path := range req.GetReplace() {
-		log.V(2).Infof("Replace path: %v ", path)
-
-		res := gnmipb.UpdateResult{
-			Path: path.GetPath(),
-			Op:   gnmipb.UpdateResult_REPLACE,
-		}
-		/* Add to Set response results. */
-		results = append(results, &res)
-	}
-
-	/* UPDATE */
-	for _, path := range req.GetUpdate() {
-		log.V(2).Infof("Update path: %v ", path)
-
-		res := gnmipb.UpdateResult{
-			Path: path.GetPath(),
-			Op:   gnmipb.UpdateResult_UPDATE,
-		}
-		/* Add to Set response results. */
-		results = append(results, &res)
-	}
-	err = dc.Set(req.GetDelete(), req.GetReplace(), req.GetUpdate())
-	if err != nil {
-		common_utils.IncCounter(common_utils.GNMI_SET_FAIL)
+		log.Errorf("[GNMI-AUDIT] SetResponse user=%s peer=%s status=FAIL err=%v duration=%v",
+			auditUser, auditPeer, err, duration)
 	} else {
-		s.SaveStartupConfig()
+		log.Infof("[GNMI-AUDIT] SetResponse user=%s peer=%s status=OK duration=%v",
+			auditUser, auditPeer, duration)
 	}
 
-	resp := &gnmipb.SetResponse{
-		Prefix:   req.GetPrefix(),
-		Response: results,
-	}
 	return resp, err
 }
 

--- a/gnmi_server/server.go
+++ b/gnmi_server/server.go
@@ -1331,15 +1331,15 @@ func extractPeer(ctx context.Context) string {
 	return "unknown"
 }
 
-func logGnmiAuditResponse(method, user, peerAddr string, start time.Time, errPtr *error) {
+func logGnmiAuditResponse(method, user, peer string, start time.Time, errPtr *error) {
 	duration := time.Since(start)
 
 	if errPtr != nil && *errPtr != nil {
 		log.Errorf("[GNMI-AUDIT] %sResponse user=%s peer=%s status=FAIL err=%v duration=%v",
-			method, user, peerAddr, *errPtr, duration)
+			method, user, peer, *errPtr, duration)
 	} else {
 		log.Infof("[GNMI-AUDIT] %sResponse user=%s peer=%s status=OK duration=%v",
-			method, user, peerAddr, duration)
+			method, user, peer, duration)
 	}
 }
 

--- a/gnmi_server/server.go
+++ b/gnmi_server/server.go
@@ -53,6 +53,7 @@ import (
 	"google.golang.org/grpc/authz"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/tls/certprovider"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/reflection"
 	"google.golang.org/grpc/security/advancedtls"
@@ -1319,6 +1320,35 @@ func (s *Server) Capabilities(ctx context.Context, req *gnmipb.CapabilityRequest
 		SupportedEncodings: supportedEncodings,
 		GNMIVersion:        "0.7.0",
 		Extension:          exts}, nil
+}
+
+func extractUser(ctx context.Context) string {
+	rc, _ := common_utils.GetContext(ctx)
+	if rc != nil && rc.Auth.User != "" {
+		return rc.Auth.User
+	}
+
+	if md, ok := metadata.FromIncomingContext(ctx); ok {
+		for _, key := range []string{"username", "user", "x-remote-user"} {
+			if values := md.Get(key); len(values) > 0 && values[0] != "" {
+				return values[0]
+			}
+		}
+	}
+
+	if username, err := getUsername(ctx); err == nil && username != "" {
+		return username
+	}
+
+	return "unknown"
+}
+
+func extractPeer(ctx context.Context) string {
+	if pr, ok := peer.FromContext(ctx); ok && pr.Addr != nil {
+		return pr.Addr.String()
+	}
+
+	return "unknown"
 }
 
 // Obtain the user name as the last element of the SPIFFE ID.

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -7269,6 +7269,125 @@ func TestSrvAdvConfig(t *testing.T) {
 	}
 }
 
+// TestGnmiAuditLogging verifies that [GNMI-AUDIT] log entries are produced
+// with the correct method, user, peer, status, and error for Get and Set RPCs.
+func TestGnmiAuditLogging(t *testing.T) {
+	type auditCall struct {
+		method string
+		user   string
+		peer   string
+		status string
+		err    error
+	}
+
+	tests := []struct {
+		desc        string
+		setupServer func(t *testing.T) *Server
+		makeRequest func(t *testing.T, gClient pb.GNMIClient, ctx context.Context)
+		wantMethod  string
+		wantStatus  string
+		wantErrMsg  string
+	}{
+		{
+			desc:        "Get request logged as FAIL on auth failure",
+			setupServer: func(t *testing.T) *Server { return createAuthServer(t, 8081) },
+			makeRequest: func(t *testing.T, gClient pb.GNMIClient, ctx context.Context) {
+				gClient.Get(ctx, &pb.GetRequest{})
+			},
+			wantMethod: "Get",
+			wantStatus: "FAIL",
+			wantErrMsg: "Unauthenticated",
+		},
+		{
+			desc:        "Set request logged as FAIL on read-only server",
+			setupServer: func(t *testing.T) *Server { return createReadServer(t, 8081) },
+			makeRequest: func(t *testing.T, gClient pb.GNMIClient, ctx context.Context) {
+				gClient.Set(ctx, &pb.SetRequest{})
+			},
+			wantMethod: "Set",
+			wantStatus: "FAIL",
+			wantErrMsg: "read-only",
+		},
+		{
+			desc:        "Set request logged as FAIL on auth failure",
+			setupServer: func(t *testing.T) *Server { return createAuthServer(t, 8081) },
+			makeRequest: func(t *testing.T, gClient pb.GNMIClient, ctx context.Context) {
+				gClient.Set(ctx, &pb.SetRequest{})
+			},
+			wantMethod: "Set",
+			wantStatus: "FAIL",
+			wantErrMsg: "Unauthenticated",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var mu sync.Mutex
+			var captured auditCall
+
+			mock := gomonkey.ApplyFunc(logGnmiAuditResponse,
+				func(method, user, peer string, start time.Time, errPtr *error) {
+					mu.Lock()
+					defer mu.Unlock()
+					captured.method = method
+					captured.user = user
+					captured.peer = peer
+					if errPtr != nil && *errPtr != nil {
+						captured.status = "FAIL"
+						captured.err = *errPtr
+					} else {
+						captured.status = "OK"
+					}
+				})
+			defer mock.Reset()
+
+			s := tt.setupServer(t)
+			go runServer(t, s)
+			defer s.Stop()
+
+			tlsConfig := &tls.Config{InsecureSkipVerify: true}
+			opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
+			conn, err := grpc.Dial("127.0.0.1:8081", opts...)
+			if err != nil {
+				t.Fatalf("Dialing failed: %v", err)
+			}
+			defer conn.Close()
+
+			gClient := pb.NewGNMIClient(conn)
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			tt.makeRequest(t, gClient, ctx)
+			// Allow time for the deferred audit log to fire after RPC returns.
+			time.Sleep(200 * time.Millisecond)
+
+			mu.Lock()
+			gotMethod := captured.method
+			gotStatus := captured.status
+			gotErr := captured.err
+			gotPeer := captured.peer
+			mu.Unlock()
+
+			if gotMethod != tt.wantMethod {
+				t.Errorf("audit method: got %q, want %q", gotMethod, tt.wantMethod)
+			}
+			if gotStatus != tt.wantStatus {
+				t.Errorf("audit status: got %q, want %q", gotStatus, tt.wantStatus)
+			}
+			if gotPeer == "" || gotPeer == "unknown" {
+				t.Errorf("audit peer should be populated, got %q", gotPeer)
+			}
+			if tt.wantErrMsg != "" {
+				if gotErr == nil {
+					t.Errorf("expected audit error containing %q but got nil", tt.wantErrMsg)
+				} else if !strings.Contains(gotErr.Error(), tt.wantErrMsg) {
+					t.Errorf("audit error %q does not contain %q", gotErr.Error(), tt.wantErrMsg)
+				}
+			}
+		})
+	}
+}
+
 func TestSrvTestConfigLogsAndReturns(t *testing.T) {
 	// 1. Force error in the FIRST WriteFile (Server Certificate)
 	t.Run("CoverageCertWriteError", func(t *testing.T) {


### PR DESCRIPTION
Summary
This PR fixes GNMI audit logging in server.go for both Get() and Set().

Changes
Get():

keeps deferred request/response audit logs

removes problematic error-variable shadowing/redeclaration paths

uses clearer local variable names in pathz handling

Set():

switches to named returns so deferred response logging can cover all exits

adds a single deferred SetResponse audit log for success/failure

removes duplicated end-of-function response logging

keeps existing functional behavior and counters

Why
Previous changes had error-scope issues and non-uniform logging behavior on early returns. This update makes logging consistent and safer.

Validation
diagnostics show no errors in server.go
branch pushed: fix/gnmi-audit-logging-get-set
commit: 172f204

## Test Results
`TestGnmiAuditLogging` added in gnmi_server/server_test.go — 3 subtests all PASS:
- Get request logged as FAIL on auth failure
- Set request logged as FAIL on read-only server
- Set request logged as FAIL on auth failure

The complete TestGnmiAuditLogging is as follows:

root@docker-desktop:/src/sonic-gnmi# cd /src/sonic-gnmi
Logging -count=1root@docker-desktop:/src/sonic-gnmi# grep -n "TestGnmiAuditLogging" gnmi_server/server_test.go
7118:// TestGnmiAuditLogging verifies that [GNMI-AUDIT] log entries are produced
7120:func TestGnmiAuditLogging(t *testing.T) {
root@docker-desktop:/src/sonic-gnmi# go test -mod=vendor -v ./gnmi_server -run **TestGnmiAuditLogging** -count=1
#github.com/sonic-net/sonic-gnmi/sonic_data_client
cgo-gcc-prolog: In function ‘_cgo_09acf087b92e_Cfunc_Py_Finalize’:
cgo-gcc-prolog:69:49: warning: unused variable ‘_cgo_a’ [-Wunused-variable]
cgo-gcc-prolog: In function ‘_cgo_09acf087b92e_Cfunc_Py_Initialize’:
cgo-gcc-prolog:81:49: warning: unused variable ‘_cgo_a’ [-Wunused-variable]
libyang[0]: Unable to use search directory "schema/" (No such file or directory)
ERROR: logging before flag.Parse: I0703 06:20:00.944570   65664 util.go:332] [CVL] : Could not read platform schema location or no platform specific schema exists. <nil>
ERROR: logging before flag.Parse: W0703 06:20:00.949425   65664 db_redis_opts.go:165] _DBRedisOptsConfig:reconfigure: flags not parsed!
ERROR: logging before flag.Parse: I0703 06:20:00.949477   65664 db_redis_opts.go:175] _DBRedisOptsConfig:reconfigure: Handling signal.
ERROR: logging before flag.Parse: W0703 06:20:00.949483   65664 db_redis_opts.go:165] _DBRedisOptsConfig:reconfigure: flags not parsed!
ERROR: logging before flag.Parse: W0703 06:20:00.963029   65664 db_redis_opts.go:165] _DBRedisOptsConfig:reconfigure: flags not parsed!
ERROR: logging before flag.Parse: W0703 06:20:00.967376   65664 db_redis_opts.go:165] _DBRedisOptsConfig:reconfigure: flags not parsed!
ERROR: logging before flag.Parse: W0703 06:20:00.968744   65664 db_redis_opts.go:165] _DBRedisOptsConfig:reconfigure: flags not parsed!
ERROR: logging before flag.Parse: W0703 06:20:00.969878   65664 db_redis_opts.go:165] _DBRedisOptsConfig:reconfigure: flags not parsed!
ERROR: logging before flag.Parse: W0703 06:20:00.971500   65664 db_redis_opts.go:165] _DBRedisOptsConfig:reconfigure: flags not parsed!
ERROR: logging before flag.Parse: W0703 06:20:00.973013   65664 db_redis_opts.go:165] _DBRedisOptsConfig:reconfigure: flags not parsed!
ERROR: logging before flag.Parse: W0703 06:20:00.974517   65664 db_redis_opts.go:165] _DBRedisOptsConfig:reconfigure: flags not parsed!
ERROR: logging before flag.Parse: W0703 06:20:00.979949   65664 db_redis_opts.go:165] _DBRedisOptsConfig:reconfigure: flags not parsed!
ERROR: logging before flag.Parse: W0703 06:20:00.980008   65664 db_redis_opts.go:119] Database instance not present for the Db name: ERROR_DB
ERROR: logging before flag.Parse: W0703 06:20:01.003601   65664 db_redis_opts.go:165] _DBRedisOptsConfig:reconfigure: flags not parsed!
ERROR: logging before flag.Parse: W0703 06:20:01.003658   65664 db_redis_opts.go:119] Database instance not present for the Db name: EVENT_DB
ERROR: logging before flag.Parse: W0703 06:20:01.006957   65664 db_redis_opts.go:165] _DBRedisOptsConfig:reconfigure: flags not parsed!
ERROR: logging before flag.Parse: I0703 06:20:01.013269   65664 db_lock.go:234] ConfigDBClearLock:
ERROR: logging before flag.Parse: W0703 06:20:01.013312   65664 db_redis_opts.go:165] _DBRedisOptsConfig:reconfigure: flags not parsed!
ERROR: logging before flag.Parse: I0703 06:20:01.016736   65664 db_lock.go:134] unlock: Already Unlocked
ERROR: logging before flag.Parse: I0703 06:20:01.016816   65664 db_lock.go:242] ConfigDBClearLock: Lock Absent
ERROR: logging before flag.Parse: W0703 06:20:01.016864   65664 db_redis_opts.go:165] _DBRedisOptsConfig:reconfigure: flags not parsed!
ERROR: logging before flag.Parse: I0703 06:20:01.019066   65664 emitjson_select.go:68] Marker file /var/run/gnmi_server.test/use_ygot_emitjson not found (err = stat /var/run/gnmi_server.test/use_ygot_emitjson: no such file or directory). Will use internal EmitJSON
ERROR: logging before flag.Parse: I0703 06:20:01.109238   65664 xlate_utils.go:1366] [transformer.go:92]init.2 Yang model List: []
ERROR: logging before flag.Parse: I0703 06:20:01.178385   65664 xspec.go:150] xspec init done ...
ERROR: logging before flag.Parse: I0703 06:20:01.178468   65664 app_interface.go:117] Registering for path =/openconfig-acl:acl
ERROR: logging before flag.Parse: I0703 06:20:01.178475   65664 app_interface.go:117] Registering for path =/sonic-
ERROR: logging before flag.Parse: I0703 06:20:01.178479   65664 app_interface.go:117] Registering for path =*
ERROR: logging before flag.Parse: W0703 06:20:01.178484   65664 common_app.go:75] Failure in fetching model capabilities data.
ERROR: logging before flag.Parse: I0703 06:20:01.178497   65664 lldp_app.go:62] Init called for LLDP modules module
ERROR: logging before flag.Parse: I0703 06:20:01.178502   65664 app_interface.go:117] Registering for path =/openconfig-lldp:lldp
ERROR: logging before flag.Parse: I0703 06:20:01.178514   65664 pfm_app.go:42] Init called for Platform module
ERROR: logging before flag.Parse: I0703 06:20:01.178518   65664 app_interface.go:117] Registering for path =/openconfig-platform:components
ERROR: logging before flag.Parse: I0703 06:20:01.178545   65664 sys_app.go:54] SysApp: Init called for System module
ERROR: logging before flag.Parse: I0703 06:20:01.178549   65664 app_interface.go:117] Registering for path =/openconfig-system:systemERROR: logging before flag.Parse: E0703 06:20:01.178587   65664 version.go:141] Error loading version config file; err=open /usr/models/yang/version.xml: no such file or directory
ERROR: logging before flag.Parse: E0703 06:20:01.178602   65664 version.go:142] API VERSION CHECK IS DISABLED
ERROR: logging before flag.Parse: I0703 06:20:01.178607   65664 app_interface.go:117] Registering for path =/ietf-yang-library:modules-state
=== RUN   TestGnmiAuditLogging
=== RUN   TestGnmiAuditLogging/Get_request_logged_as_FAIL_on_auth_failure
=== RUN   TestGnmiAuditLogging/Set_request_logged_as_FAIL_on_read-only_server
=== RUN   TestGnmiAuditLogging/Set_request_logged_as_FAIL_on_auth_failure
--- **PASS: TestGnmiAuditLogging** (6.17s)
    --- **PASS: TestGnmiAuditLogging/Get_request_logged_as_FAIL_on_auth_failure** (0.60s)
    --- **PASS: TestGnmiAuditLogging/Set_request_logged_as_FAIL_on_read-only_server** (2.16s)
    --- **PASS: TestGnmiAuditLogging/Set_request_logged_as_FAIL_on_auth_failure** (3.41s)
PASS
ok      github.com/sonic-net/sonic-gnmi/gnmi_server     6.667s


The dedicated audit test passed in Docker.
The important part of your output is:
•	[=== RUN TestGnmiAuditLogging](vscode-file://vscode-app/c:/Users/weimingxu/AppData/Local/Programs/Microsoft%20VS%20Code/6a44c352bd/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
•	three subtests all PASS
•	final PASS
•	package [ok](vscode-file://vscode-app/c:/Users/weimingxu/AppData/Local/Programs/Microsoft%20VS%20Code/6a44c352bd/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
So the new audit-logging unit test in [server_test.go:7120](vscode-file://vscode-app/c:/Users/weimingxu/AppData/Local/Programs/Microsoft%20VS%20Code/6a44c352bd/resources/app/out/vs/code/electron-browser/workbench/workbench.html) is good. The earlier ERROR: logging before flag.Parse, version.xml warnings, and cgo warnings did not fail the test run.
