### PR TITLE
Component test for Components Model - SoftwareComponents

### DIFF
--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -486,6 +486,424 @@ func TestGnmiGetInterfaceCountersVPath(t *testing.T) {
 	}
 }
 
+func TestGnmiGetSoftwareComponents(t *testing.T) {
+	// 1. Start gNMI server
+	s := createServer(t, 8081)
+	go runServer(t, s)
+
+	prepareDbTranslib(t)
+	ns, _ := sdcfg.GetDbDefaultNamespace()
+	ctx := context.Background()
+
+	// Use StateDB (DB No 6 in SONiC)
+	stateClient := getRedisClientN(t, 6, ns)
+	defer stateClient.Close()
+
+	// CONFIG_DB (DB 4)
+	configClient := getRedisClientN(t, 4, ns)
+	defer configClient.Close()
+
+	// 2. Prepare Mock Data in Redis (SW_COMP_INFO Table)
+	// Mock an Operating System entry
+	osFields := map[string]interface{}{
+		"name":             "os0",
+		"software-version": "20240531.42",
+		"oper-status":      "active",
+		"type":             "OPERATING_SYSTEM",
+		"parent":           "chassis",
+	}
+	stateClient.HSet(ctx, "SW_COMP_INFO|os0", osFields)
+	configClient.HSet(ctx, "SW_COMP_INFO|os0", osFields)
+
+	// Mock OS entry with invalid oper-status
+	osBadOperFields := map[string]interface{}{
+		"name":        "os_bad_oper0",
+		"type":        "OPERATING_SYSTEM",
+		"oper-status": "invalid_oper_value",
+	}
+	stateClient.HSet(ctx, "SW_COMP_INFO|os_bad_oper0", osBadOperFields)
+	configClient.HSet(ctx, "SW_COMP_INFO|os_bad_oper0", osBadOperFields)
+
+	// Mock OS entry with missing software-version to trigger error path
+	osNoVerFields := map[string]interface{}{
+		"name": "os1",
+		"type": "OPERATING_SYSTEM",
+	}
+	stateClient.HSet(ctx, "SW_COMP_INFO|os1", osNoVerFields)
+	configClient.HSet(ctx, "SW_COMP_INFO|os1", osNoVerFields)
+
+	// Mock Boot Loader entry
+	bootFields := map[string]interface{}{
+		"name":             "boot_loader0",
+		"software-version": "2.06",
+		"module-type":      "BOOT_LOADER",
+		"type":             "SOFTWARE_MODULE",
+		"oper-status":      "active",
+	}
+	stateClient.HSet(ctx, "SW_COMP_INFO|boot_loader0", bootFields)
+	configClient.HSet(ctx, "SW_COMP_INFO|boot_loader0", bootFields)
+
+	// Mock BIOS entry
+	biosFields := map[string]interface{}{
+		"name":             "bios0",
+		"software-version": "1.0.0",
+		"type":             "BIOS",
+	}
+	stateClient.HSet(ctx, "SW_COMP_INFO|bios0", biosFields)
+	configClient.HSet(ctx, "SW_COMP_INFO|bios0", biosFields)
+
+	// Mock Network Stack (Software Module) entry
+	swModFields := map[string]interface{}{
+		"name":        "network_stack0",
+		"type":        "SOFTWARE_MODULE",
+		"module-type": "USERSPACE_PACKAGE_BUNDLE",
+		"oper-status": "active",
+	}
+	stateClient.HSet(ctx, "SW_COMP_INFO|network_stack0", swModFields)
+	configClient.HSet(ctx, "SW_COMP_INFO|network_stack0", swModFields)
+
+	// 3. Setup gNMI Client
+	tlsConfig := &tls.Config{InsecureSkipVerify: true}
+	opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
+	targetAddr := "127.0.0.1:8081"
+	conn, err := grpc.Dial(targetAddr, opts...)
+	if err != nil {
+		t.Fatalf("Dialing to %q failed: %v", targetAddr, err)
+	}
+	defer conn.Close()
+	gClient := pb.NewGNMIClient(conn)
+
+	// 4. Define Test Scenarios
+	tds := []struct {
+		desc        string
+		pathTarget  string
+		textPbPath  string
+		timeout     time.Duration
+		wantRetCode codes.Code
+		wantRespVal interface{}
+		valTest     bool
+	}{
+		// --- Container / Subtree Queries (AllPaths and StatePaths) ---
+		{
+			desc:       "Get OS Full Component Subtree (AllPaths)",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+                elem: <name: "openconfig-platform:components" >
+                elem: <name: "component" key:<key:"name" value:"os0" > >
+            `,
+			wantRetCode: codes.OK,
+			valTest:     false,
+		},
+		{
+			desc:       "Get OS State Container (StatePaths)",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+                elem: <name: "openconfig-platform:components" >
+                elem: <name: "component" key:<key:"name" value:"os0" > >
+                elem: <name: "state" >
+            `,
+			wantRetCode: codes.OK,
+			valTest:     false,
+		},
+		{
+			desc:       "Get BootLoader Full Subtree",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+                elem: <name: "openconfig-platform:components" >
+                elem: <name: "component" key:<key:"name" value:"boot_loader0" > >
+            `,
+			wantRetCode: codes.OK,
+			valTest:     false,
+		},
+		{
+			desc:       "Get BIOS State Container",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+                elem: <name: "openconfig-platform:components" >
+                elem: <name: "component" key:<key:"name" value:"bios0" > >
+                elem: <name: "state" >
+            `,
+			wantRetCode: codes.OK,
+			valTest:     false,
+		},
+		{
+			desc:       "Get Network Stack Full Subtree",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+                elem: <name: "openconfig-platform:components" >
+                elem: <name: "component" key:<key:"name" value:"network_stack0" > >
+            `,
+			wantRetCode: codes.OK,
+			valTest:     false,
+		},
+		// --- Individual Singular State Leaves---
+		{
+			desc:       "Get OS Component State Name",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+                elem: <name: "openconfig-platform:components" >
+                elem: <name: "component" key:<key:"name" value:"os0" > >
+                elem: <name: "state" >
+                elem: <name: "name" >
+            `,
+			wantRetCode: codes.OK,
+			valTest:     false,
+		},
+		{
+			desc:       "Get OS Component Type",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+                                elem: <name: "openconfig-platform:components" >
+                                elem: <name: "component" key:<key:"name" value:"os0" > >
+                                elem: <name: "state" >
+                                elem: <name: "type" >
+                        `,
+			wantRetCode: codes.OK,
+			valTest:     false,
+		},
+		{
+			desc:       "Get OS Component State (Software Version)",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+                                elem: <name: "openconfig-platform:components" >
+                                elem: <name: "component" key:<key:"name" value:"os0" > >
+                                elem: <name: "state" >
+                                elem: <name: "software-version" >
+                        `,
+			wantRetCode: codes.OK,
+			valTest:     false,
+		},
+		{
+			desc:       "Get OS Component State Parent",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+                elem: <name: "openconfig-platform:components" >
+                elem: <name: "component" key:<key:"name" value:"os0" > >
+                elem: <name: "state" >
+                elem: <name: "parent" >
+            `,
+			wantRetCode: codes.OK,
+			valTest:     false,
+		},
+		{
+			desc:       "Get OS Component State Oper Status",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+                elem: <name: "openconfig-platform:components" >
+                elem: <name: "component" key:<key:"name" value:"os0" > >
+                elem: <name: "state" >
+                elem: <name: "oper-status" >
+            `,
+			wantRetCode: codes.OK,
+			valTest:     false,
+		},
+		{
+			desc:       "Get Bootloader Software Version",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+                                elem: <name: "openconfig-platform:components" >
+                                elem: <name: "component" key:<key:"name" value:"boot_loader0" > >
+                                elem: <name: "state" >
+                                elem: <name: "software-version" >
+                        `,
+			wantRetCode: codes.OK,
+			valTest:     false,
+		},
+		{
+			desc:       "Get Bootloader component name",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+                                elem: <name: "openconfig-platform:components" >
+                                elem: <name: "component" key:<key:"name" value:"boot_loader0" > >
+                                elem: <name: "state" >
+                                elem: <name: "name" >
+                        `,
+			wantRetCode: codes.OK,
+			valTest:     false,
+		},
+		{
+			desc:       "Get Bootloader Specific Type",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+                                elem: <name: "openconfig-platform:components" >
+                                elem: <name: "component" key:<key:"name" value:"boot_loader0" > >
+                                elem: <name: "state" >
+                                elem: <name: "type" >
+                        `,
+			wantRetCode: codes.OK,
+			valTest:     false,
+		},
+		{
+			desc:       "Get Software Module (Network Stack) Type",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+                                elem: <name: "openconfig-platform:components" >
+                                elem: <name: "component" key:<key:"name" value:"network_stack0" > >
+                                elem: <name: "software-module" >
+                                elem: <name: "state" >
+                                elem: <name: "module-type" >
+                        `,
+			wantRetCode: codes.OK,
+			valTest:     false,
+		},
+		{
+			desc:       "Get Software Module Oper Status",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+                                elem: <name: "openconfig-platform:components" >
+                                elem: <name: "component" key:<key:"name" value:"network_stack0" > >
+                                elem: <name: "state" >
+                                elem: <name: "oper-status" >
+                        `,
+			wantRetCode: codes.OK,
+			valTest:     false,
+		},
+		{
+			desc:       "Get Network Stack Component State Type",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+                elem: <name: "openconfig-platform:components" >
+                elem: <name: "component" key:<key:"name" value:"network_stack0" > >
+                elem: <name: "state" >
+                elem: <name: "type" >
+            `,
+			wantRetCode: codes.OK,
+			valTest:     false,
+		},
+		{
+			desc:       "Get BIOS Component State Type",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+                elem: <name: "openconfig-platform:components" >
+                elem: <name: "component" key:<key:"name" value:"bios0" > >
+                elem: <name: "state" >
+                elem: <name: "type" >
+            `,
+			wantRetCode: codes.OK,
+			valTest:     false,
+		},
+		{
+			desc:       "Get Software Module Container Path (COMP_SW_MOD)",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+                elem: <name: "openconfig-platform:components" >
+                elem: <name: "component" key:<key:"name" value:"network_stack0" > >
+                elem: <name: "software-module" >
+            `,
+			wantRetCode: codes.OK,
+			valTest:     false,
+		},
+		{
+			desc:       "Get Software Module State Container Path (COMP_SW_MOD_ST)",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+                elem: <name: "openconfig-platform:components" >
+                elem: <name: "component" key:<key:"name" value:"network_stack0" > >
+                elem: <name: "software-module" >
+                elem: <name: "state" >
+            `,
+			wantRetCode: codes.OK,
+			valTest:     false,
+		},
+		// --- Error Paths / Invalid Requests ---
+		{
+			desc:       "Get OS Component Software Version when missing in DB (Expect Error)",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+                elem: <name: "openconfig-platform:components" >
+                elem: <name: "component" key:<key:"name" value:"os1" > >
+                elem: <name: "state" >
+                elem: <name: "software-version" >
+`,
+			wantRetCode: codes.NotFound,
+			valTest:     false,
+		},
+		{
+			desc:       "Get Non-Existent SW Component (Unknown Component Name)",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+                elem: <name: "openconfig-platform:components" >
+                elem: <name: "component" key:<key:"name" value:"os_non_existent" > >
+                elem: <name: "state" >
+            `,
+			wantRetCode: codes.NotFound,
+			valTest:     false,
+		},
+		{
+			desc:       "Trigger getCompTypeByName for OS pattern (not in DB)",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+                elem: <name: "openconfig-platform:components" >
+                elem: <name: "component" key:<key:"name" value:"os0_no_db" > >
+                elem: <name: "state" >
+            `,
+			wantRetCode: codes.NotFound,
+			valTest:     false,
+		},
+		{
+			desc:       "Trigger getCompTypeByName for Network Stack pattern (not in DB)",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+                elem: <name: "openconfig-platform:components" >
+                elem: <name: "component" key:<key:"name" value:"network_stack1_no_db" > >
+                elem: <name: "state" >
+            `,
+			wantRetCode: codes.NotFound,
+			valTest:     false,
+		},
+		{
+			desc:       "Trigger getCompTypeByName for BootLoader pattern (not in DB)",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+                elem: <name: "openconfig-platform:components" >
+                elem: <name: "component" key:<key:"name" value:"boot_loader_no_db" > >
+                elem: <name: "state" >
+            `,
+			wantRetCode: codes.NotFound,
+			valTest:     false,
+		},
+		{
+			desc:       "Get Oper Status on OS with invalid status string in DB (Triggers invalid field value error)",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+                elem: <name: "openconfig-platform:components" >
+                elem: <name: "component" key:<key:"name" value:"os_bad_oper0" > >
+                elem: <name: "state" >
+                elem: <name: "oper-status" >
+            `,
+			wantRetCode: codes.NotFound,
+			valTest:     false,
+		},
+		{
+			desc:       "Get Module Type on OS Component (Triggers cType != CompTypeNWStack error)",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+                elem: <name: "openconfig-platform:components" >
+                elem: <name: "component" key:<key:"name" value:"os0" > >
+                elem: <name: "software-module" >
+                elem: <name: "state" >
+                elem: <name: "module-type" >
+            `,
+			wantRetCode: codes.NotFound,
+			valTest:     false,
+		},
+	}
+
+	// 5. Run Tests
+	for _, td := range tds {
+		t.Run(td.desc, func(t *testing.T) {
+			if td.timeout == 0 {
+				td.timeout = 10 * time.Second
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), td.timeout)
+			defer cancel()
+
+			runTestGet(t, ctx, gClient, td.pathTarget, td.textPbPath, td.wantRetCode, td.wantRespVal, td.valTest)
+		})
+	}
+	s.Stop()
+}
+
 // runTestGet requests a path from the server by Get grpc call, and compares if
 // the return code and response value are expected.
 func runTestGet(t *testing.T, ctx context.Context, gClient pb.GNMIClient, pathTarget string,

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -486,6 +486,435 @@ func TestGnmiGetInterfaceCountersVPath(t *testing.T) {
 	}
 }
 
+func TestGnmiGetSoftwareComponents(t *testing.T) {
+	// 1. Define all structures locally inside the test function
+	type SoftwareComponentState struct {
+		Name            string `json:"name"`
+		Type            string `json:"type"`
+		Parent          string `json:"parent,omitempty"`
+		OperStatus      string `json:"oper-status,omitempty"`
+		SoftwareVersion string `json:"software-version"` // Removed omitempty to match server "" output
+	}
+
+	type SoftwareModuleState struct {
+		ModuleType string `json:"openconfig-platform-software:module-type,omitempty"`
+	}
+
+	type SoftwareModule struct {
+		State SoftwareModuleState `json:"state"`
+	}
+
+	type ComponentEntry struct {
+		Name           string                 `json:"name"`
+		State          SoftwareComponentState `json:"state"`
+		SoftwareModule *SoftwareModule        `json:"software-module,omitempty"`
+	}
+
+	type ComponentResp struct {
+		Component []ComponentEntry `json:"openconfig-platform:component"`
+	}
+
+	type StateResp struct {
+		State SoftwareComponentState `json:"openconfig-platform:state"`
+	}
+
+	type ModuleStateResp struct {
+		State SoftwareModuleState `json:"openconfig-platform:state"`
+	}
+
+	type ModuleContainerResp struct {
+		SoftwareModule SoftwareModule `json:"openconfig-platform:software-module"`
+	}
+
+	type NameResp struct {
+		Name string `json:"openconfig-platform:name"`
+	}
+
+	type TypeResp struct {
+		Type string `json:"openconfig-platform:type"`
+	}
+
+	type VersionResp struct {
+		Version string `json:"openconfig-platform:software-version"`
+	}
+
+	type ParentResp struct {
+		Parent string `json:"openconfig-platform:parent"`
+	}
+
+	type OperStatusResp struct {
+		OperStatus string `json:"openconfig-platform:oper-status"`
+	}
+
+	// Server/DB setup
+	freePort := getFreePort(t)
+	s := createServer(t, freePort)
+	go runServer(t, s)
+	defer s.Stop()
+	prepareDbTranslib(t)
+	ctx := context.Background()
+	ns, _ := sdcfg.GetDbDefaultNamespace()
+
+	stateDbId, _ := sdcfg.GetDbId("STATE_DB", ns)
+	stateClient := getRedisClientN(t, stateDbId, ns)
+	defer stateClient.Close()
+
+	// Seed State DB
+	if err := stateClient.HSet(ctx, "DEVICE_METADATA|localhost", map[string]interface{}{
+		"software_version": "20240531.42",
+	}).Err(); err != nil {
+		t.Fatalf("Failed to HSet DEVICE_METADATA: %v", err)
+	}
+
+	if err := stateClient.HSet(ctx, "COMPONENT|os0", map[string]interface{}{
+		"name":        "os0",
+		"type":        "OPENCONFIG-PLATFORM-TYPES:OPERATING_SYSTEM",
+		"oper-status": "ACTIVE",
+		"parent":      "chassis",
+	}).Err(); err != nil {
+		t.Fatalf("Failed to HSet COMPONENT|os0: %v", err)
+	}
+
+	if err := stateClient.HSet(ctx, "COMPONENT|boot_loader0", map[string]interface{}{
+		"name":             "boot_loader0",
+		"type":             "OPENCONFIG-PLATFORM-TYPES:BOOT_LOADER",
+		"parent":           "chassis",
+		"software-version": "2.06",
+	}).Err(); err != nil {
+		t.Fatalf("Failed to HSet COMPONENT|boot_loader0: %v", err)
+	}
+
+	if err := stateClient.HSet(ctx, "COMPONENT|network_stack0", map[string]interface{}{
+		"name":        "network_stack0",
+		"type":        "OPENCONFIG-PLATFORM-TYPES:SOFTWARE_MODULE",
+		"oper-status": "ACTIVE",
+		"parent":      "chassis",
+	}).Err(); err != nil {
+		t.Fatalf("Failed to HSet COMPONENT|network_stack0: %v", err)
+	}
+
+	t.Cleanup(func() {
+		cleanupCtx := context.Background()
+		stateClient.Del(cleanupCtx, "DEVICE_METADATA|localhost")
+		stateClient.Del(cleanupCtx, "COMPONENT|os0")
+		stateClient.Del(cleanupCtx, "COMPONENT|boot_loader0")
+		stateClient.Del(cleanupCtx, "COMPONENT|network_stack0")
+	})
+
+	targetAddr := fmt.Sprintf("127.0.0.1:%d", s.config.Port)
+	tlsConfig := &tls.Config{InsecureSkipVerify: true}
+	opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
+	conn, err := grpc.Dial(targetAddr, opts...)
+	if err != nil {
+		t.Fatalf("Dialing to %q failed: %v", targetAddr, err)
+	}
+	defer conn.Close()
+	gClient := pb.NewGNMIClient(conn)
+
+	// 2. Prepare Expected Data Structs
+	osState := SoftwareComponentState{
+		Name:            "os0",
+		Type:            "openconfig-platform-types:OPERATING_SYSTEM",
+		OperStatus:      "openconfig-platform-types:ACTIVE",
+		Parent:          "chassis",
+		SoftwareVersion: "20240531.42",
+	}
+
+	bootloaderState := SoftwareComponentState{
+		Name:            "boot_loader0",
+		Type:            "openconfig-platform-types:BOOT_LOADER",
+		Parent:          "chassis",
+		SoftwareVersion: "2.06",
+	}
+
+	networkStackState := SoftwareComponentState{
+		Name:            "network_stack0",
+		Type:            "openconfig-platform-types:SOFTWARE_MODULE",
+		OperStatus:      "openconfig-platform-types:ACTIVE",
+		Parent:          "chassis",
+		SoftwareVersion: "", // Server returns empty string when not found in DB but exists in schema
+	}
+
+	modState := SoftwareModuleState{
+		ModuleType: "openconfig-platform-software:USERSPACE_PACKAGE_BUNDLE",
+	}
+
+	var osCompVal ComponentResp
+	osCompVal.Component = append(osCompVal.Component, ComponentEntry{
+		Name:  "os0",
+		State: osState,
+	})
+
+	var bootloaderCompVal ComponentResp
+	bootloaderCompVal.Component = append(bootloaderCompVal.Component, ComponentEntry{
+		Name:  "boot_loader0",
+		State: bootloaderState,
+	})
+
+	var networkStackCompVal ComponentResp
+	networkStackCompVal.Component = append(networkStackCompVal.Component, ComponentEntry{
+		Name:           "network_stack0",
+		State:          networkStackState,
+		SoftwareModule: &SoftwareModule{State: modState},
+	})
+
+	marshal := func(v interface{}) []byte {
+		b, _ := json.Marshal(v)
+		return b
+	}
+
+	tds := []struct {
+		desc        string
+		pathTarget  string
+		textPbPath  string
+		wantRetCode codes.Code
+		wantRespVal interface{}
+		valTest     bool
+	}{
+		{
+			desc:        "Get_OS_Full_Component_Subtree_(AllPaths)",
+			pathTarget:  "OC_YANG",
+			textPbPath:  `elem: <name: "openconfig-platform:components" > elem: <name: "component" key:<key:"name" value:"os0" > >`,
+			wantRetCode: codes.OK,
+			wantRespVal: marshal(osCompVal),
+			valTest:     true,
+		},
+		{
+			desc:        "Get_OS_State_Container_(StatePaths)",
+			pathTarget:  "OC_YANG",
+			textPbPath:  `elem: <name: "openconfig-platform:components" > elem: <name: "component" key:<key:"name" value:"os0" > > elem: <name: "state" >`,
+			wantRetCode: codes.OK,
+			wantRespVal: marshal(StateResp{State: osState}),
+			valTest:     true,
+		},
+		{
+			desc:        "Get_BootLoader_Full_Subtree",
+			pathTarget:  "OC_YANG",
+			textPbPath:  `elem: <name: "openconfig-platform:components" > elem: <name: "component" key:<key:"name" value:"boot_loader0" > >`,
+			wantRetCode: codes.OK,
+			wantRespVal: marshal(bootloaderCompVal),
+			valTest:     true,
+		},
+		{
+			desc:        "Get_Network_Stack_Full_Subtree",
+			pathTarget:  "OC_YANG",
+			textPbPath:  `elem: <name: "openconfig-platform:components" > elem: <name: "component" key:<key:"name" value:"network_stack0" > >`,
+			wantRetCode: codes.OK,
+			wantRespVal: marshal(networkStackCompVal),
+			valTest:     true,
+		},
+		{
+			desc:        "Get_OS_Component_State_Name",
+			pathTarget:  "OC_YANG",
+			textPbPath:  `elem: <name: "openconfig-platform:components" > elem: <name: "component" key:<key:"name" value:"os0" > > elem: <name: "state" > elem: <name: "name" >`,
+			wantRetCode: codes.OK,
+			wantRespVal: marshal(NameResp{Name: "os0"}),
+			valTest:     true,
+		},
+		{
+			desc:        "Get_OS_Component_Type",
+			pathTarget:  "OC_YANG",
+			textPbPath:  `elem: <name: "openconfig-platform:components" > elem: <name: "component" key:<key:"name" value:"os0" > > elem: <name: "state" > elem: <name: "type" >`,
+			wantRetCode: codes.OK,
+			wantRespVal: marshal(TypeResp{Type: "openconfig-platform-types:OPERATING_SYSTEM"}),
+			valTest:     true,
+		},
+		{
+			desc:        "Get_OS_Component_State_(Software_Version)",
+			pathTarget:  "OC_YANG",
+			textPbPath:  `elem: <name: "openconfig-platform:components" > elem: <name: "component" key:<key:"name" value:"os0" > > elem: <name: "state" > elem: <name: "software-version" >`,
+			wantRetCode: codes.OK,
+			wantRespVal: marshal(VersionResp{Version: "20240531.42"}),
+			valTest:     true,
+		},
+		{
+			desc:        "Get_OS_Component_State_Parent",
+			pathTarget:  "OC_YANG",
+			textPbPath:  `elem: <name: "openconfig-platform:components" > elem: <name: "component" key:<key:"name" value:"os0" > > elem: <name: "state" > elem: <name: "parent" >`,
+			wantRetCode: codes.OK,
+			wantRespVal: marshal(ParentResp{Parent: "chassis"}),
+			valTest:     true,
+		},
+		{
+			desc:        "Get_OS_Component_State_Oper_Status",
+			pathTarget:  "OC_YANG",
+			textPbPath:  `elem: <name: "openconfig-platform:components" > elem: <name: "component" key:<key:"name" value:"os0" > > elem: <name: "state" > elem: <name: "oper-status" >`,
+			wantRetCode: codes.OK,
+			wantRespVal: marshal(OperStatusResp{OperStatus: "openconfig-platform-types:ACTIVE"}),
+			valTest:     true,
+		},
+		{
+			desc:        "Get_Bootloader_Software_Version",
+			pathTarget:  "OC_YANG",
+			textPbPath:  `elem: <name: "openconfig-platform:components" > elem: <name: "component" key:<key:"name" value:"boot_loader0" > > elem: <name: "state" > elem: <name: "software-version" >`,
+			wantRetCode: codes.OK,
+			wantRespVal: marshal(VersionResp{Version: "2.06"}),
+			valTest:     true,
+		},
+		{
+			desc:        "Get_Bootloader_component_name",
+			pathTarget:  "OC_YANG",
+			textPbPath:  `elem: <name: "openconfig-platform:components" > elem: <name: "component" key:<key:"name" value:"boot_loader0" > > elem: <name: "state" > elem: <name: "name" >`,
+			wantRetCode: codes.OK,
+			wantRespVal: marshal(NameResp{Name: "boot_loader0"}),
+			valTest:     true,
+		},
+		{
+			desc:        "Get_Bootloader_Specific_Type",
+			pathTarget:  "OC_YANG",
+			textPbPath:  `elem: <name: "openconfig-platform:components" > elem: <name: "component" key:<key:"name" value:"boot_loader0" > > elem: <name: "state" > elem: <name: "type" >`,
+			wantRetCode: codes.OK,
+			wantRespVal: marshal(TypeResp{Type: "openconfig-platform-types:BOOT_LOADER"}),
+			valTest:     true,
+		},
+		{
+			desc:        "Get_Software_Module_(Network_Stack)_Type",
+			pathTarget:  "OC_YANG",
+			textPbPath:  `elem: <name: "openconfig-platform:components" > elem: <name: "component" key:<key:"name" value:"network_stack0" > > elem: <name: "software-module" > elem: <name: "state" > elem: <name: "module-type" >`,
+			wantRetCode: codes.OK,
+			wantRespVal: marshal(modState),
+			valTest:     true,
+		},
+		{
+			desc:        "Get_Software_Module_Oper_Status",
+			pathTarget:  "OC_YANG",
+			textPbPath:  `elem: <name: "openconfig-platform:components" > elem: <name: "component" key:<key:"name" value:"network_stack0" > > elem: <name: "state" > elem: <name: "oper-status" >`,
+			wantRetCode: codes.OK,
+			wantRespVal: marshal(OperStatusResp{OperStatus: "openconfig-platform-types:ACTIVE"}),
+			valTest:     true,
+		},
+		{
+			desc:        "Get_Network_Stack_Component_State_Type",
+			pathTarget:  "OC_YANG",
+			textPbPath:  `elem: <name: "openconfig-platform:components" > elem: <name: "component" key:<key:"name" value:"network_stack0" > > elem: <name: "state" > elem: <name: "type" >`,
+			wantRetCode: codes.OK,
+			wantRespVal: marshal(TypeResp{Type: "openconfig-platform-types:SOFTWARE_MODULE"}),
+			valTest:     true,
+		},
+		{
+			desc:        "Get_Software_Module_Container_Path_(COMP_SW_MOD)",
+			pathTarget:  "OC_YANG",
+			textPbPath:  `elem: <name: "openconfig-platform:components" > elem: <name: "component" key:<key:"name" value:"network_stack0" > > elem: <name: "software-module" >`,
+			wantRetCode: codes.OK,
+			wantRespVal: marshal(ModuleContainerResp{SoftwareModule: SoftwareModule{State: modState}}),
+			valTest:     true,
+		},
+		{
+			desc:        "Get_Software_Module_State_Container_Path_(COMP_SW_MOD_ST)",
+			pathTarget:  "OC_YANG",
+			textPbPath:  `elem: <name: "openconfig-platform:components" > elem: <name: "component" key:<key:"name" value:"network_stack0" > > elem: <name: "software-module" > elem: <name: "state" >`,
+			wantRetCode: codes.OK,
+			wantRespVal: marshal(ModuleStateResp{State: modState}),
+			valTest:     true,
+		},
+		{
+			desc:        "Get_Non-Existent_SW_Component_(NotFound)",
+			pathTarget:  "OC_YANG",
+			textPbPath:  `elem: <name: "openconfig-platform:components" > elem: <name: "component" key:<key:"name" value:"unknown_comp" > >`,
+			wantRetCode: codes.NotFound,
+			wantRespVal: nil,
+			valTest:     false,
+		},
+		// --- Error Paths / Invalid Requests ---
+		{
+			desc:       "Get OS Component Software Version when missing in DB (Expect Error)",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+                elem: <name: "openconfig-platform:components" >
+                elem: <name: "component" key:<key:"name" value:"os1" > >
+                elem: <name: "state" >
+                elem: <name: "software-version" >
+`,
+			wantRetCode: codes.NotFound,
+			wantRespVal: nil,
+			valTest:     false,
+		},
+		{
+			desc:       "Get Non-Existent SW Component (Unknown Component Name)",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+                elem: <name: "openconfig-platform:components" >
+                elem: <name: "component" key:<key:"name" value:"os_non_existent" > >
+                elem: <name: "state" >
+            `,
+			wantRetCode: codes.NotFound,
+			wantRespVal: nil,
+			valTest:     false,
+		},
+		{
+			desc:       "Trigger getCompTypeByName for OS pattern (not in DB)",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+                elem: <name: "openconfig-platform:components" >
+                elem: <name: "component" key:<key:"name" value:"os0_no_db" > >
+                elem: <name: "state" >
+            `,
+			wantRetCode: codes.NotFound,
+			wantRespVal: nil,
+			valTest:     false,
+		},
+		{
+			desc:       "Trigger getCompTypeByName for Network Stack pattern (not in DB)",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+                elem: <name: "openconfig-platform:components" >
+                elem: <name: "component" key:<key:"name" value:"network_stack1_no_db" > >
+                elem: <name: "state" >
+            `,
+			wantRetCode: codes.NotFound,
+			wantRespVal: nil,
+			valTest:     false,
+		},
+		{
+			desc:       "Trigger getCompTypeByName for BootLoader pattern (not in DB)",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+                elem: <name: "openconfig-platform:components" >
+                elem: <name: "component" key:<key:"name" value:"boot_loader_no_db" > >
+                elem: <name: "state" >
+            `,
+			wantRetCode: codes.NotFound,
+			wantRespVal: nil,
+			valTest:     false,
+		},
+		{
+			desc:       "Get Oper Status on OS with invalid status string in DB (Triggers invalid field value error)",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+                elem: <name: "openconfig-platform:components" >
+                elem: <name: "component" key:<key:"name" value:"os_bad_oper0" > >
+                elem: <name: "state" >
+                elem: <name: "oper-status" >
+            `,
+			wantRetCode: codes.NotFound,
+			wantRespVal: nil,
+			valTest:     false,
+		},
+		{
+			desc:       "Get Module Type on OS Component (Triggers cType != CompTypeNWStack error)",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+                elem: <name: "openconfig-platform:components" >
+                elem: <name: "component" key:<key:"name" value:"os0" > >
+                elem: <name: "software-module" >
+                elem: <name: "state" >
+                elem: <name: "module-type" >
+            `,
+			wantRetCode: codes.NotFound,
+			wantRespVal: nil,
+			valTest:     false,
+		},
+	}
+
+	for _, td := range tds {
+		t.Run(td.desc, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			runTestGet(t, ctx, gClient, td.pathTarget, td.textPbPath, td.wantRetCode, td.wantRespVal, td.valTest)
+		})
+	}
+}
+
 // runTestGet requests a path from the server by Get grpc call, and compares if
 // the return code and response value are expected.
 func runTestGet(t *testing.T, ctx context.Context, gClient pb.GNMIClient, pathTarget string,


### PR DESCRIPTION
This PR is created to add a component test case for Open Config platform components software components Model.

Base PR  - [PR #230](https://github.com/sonic-net/sonic-mgmt-common/pull/230)

**Test Results:**

=== RUN   TestGnmiGetSoftwareComponents
=== RUN   TestGnmiGetSoftwareComponents/Get_OS_Full_Component_Subtree_(AllPaths)
    server_test.go:5483: [TestGnmiGetSoftwareComponents/Get_OS_Full_Component_Subtree_(AllPaths)] gotVal:
        {
          "openconfig-platform:component": [
            {
              "name": "os0",
              "state": {
                "name": "os0",
                "oper-status": "openconfig-platform-types:ACTIVE",
                "parent": "chassis",
                "software-version": "20240531.42",
                "type": "openconfig-platform-types:OPERATING_SYSTEM"
              }
            }
          ]
        }
=== RUN   TestGnmiGetSoftwareComponents/Get_OS_State_Container_(StatePaths)
    server_test.go:5483: [TestGnmiGetSoftwareComponents/Get_OS_State_Container_(StatePaths)] gotVal:
        {
          "openconfig-platform:state": {
            "name": "os0",
            "oper-status": "openconfig-platform-types:ACTIVE",
            "parent": "chassis",
            "software-version": "20240531.42",
            "type": "openconfig-platform-types:OPERATING_SYSTEM"
          }
        }
=== RUN   TestGnmiGetSoftwareComponents/Get_BootLoader_Full_Subtree
    server_test.go:5483: [TestGnmiGetSoftwareComponents/Get_BootLoader_Full_Subtree] gotVal:
        {
          "openconfig-platform:component": [
            {
              "name": "boot_loader0",
              "state": {
                "name": "boot_loader0",
                "parent": "chassis",
                "software-version": "2.06",
                "type": "openconfig-platform-types:BOOT_LOADER"
              }
            }
          ]
        }
=== RUN   TestGnmiGetSoftwareComponents/Get_Network_Stack_Full_Subtree
    server_test.go:5483: [TestGnmiGetSoftwareComponents/Get_Network_Stack_Full_Subtree] gotVal:
        {
          "openconfig-platform:component": [
            {
              "name": "network_stack0",
              "software-module": {
                "state": {
                  "openconfig-platform-software:module-type": "openconfig-platform-software:USERSPACE_PACKAGE_BUNDLE"
                }
              },
              "state": {
                "name": "network_stack0",
                "oper-status": "openconfig-platform-types:ACTIVE",
                "parent": "chassis",
                "software-version": "",
                "type": "openconfig-platform-types:SOFTWARE_MODULE"
              }
            }
          ]
        }
=== RUN   TestGnmiGetSoftwareComponents/Get_OS_Component_State_Name
    server_test.go:5483: [TestGnmiGetSoftwareComponents/Get_OS_Component_State_Name] gotVal:
        {
          "openconfig-platform:name": "os0"
        }
=== RUN   TestGnmiGetSoftwareComponents/Get_OS_Component_Type
    server_test.go:5483: [TestGnmiGetSoftwareComponents/Get_OS_Component_Type] gotVal:
        {
          "openconfig-platform:type": "openconfig-platform-types:OPERATING_SYSTEM"
        }
=== RUN   TestGnmiGetSoftwareComponents/Get_OS_Component_State_(Software_Version)
    server_test.go:5483: [TestGnmiGetSoftwareComponents/Get_OS_Component_State_(Software_Version)] gotVal:
        {
          "openconfig-platform:software-version": "20240531.42"
        }
=== RUN   TestGnmiGetSoftwareComponents/Get_OS_Component_State_Parent
    server_test.go:5483: [TestGnmiGetSoftwareComponents/Get_OS_Component_State_Parent] gotVal:
        {
          "openconfig-platform:parent": "chassis"
        }
=== RUN   TestGnmiGetSoftwareComponents/Get_OS_Component_State_Oper_Status
    server_test.go:5483: [TestGnmiGetSoftwareComponents/Get_OS_Component_State_Oper_Status] gotVal:
        {
          "openconfig-platform:oper-status": "openconfig-platform-types:ACTIVE"
        }
=== RUN   TestGnmiGetSoftwareComponents/Get_Bootloader_Software_Version
    server_test.go:5483: [TestGnmiGetSoftwareComponents/Get_Bootloader_Software_Version] gotVal:
        {
          "openconfig-platform:software-version": "2.06"
        }
=== RUN   TestGnmiGetSoftwareComponents/Get_Bootloader_component_name
    server_test.go:5483: [TestGnmiGetSoftwareComponents/Get_Bootloader_component_name] gotVal:
        {
          "openconfig-platform:name": "boot_loader0"
        }
=== RUN   TestGnmiGetSoftwareComponents/Get_Bootloader_Specific_Type
    server_test.go:5483: [TestGnmiGetSoftwareComponents/Get_Bootloader_Specific_Type] gotVal:
        {
          "openconfig-platform:type": "openconfig-platform-types:BOOT_LOADER"
        }
=== RUN   TestGnmiGetSoftwareComponents/Get_Software_Module_(Network_Stack)_Type
    server_test.go:5483: [TestGnmiGetSoftwareComponents/Get_Software_Module_(Network_Stack)_Type] gotVal:
        {
          "openconfig-platform-software:module-type": "openconfig-platform-software:USERSPACE_PACKAGE_BUNDLE"
        }
=== RUN   TestGnmiGetSoftwareComponents/Get_Software_Module_Oper_Status
    server_test.go:5483: [TestGnmiGetSoftwareComponents/Get_Software_Module_Oper_Status] gotVal:
        {
          "openconfig-platform:oper-status": "openconfig-platform-types:ACTIVE"
        }
=== RUN   TestGnmiGetSoftwareComponents/Get_Network_Stack_Component_State_Type
    server_test.go:5483: [TestGnmiGetSoftwareComponents/Get_Network_Stack_Component_State_Type] gotVal:
        {
          "openconfig-platform:type": "openconfig-platform-types:SOFTWARE_MODULE"
        }
=== RUN   TestGnmiGetSoftwareComponents/Get_Software_Module_Container_Path_(COMP_SW_MOD)
    server_test.go:5483: [TestGnmiGetSoftwareComponents/Get_Software_Module_Container_Path_(COMP_SW_MOD)] gotVal:
        {
          "openconfig-platform:software-module": {
            "state": {
              "openconfig-platform-software:module-type": "openconfig-platform-software:USERSPACE_PACKAGE_BUNDLE"
            }
          }
        }
=== RUN   TestGnmiGetSoftwareComponents/Get_Software_Module_State_Container_Path_(COMP_SW_MOD_ST)
    server_test.go:5483: [TestGnmiGetSoftwareComponents/Get_Software_Module_State_Container_Path_(COMP_SW_MOD_ST)] gotVal:
        {
          "openconfig-platform:state": {
            "openconfig-platform-software:module-type": "openconfig-platform-software:USERSPACE_PACKAGE_BUNDLE"
          }
        }
=== RUN   TestGnmiGetSoftwareComponents/Get_Non-Existent_SW_Component_(NotFound)
=== RUN   TestGnmiGetSoftwareComponents/Get_OS_Component_Software_Version_when_missing_in_DB_(Expect_Error)
=== RUN   TestGnmiGetSoftwareComponents/Get_Non-Existent_SW_Component_(Unknown_Component_Name)
=== RUN   TestGnmiGetSoftwareComponents/Trigger_getCompTypeByName_for_OS_pattern_(not_in_DB)
=== RUN   TestGnmiGetSoftwareComponents/Trigger_getCompTypeByName_for_Network_Stack_pattern_(not_in_DB)
=== RUN   TestGnmiGetSoftwareComponents/Trigger_getCompTypeByName_for_BootLoader_pattern_(not_in_DB)
=== RUN   TestGnmiGetSoftwareComponents/Get_Oper_Status_on_OS_with_invalid_status_string_in_DB_(Triggers_invalid_field_value_error)
=== RUN   TestGnmiGetSoftwareComponents/Get_Module_Type_on_OS_Component_(Triggers_cType_!=_CompTypeNWStack_error)
--- PASS: TestGnmiGetSoftwareComponents (1.93s)
    --- PASS: TestGnmiGetSoftwareComponents/Get_OS_Full_Component_Subtree_(AllPaths) (0.04s)
    --- PASS: TestGnmiGetSoftwareComponents/Get_OS_State_Container_(StatePaths) (0.02s)
    --- PASS: TestGnmiGetSoftwareComponents/Get_BootLoader_Full_Subtree (0.01s)
    --- PASS: TestGnmiGetSoftwareComponents/Get_Network_Stack_Full_Subtree (0.02s)
    --- PASS: TestGnmiGetSoftwareComponents/Get_OS_Component_State_Name (0.02s)
    --- PASS: TestGnmiGetSoftwareComponents/Get_OS_Component_Type (0.02s)
    --- PASS: TestGnmiGetSoftwareComponents/Get_OS_Component_State_(Software_Version) (0.02s)
    --- PASS: TestGnmiGetSoftwareComponents/Get_OS_Component_State_Parent (0.02s)
    --- PASS: TestGnmiGetSoftwareComponents/Get_OS_Component_State_Oper_Status (0.02s)
    --- PASS: TestGnmiGetSoftwareComponents/Get_Bootloader_Software_Version (0.02s)
    --- PASS: TestGnmiGetSoftwareComponents/Get_Bootloader_component_name (0.02s)
    --- PASS: TestGnmiGetSoftwareComponents/Get_Bootloader_Specific_Type (0.02s)
    --- PASS: TestGnmiGetSoftwareComponents/Get_Software_Module_(Network_Stack)_Type (0.02s)
    --- PASS: TestGnmiGetSoftwareComponents/Get_Software_Module_Oper_Status (0.02s)
    --- PASS: TestGnmiGetSoftwareComponents/Get_Network_Stack_Component_State_Type (0.02s)
    --- PASS: TestGnmiGetSoftwareComponents/Get_Software_Module_Container_Path_(COMP_SW_MOD) (0.02s)
    --- PASS: TestGnmiGetSoftwareComponents/Get_Software_Module_State_Container_Path_(COMP_SW_MOD_ST) (0.01s)
    --- PASS: TestGnmiGetSoftwareComponents/Get_Non-Existent_SW_Component_(NotFound) (0.01s)
    --- PASS: TestGnmiGetSoftwareComponents/Get_OS_Component_Software_Version_when_missing_in_DB_(Expect_Error) (0.01s)
    --- PASS: TestGnmiGetSoftwareComponents/Get_Non-Existent_SW_Component_(Unknown_Component_Name) (0.01s)
    --- PASS: TestGnmiGetSoftwareComponents/Trigger_getCompTypeByName_for_OS_pattern_(not_in_DB) (0.01s)
    --- PASS: TestGnmiGetSoftwareComponents/Trigger_getCompTypeByName_for_Network_Stack_pattern_(not_in_DB) (0.01s)
    --- PASS: TestGnmiGetSoftwareComponents/Trigger_getCompTypeByName_for_BootLoader_pattern_(not_in_DB) (0.01s)
    --- PASS: TestGnmiGetSoftwareComponents/Get_Oper_Status_on_OS_with_invalid_status_string_in_DB_(Triggers_invalid_field_value_error) (0.02s)
    --- PASS: TestGnmiGetSoftwareComponents/Get_Module_Type_on_OS_Component_(Triggers_cType_!=_CompTypeNWStack_error) (0.01s)
PASS
