### PR TITLE
[gnoi] Increase log verbosity for JsonPatch in SetIncrementalConfig

### DIFF
--- a/sonic_data_client/mixed_db_client.go
+++ b/sonic_data_client/mixed_db_client.go
@@ -1539,7 +1539,7 @@ func (c *MixedDbClient) SetIncrementalConfig(delete []*gnmipb.Path, replace []*g
 	if err != nil {
 		return err
 	}
-	log.V(2).Infof("JsonPatch: %s", text)
+	log.V(3).Infof("JsonPatch: %s", text)
 	patchFile := c.workPath + "/gcu.patch"
 	err = ioutil.WriteFile(patchFile, []byte(text), 0644)
 	if err != nil {


### PR DESCRIPTION
#### Why I did it

The `JsonPatch` payload logged in `SetIncrementalConfig` (`sonic_data_client/mixed_db_client.go`) can be large and contains the full incremental config patch. It was logged at `V(2)`, which made it appear in normal logs (glog verbosity `v=2`) and added noise. Move the log line from `V(2)` to `V(3)` so it is only emitted at higher verbosity.

#### How I did it

Changed the `JsonPatch` log statement in `SetIncrementalConfig` from `log.V(2)` to `log.V(3)`:

```go
- log.V(2).Infof("JsonPatch: %s", text)
+ log.V(3).Infof("JsonPatch: %s", text)
```

#### How to verify it

Applied a CONFIG_DB `PORT|Ethernet0` update on vlab-01 with glog verbosity `v=2` and inspected the gnmi-native logs.

**Before the change** — the `JsonPatch` content is logged at `V(2)` (see `mixed_db_client.go:1542`):

```
2026 Jun 29 23:10:19.419714 vlab-01 INFO gnmi#supervisord: gnmi-native I0629 23:10:19.416166 1549813 server.go:1202] Update path: path:{origin:"sonic-db"  elem:{name:"CONFIG_DB"}  elem:{name:"localhost"}  elem:{name:"PORT"}  elem:{name:"Ethernet0"}}  val:{json_ietf_val:"{\"mtu\":\"9100\",\"admin_status\":\"up\"}"}
2026 Jun 29 23:10:19.419735 vlab-01 INFO gnmi#supervisord: gnmi-native I0629 23:10:19.417559 1549813 dbus_client.go:92] DbusClient: NewDbusClient
2026 Jun 29 23:10:19.955108 vlab-01 INFO gnmi#supervisord: gnmi-native I0629 23:10:19.954688 1549813 mixed_db_client.go:1503] Path #origin:"sonic-db"  elem:{name:"PORT"}  elem:{name:"Ethernet0"}
2026 Jun 29 23:10:19.955125 vlab-01 INFO gnmi#supervisord: gnmi-native I0629 23:10:19.954776 1549813 mixed_db_client.go:1542] JsonPatch: [{"op":"add","path":"/PORT/Ethernet0","value":{"admin_status":"up","mtu":"9100"}}]
2026 Jun 29 23:10:21.421997 vlab-01 INFO gnmi#supervisord: gnmi-native 2026/06/29 23:10:21 INFO: [transport] [server-transport 0xc001b0b800] Closing: EOF
2026 Jun 29 23:10:21.422024 vlab-01 INFO gnmi#supervisord: gnmi-native 2026/06/29 23:10:21 INFO: [transport] [server-transport 0xc001b0b800] loopyWriter exiting with error: transport closed by client
```

**After the change** — at the same `v=2` verbosity, the surrounding `V(2)` lines are still present but no `JsonPatch:` line appears (it is now gated at `V(3)`):

```
2026 Jun 30 20:12:17.818079 vlab-01 INFO gnmi#supervisord: gnmi-native I0630 20:12:17.814422 1958749 server.go:1219] Update path: path:{origin:"sonic-db"  elem:{name:"CONFIG_DB"}  elem:{name:"localhost"}  elem:{name:"PORT"}  elem:{name:"Ethernet0"}  elem:{name:"mtu"}}  val:{json_ietf_val:"\"9100\""}
2026 Jun 30 20:12:17.818100 vlab-01 INFO gnmi#supervisord: gnmi-native I0630 20:12:17.815285 1958749 dbus_client.go:92] DbusClient: NewDbusClient
2026 Jun 30 20:12:18.361651 vlab-01 INFO gnmi#supervisord: gnmi-native I0630 20:12:18.361100 1958749 mixed_db_client.go:1503] Path #origin:"sonic-db"  elem:{name:"PORT"}  elem:{name:"Ethernet0"}  elem:{name:"mtu"}
2026 Jun 30 20:12:21.596788 vlab-01 INFO gnmi#supervisord: gnmi-native 2026/06/30 20:12:21 INFO: [transport] [server-transport 0xc00162ac00] Closing: EOF
2026 Jun 30 20:12:21.596813 vlab-01 INFO gnmi#supervisord: gnmi-native 2026/06/30 20:12:21 INFO: [transport] [server-transport 0xc00162ac00] loopyWriter exiting with error: transport closed by client
```

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog

Move `JsonPatch` log in `SetIncrementalConfig` from `V(2)` to `V(3)` to reduce log noise at default verbosity.

#### Link to config_db schema for YANG module changes

N/A
