### PR TITLE
[github]: Add backport test evidence sections

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,16 +21,51 @@
 <!--
 - Note we only backport fixes to a release branch, *not* features!
 - Please also provide a reason for the backporting below.
+- If you request a backport/cherry-pick, provide both:
+  1. A GitHub issue or Microsoft ADO work item describing the failure.
+  2. Test evidence from the target release branch(es) requested below,
+     not only from master.
 - e.g.
 - [x] 202006
 -->
 
-- [ ] 201811
-- [ ] 201911
-- [ ] 202006
-- [ ] 202012
-- [ ] 202106
-- [ ] 202111
+- [ ] 202305
+- [ ] 202311
+- [ ] 202405
+- [ ] 202411
+- [ ] 202505
+- [ ] 202511
+- [ ] 202605
+
+Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
+Failure type: <!-- day-one issue / regression / other -->
+
+#### Tested branch
+
+<!--
+- Select each branch where the change was tested.
+- If you request a backport/cherry-pick, select the base branch and the tested
+  target release branch(es).
+-->
+
+- [ ] master
+- [ ] 202305
+- [ ] 202311
+- [ ] 202405
+- [ ] 202411
+- [ ] 202505
+- [ ] 202511
+- [ ] 202605
+- [ ] N/A
+
+#### Test result
+
+<!--
+- Provide the tested image version and test evidence for each selected branch.
+- e.g.
+- master: 20260716.01 - <test result or link>
+- 202605: 20260531.42 - <test result or link>
+-->
 
 #### Description for the changelog
 <!--


### PR DESCRIPTION
#### Why I did it

Modernize the backport section of the `.github/pull_request_template.md`
template to match the tracking and target-branch test-evidence structure
introduced in sonic-net/sonic-buildimage#28464 and sonic-net/sonic-mgmt#26279.
This is a template-only documentation change with no backport requested for
this PR itself.

##### Work item tracking
- Microsoft ADO (number only): N/A (template-only change)

#### How I did it

- Kept the existing `#### Which release branch to backport (provide reason
  below if selected)` heading and updated its hidden instructions to require
  a GitHub issue or Microsoft ADO work item describing the failure plus
  test evidence from the target release branch(es).
- Replaced the stale backport checkbox list (201811, 201911, 202006, 202012,
  202106, 202111) with the currently active release branches: 202305,
  202311, 202405, 202411, 202505, 202511, 202605.
- Added visible `Tracking issue/work item for backport/cherry-pick request`
  and `Failure type` fields after the backport checkboxes.
- Added a new `#### Tested branch` section with hidden instructions and
  checkboxes for master, the seven active release branches, and N/A.
- Added a new `#### Test result` section asking for tested image/build
  version and evidence for each selected branch, with examples for master
  and 202605.
- Preserved the changelog, config_db schema link, and cute animal sections
  unchanged. No automation code, labels, or unrelated changes were added.

#### How to verify it

Render `.github/pull_request_template.md` on GitHub (e.g. via the "Preview"
tab or by opening this PR, which uses the updated template) and confirm all
sections render correctly with valid Markdown, matching the structure used
in sonic-net/sonic-buildimage#28464 and sonic-net/sonic-mgmt#26279.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A - template-only change, no backport requested.
Failure type: N/A

#### Tested branch

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605
- [x] N/A

#### Test result

N/A - this is a template-only Markdown validation change. Verified by
rendering the template and running `git diff --check` locally to confirm
no whitespace/structural issues.

#### Description for the changelog

Modernize PR template backport section with tracking and target-branch test-evidence fields, matching sonic-net/sonic-buildimage#28464 and sonic-net/sonic-mgmt#26279.

#### Link to config_db schema for YANG module changes

N/A - no YANG/config_db changes in this PR.

#### A picture of a cute animal (not mandatory but encouraged)

🦫
