### PR TITLE
telemetry: resolve no-TLS link-local bind by interface

### DIFF
--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -52,6 +52,7 @@ type TelemetryConfig struct {
 	ZmqPort                  *string
 	Insecure                 *bool
 	NoTLS                    *bool
+	AllowNoTLSLinkLocal      *bool
 	AllowNoClientCert        *bool
 	JwtRefInt                *uint64
 	JwtValInt                *uint64
@@ -181,6 +182,7 @@ func setupFlags(fs *flag.FlagSet) (*TelemetryConfig, *gnmi.Config, error) {
 		ZmqPort:                  fs.String("zmq_port", "", "Orchagent ZMQ port, when not set or empty string telemetry server will switch to Redis based communication channel."),
 		Insecure:                 fs.Bool("insecure", false, "Skip providing TLS cert and key, for testing only!"),
 		NoTLS:                    fs.Bool("noTLS", false, "disable TLS, for testing only!"),
+		AllowNoTLSLinkLocal:      fs.Bool("allow_no_tls_link_local", false, "Allow --noTLS to bind an IPv4 link-local address on a trusted local network."),
 		AllowNoClientCert:        fs.Bool("allow_no_client_auth", false, "When set, telemetry server will request but not require a client certificate."),
 		JwtRefInt:                fs.Uint64("jwt_refresh_int", 900, "Seconds before JWT expiry the token can be refreshed."),
 		JwtValInt:                fs.Uint64("jwt_valid_int", 3600, "Seconds that JWT token is valid for."),
@@ -254,10 +256,14 @@ func setupFlags(fs *flag.FlagSet) (*TelemetryConfig, *gnmi.Config, error) {
 
 	if *telemetryCfg.NoTLS {
 		ip := net.ParseIP(*telemetryCfg.BindAddress)
-		if ip == nil || !ip.IsLoopback() {
+		linkLocalAllowed := *telemetryCfg.AllowNoTLSLinkLocal && ip != nil && ip.To4() != nil && ip.IsLinkLocalUnicast()
+		if ip == nil || (!ip.IsLoopback() && !linkLocalAllowed) {
 			return nil, nil, fmt.Errorf(
-				"--noTLS requires --bind_address to be a loopback address (e.g. 127.0.0.1 or ::1) " +
-					"to prevent cleartext gRPC exposure over the network")
+				"--noTLS requires --bind_address to be a loopback address (e.g. 127.0.0.1 or ::1); " +
+					"an IPv4 link-local address requires --allow_no_tls_link_local")
+		}
+		if linkLocalAllowed && *telemetryCfg.GnmiVrf != "" && *telemetryCfg.GnmiVrf != "default" {
+			return nil, nil, fmt.Errorf("--allow_no_tls_link_local cannot be used with a non-default --gnmi_vrf")
 		}
 	}
 

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -42,7 +42,11 @@ const (
 	linkLocalAddressRetryDelay  = time.Second
 )
 
-var resolveIPv4LinkLocalAddress = ipv4LinkLocalAddress
+var (
+	interfaceByName             = net.InterfaceByName
+	interfaceAddresses          = func(iface *net.Interface) ([]net.Addr, error) { return iface.Addrs() }
+	resolveIPv4LinkLocalAddress = ipv4LinkLocalAddress
+)
 
 type TelemetryConfig struct {
 	UserAuth                 gnmi.AuthTypes
@@ -366,12 +370,12 @@ func setupFlags(fs *flag.FlagSet) (*TelemetryConfig, *gnmi.Config, error) {
 }
 
 func ipv4LinkLocalAddress(interfaceName string) (string, error) {
-	iface, err := net.InterfaceByName(interfaceName)
+	iface, err := interfaceByName(interfaceName)
 	if err != nil {
 		return "", fmt.Errorf("cannot find link-local interface %q: %w", interfaceName, err)
 	}
 
-	addresses, err := iface.Addrs()
+	addresses, err := interfaceAddresses(iface)
 	if err != nil {
 		return "", fmt.Errorf("cannot read addresses for link-local interface %q: %w", interfaceName, err)
 	}

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -37,7 +37,12 @@ const (
 	ServerStop    ServerControlValue = iota // 0
 	ServerStart   ServerControlValue = iota // 1
 	ServerRestart ServerControlValue = iota // 2
+
+	linkLocalAddressWaitTimeout = 30 * time.Second
+	linkLocalAddressRetryDelay  = time.Second
 )
+
+var resolveIPv4LinkLocalAddress = ipv4LinkLocalAddress
 
 type TelemetryConfig struct {
 	UserAuth                 gnmi.AuthTypes
@@ -52,7 +57,7 @@ type TelemetryConfig struct {
 	ZmqPort                  *string
 	Insecure                 *bool
 	NoTLS                    *bool
-	AllowNoTLSLinkLocal      *bool
+	NoTLSLinkLocalInterface  *string
 	AllowNoClientCert        *bool
 	JwtRefInt                *uint64
 	JwtValInt                *uint64
@@ -87,7 +92,7 @@ type TelemetryConfig struct {
 func main() {
 	err := runTelemetry(os.Args)
 	if err != nil {
-		log.Errorf("Unable to setup telemetry config due to err: %v", err)
+		log.Fatalf("Unable to setup telemetry config due to err: %v", err)
 	}
 }
 
@@ -182,7 +187,7 @@ func setupFlags(fs *flag.FlagSet) (*TelemetryConfig, *gnmi.Config, error) {
 		ZmqPort:                  fs.String("zmq_port", "", "Orchagent ZMQ port, when not set or empty string telemetry server will switch to Redis based communication channel."),
 		Insecure:                 fs.Bool("insecure", false, "Skip providing TLS cert and key, for testing only!"),
 		NoTLS:                    fs.Bool("noTLS", false, "disable TLS, for testing only!"),
-		AllowNoTLSLinkLocal:      fs.Bool("allow_no_tls_link_local", false, "Allow --noTLS to bind an IPv4 link-local address on a trusted local network."),
+		NoTLSLinkLocalInterface:  fs.String("no_tls_link_local_interface", "", "Bind --noTLS to the only IPv4 link-local address on this interface."),
 		AllowNoClientCert:        fs.Bool("allow_no_client_auth", false, "When set, telemetry server will request but not require a client certificate."),
 		JwtRefInt:                fs.Uint64("jwt_refresh_int", 900, "Seconds before JWT expiry the token can be refreshed."),
 		JwtValInt:                fs.Uint64("jwt_valid_int", 3600, "Seconds that JWT token is valid for."),
@@ -254,16 +259,30 @@ func setupFlags(fs *flag.FlagSet) (*TelemetryConfig, *gnmi.Config, error) {
 		log.Infof("Log level must be greater than 0, setting to default value of 2")
 	}
 
-	if *telemetryCfg.NoTLS {
-		ip := net.ParseIP(*telemetryCfg.BindAddress)
-		linkLocalAllowed := *telemetryCfg.AllowNoTLSLinkLocal && ip != nil && ip.To4() != nil && ip.IsLinkLocalUnicast()
-		if ip == nil || (!ip.IsLoopback() && !linkLocalAllowed) {
-			return nil, nil, fmt.Errorf(
-				"--noTLS requires --bind_address to be a loopback address (e.g. 127.0.0.1 or ::1); " +
-					"an IPv4 link-local address requires --allow_no_tls_link_local")
+	if *telemetryCfg.NoTLSLinkLocalInterface != "" {
+		if !*telemetryCfg.NoTLS {
+			return nil, nil, fmt.Errorf("--no_tls_link_local_interface requires --noTLS")
 		}
-		if linkLocalAllowed && *telemetryCfg.GnmiVrf != "" && *telemetryCfg.GnmiVrf != "default" {
-			return nil, nil, fmt.Errorf("--allow_no_tls_link_local cannot be used with a non-default --gnmi_vrf")
+		if *telemetryCfg.BindAddress != "" {
+			return nil, nil, fmt.Errorf("--no_tls_link_local_interface cannot be used with --bind_address")
+		}
+		if *telemetryCfg.GnmiVrf != "" && *telemetryCfg.GnmiVrf != "default" {
+			return nil, nil, fmt.Errorf("--no_tls_link_local_interface cannot be used with a non-default --gnmi_vrf")
+		}
+	}
+
+	if *telemetryCfg.NoTLS {
+		if *telemetryCfg.NoTLSLinkLocalInterface != "" {
+			bindAddress, err := waitForIPv4LinkLocalAddress(*telemetryCfg.NoTLSLinkLocalInterface, linkLocalAddressWaitTimeout, linkLocalAddressRetryDelay)
+			if err != nil {
+				return nil, nil, err
+			}
+			*telemetryCfg.BindAddress = bindAddress
+		} else {
+			ip := net.ParseIP(*telemetryCfg.BindAddress)
+			if ip == nil || !ip.IsLoopback() {
+				return nil, nil, fmt.Errorf("--noTLS requires --bind_address to be a loopback address (e.g. 127.0.0.1 or ::1)")
+			}
 		}
 	}
 
@@ -344,6 +363,49 @@ func setupFlags(fs *flag.FlagSet) (*TelemetryConfig, *gnmi.Config, error) {
 	cfg.AuthzPolicyFile = string(*telemetryCfg.AuthzPolicyFile)
 	cfg.EnableStreamMultiplexing = *telemetryCfg.EnableStreamMultiplexing
 	return telemetryCfg, cfg, nil
+}
+
+func ipv4LinkLocalAddress(interfaceName string) (string, error) {
+	iface, err := net.InterfaceByName(interfaceName)
+	if err != nil {
+		return "", fmt.Errorf("cannot find link-local interface %q: %w", interfaceName, err)
+	}
+
+	addresses, err := iface.Addrs()
+	if err != nil {
+		return "", fmt.Errorf("cannot read addresses for link-local interface %q: %w", interfaceName, err)
+	}
+
+	return selectIPv4LinkLocalAddress(interfaceName, addresses)
+}
+
+func waitForIPv4LinkLocalAddress(interfaceName string, timeout, retryDelay time.Duration) (string, error) {
+	deadline := time.Now().Add(timeout)
+	for {
+		address, err := resolveIPv4LinkLocalAddress(interfaceName)
+		if err == nil {
+			return address, nil
+		}
+		if !time.Now().Before(deadline) {
+			return "", fmt.Errorf("timed out waiting for IPv4 link-local address on interface %q: %w", interfaceName, err)
+		}
+		time.Sleep(retryDelay)
+	}
+}
+
+func selectIPv4LinkLocalAddress(interfaceName string, addresses []net.Addr) (string, error) {
+	var linkLocalAddresses []string
+	for _, address := range addresses {
+		ip, _, err := net.ParseCIDR(address.String())
+		if err == nil && ip.To4() != nil && ip.IsLinkLocalUnicast() {
+			linkLocalAddresses = append(linkLocalAddresses, ip.String())
+		}
+	}
+
+	if len(linkLocalAddresses) != 1 {
+		return "", fmt.Errorf("link-local interface %q must have exactly one IPv4 link-local address; found %d", interfaceName, len(linkLocalAddresses))
+	}
+	return linkLocalAddresses[0], nil
 }
 
 func isFlagPassed(fs *flag.FlagSet, name string) bool {

--- a/telemetry/telemetry_test.go
+++ b/telemetry/telemetry_test.go
@@ -1472,8 +1472,9 @@ func TestCertAuthDisabledWhenNoCaCert(t *testing.T) {
 	}
 }
 
-func TestNoTLSRequiresLoopbackAddress(t *testing.T) {
-	// --noTLS must be rejected unless --bind_address is a loopback address.
+func TestNoTLSBindAddress(t *testing.T) {
+	// --noTLS must be rejected unless --bind_address is loopback or an explicitly
+	// allowed IPv4 link-local address.
 	originalArgs := os.Args
 	defer func() { os.Args = originalArgs }()
 
@@ -1487,6 +1488,12 @@ func TestNoTLSRequiresLoopbackAddress(t *testing.T) {
 		{"loopback ipv4", []string{"cmd", "-port", "8080", "-noTLS", "-bind_address", "127.0.0.1"}, false},
 		{"loopback ipv4 alt", []string{"cmd", "-port", "8080", "-noTLS", "-bind_address", "127.0.0.2"}, false},
 		{"loopback ipv6", []string{"cmd", "-port", "8080", "-noTLS", "-bind_address", "::1"}, false},
+		{"link-local without opt-in", []string{"cmd", "-port", "8080", "-noTLS", "-bind_address", "169.254.200.1"}, true},
+		{"link-local with opt-in", []string{"cmd", "-port", "8080", "-noTLS", "-bind_address", "169.254.200.1", "-allow_no_tls_link_local"}, false},
+		{"link-local with default vrf", []string{"cmd", "-port", "8080", "-noTLS", "-bind_address", "169.254.200.1", "-allow_no_tls_link_local", "-gnmi_vrf", "default"}, false},
+		{"link-local with non-default vrf", []string{"cmd", "-port", "8080", "-noTLS", "-bind_address", "169.254.200.1", "-allow_no_tls_link_local", "-gnmi_vrf", "mgmt"}, true},
+		{"private with opt-in", []string{"cmd", "-port", "8080", "-noTLS", "-bind_address", "10.0.0.1", "-allow_no_tls_link_local"}, true},
+		{"ipv6 link-local with opt-in", []string{"cmd", "-port", "8080", "-noTLS", "-bind_address", "fe80::1", "-allow_no_tls_link_local"}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/telemetry/telemetry_test.go
+++ b/telemetry/telemetry_test.go
@@ -1561,6 +1561,43 @@ func TestWaitForIPv4LinkLocalAddress(t *testing.T) {
 	}
 }
 
+func TestIPv4LinkLocalAddress(t *testing.T) {
+	originalInterfaceByName := interfaceByName
+	originalInterfaceAddresses := interfaceAddresses
+	defer func() {
+		interfaceByName = originalInterfaceByName
+		interfaceAddresses = originalInterfaceAddresses
+	}()
+
+	interfaceByName = func(name string) (*net.Interface, error) {
+		return nil, errors.New("not found")
+	}
+	if _, err := ipv4LinkLocalAddress("eth0-midplane"); err == nil {
+		t.Fatal("expected interface lookup error, got nil")
+	}
+
+	interfaceByName = func(name string) (*net.Interface, error) {
+		return &net.Interface{Name: name}, nil
+	}
+	interfaceAddresses = func(iface *net.Interface) ([]net.Addr, error) {
+		return nil, errors.New("addresses unavailable")
+	}
+	if _, err := ipv4LinkLocalAddress("eth0-midplane"); err == nil {
+		t.Fatal("expected address lookup error, got nil")
+	}
+
+	interfaceAddresses = func(iface *net.Interface) ([]net.Addr, error) {
+		return []net.Addr{&net.IPNet{IP: net.ParseIP("169.254.200.1"), Mask: net.CIDRMask(24, 32)}}, nil
+	}
+	address, err := ipv4LinkLocalAddress("eth0-midplane")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if address != "169.254.200.1" {
+		t.Fatalf("address = %q, want 169.254.200.1", address)
+	}
+}
+
 func TestSelectIPv4LinkLocalAddress(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/telemetry/telemetry_test.go
+++ b/telemetry/telemetry_test.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"io/ioutil"
 	"math/big"
+	"net"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -1473,8 +1474,6 @@ func TestCertAuthDisabledWhenNoCaCert(t *testing.T) {
 }
 
 func TestNoTLSBindAddress(t *testing.T) {
-	// --noTLS must be rejected unless --bind_address is loopback or an explicitly
-	// allowed IPv4 link-local address.
 	originalArgs := os.Args
 	defer func() { os.Args = originalArgs }()
 
@@ -1488,12 +1487,11 @@ func TestNoTLSBindAddress(t *testing.T) {
 		{"loopback ipv4", []string{"cmd", "-port", "8080", "-noTLS", "-bind_address", "127.0.0.1"}, false},
 		{"loopback ipv4 alt", []string{"cmd", "-port", "8080", "-noTLS", "-bind_address", "127.0.0.2"}, false},
 		{"loopback ipv6", []string{"cmd", "-port", "8080", "-noTLS", "-bind_address", "::1"}, false},
-		{"link-local without opt-in", []string{"cmd", "-port", "8080", "-noTLS", "-bind_address", "169.254.200.1"}, true},
-		{"link-local with opt-in", []string{"cmd", "-port", "8080", "-noTLS", "-bind_address", "169.254.200.1", "-allow_no_tls_link_local"}, false},
-		{"link-local with default vrf", []string{"cmd", "-port", "8080", "-noTLS", "-bind_address", "169.254.200.1", "-allow_no_tls_link_local", "-gnmi_vrf", "default"}, false},
-		{"link-local with non-default vrf", []string{"cmd", "-port", "8080", "-noTLS", "-bind_address", "169.254.200.1", "-allow_no_tls_link_local", "-gnmi_vrf", "mgmt"}, true},
-		{"private with opt-in", []string{"cmd", "-port", "8080", "-noTLS", "-bind_address", "10.0.0.1", "-allow_no_tls_link_local"}, true},
-		{"ipv6 link-local with opt-in", []string{"cmd", "-port", "8080", "-noTLS", "-bind_address", "fe80::1", "-allow_no_tls_link_local"}, true},
+		{"link-local bind address", []string{"cmd", "-port", "8080", "-noTLS", "-bind_address", "169.254.200.1"}, true},
+		{"loopback with non-default vrf", []string{"cmd", "-port", "8080", "-noTLS", "-bind_address", "127.0.0.1", "-gnmi_vrf", "mgmt"}, false},
+		{"interface and bind address", []string{"cmd", "-port", "8080", "-noTLS", "-bind_address", "127.0.0.1", "-no_tls_link_local_interface", "lo"}, true},
+		{"interface without noTLS", []string{"cmd", "-port", "8080", "-insecure", "-no_tls_link_local_interface", "lo"}, true},
+		{"interface with non-default vrf", []string{"cmd", "-port", "8080", "-noTLS", "-no_tls_link_local_interface", "lo", "-gnmi_vrf", "mgmt"}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1505,6 +1503,87 @@ func TestNoTLSBindAddress(t *testing.T) {
 			}
 			if !tt.wantErr && err != nil {
 				t.Errorf("unexpected error for args %v: %v", tt.args, err)
+			}
+		})
+	}
+}
+
+func TestNoTLSLinkLocalInterface(t *testing.T) {
+	originalResolver := resolveIPv4LinkLocalAddress
+	defer func() { resolveIPv4LinkLocalAddress = originalResolver }()
+	resolveIPv4LinkLocalAddress = func(interfaceName string) (string, error) {
+		if interfaceName != "eth0-midplane" {
+			t.Fatalf("unexpected interface %q", interfaceName)
+		}
+		return "169.254.200.1", nil
+	}
+
+	originalArgs := os.Args
+	defer func() { os.Args = originalArgs }()
+	os.Args = []string{"cmd", "-port", "8080", "-noTLS", "-no_tls_link_local_interface", "eth0-midplane"}
+	telemetryCfg, cfg, err := setupFlags(flag.NewFlagSet("test", flag.ContinueOnError))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := *telemetryCfg.BindAddress; got != "169.254.200.1" {
+		t.Fatalf("telemetry bind address = %q, want 169.254.200.1", got)
+	}
+	if got := cfg.BindAddress; got != "169.254.200.1" {
+		t.Fatalf("gNMI bind address = %q, want 169.254.200.1", got)
+	}
+}
+
+func TestWaitForIPv4LinkLocalAddress(t *testing.T) {
+	originalResolver := resolveIPv4LinkLocalAddress
+	defer func() { resolveIPv4LinkLocalAddress = originalResolver }()
+
+	calls := 0
+	resolveIPv4LinkLocalAddress = func(interfaceName string) (string, error) {
+		calls++
+		if calls == 1 {
+			return "", errors.New("address not ready")
+		}
+		return "169.254.200.1", nil
+	}
+	address, err := waitForIPv4LinkLocalAddress("eth0-midplane", time.Second, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if address != "169.254.200.1" || calls != 2 {
+		t.Fatalf("address = %q, calls = %d; want 169.254.200.1 after two calls", address, calls)
+	}
+
+	resolveIPv4LinkLocalAddress = func(interfaceName string) (string, error) {
+		return "", errors.New("address not ready")
+	}
+	if _, err := waitForIPv4LinkLocalAddress("eth0-midplane", 0, 0); err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+}
+
+func TestSelectIPv4LinkLocalAddress(t *testing.T) {
+	tests := []struct {
+		name      string
+		addresses []net.Addr
+		want      string
+		wantErr   bool
+	}{
+		{"one link-local", []net.Addr{&net.IPNet{IP: net.ParseIP("10.0.0.1"), Mask: net.CIDRMask(24, 32)}, &net.IPNet{IP: net.ParseIP("169.254.200.1"), Mask: net.CIDRMask(24, 32)}, &net.IPNet{IP: net.ParseIP("fe80::1"), Mask: net.CIDRMask(64, 128)}}, "169.254.200.1", false},
+		{"no link-local", []net.Addr{&net.IPNet{IP: net.ParseIP("10.0.0.1"), Mask: net.CIDRMask(24, 32)}}, "", true},
+		{"two link-local", []net.Addr{&net.IPNet{IP: net.ParseIP("169.254.200.1"), Mask: net.CIDRMask(24, 32)}, &net.IPNet{IP: net.ParseIP("169.254.200.2"), Mask: net.CIDRMask(24, 32)}}, "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := selectIPv4LinkLocalAddress("eth0-midplane", tt.addresses)
+			if tt.wantErr && err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatal(err)
+			}
+			if got != tt.want {
+				t.Fatalf("address = %q, want %q", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
#### Why I did it

SmartSwitch DPUs expose plaintext gNMI/gNOI only on their chassis-internal
IPv4 link-local midplane. The NPU proxy must reach that address, but the current
`--noTLS` validation permits loopback addresses only. This makes it impossible
to restore proxy connectivity without removing the cleartext bind protection
entirely.

This is the binary-side dependency for
https://github.com/sonic-net/sonic-buildimage/issues/28540.

#### How I did it

- Added an explicit, default-off `--no_tls_link_local_interface` option.
- Kept loopback as the default requirement for `--noTLS`.
- Resolve exactly one IPv4 link-local address from the named interface and bind
  that concrete address.
- Wait up to 30 seconds for address readiness, then fail nonzero if the address
  remains unavailable or ambiguous.
- Reject simultaneous explicit bind-address configuration and use with a
  non-default gNMI VRF.
- Added deterministic tests for arguments, delayed readiness, timeout, and
  zero/one/multiple link-local address selection.

#### How to verify it

- Native arm64 SONiC package and container build succeeded, including gofmt
  validation and compilation of the telemetry binary.
- On a physical SmartSwitch DPU, the built binary resolved the concrete
  `eth0-midplane` IPv4 link-local address itself.
- With the dependent launch-script change, both DPU services bound only to the
  concrete midplane link-local address. Direct gNOI `System.Time` and the real
  NPU UDS metadata-routed DPUProxy call succeeded.
- Negative TCP probes confirmed the services were not listening on the DPU
  management address or loopback.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: regression

#### Tested branch

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605
- [ ] N/A

#### Test result

- master: native arm64 build passed; physical SmartSwitch direct and proxied
  gNOI validation passed.

#### Description for the changelog

Allow explicitly selected plaintext gNMI binding to an interface's IPv4 link-local address.

#### Link to config_db schema for YANG module changes

N/A
