### PR TITLE
Add paths_blacklist flag to reject blacklisted paths in Get/Set/Subscribe

### DIFF
--- a/gnmi_server/client_subscribe.go
+++ b/gnmi_server/client_subscribe.go
@@ -176,10 +176,6 @@ func (c *Client) Run(stream gnmipb.GNMI_SubscribeServer, config *Config) (err er
 		return status.Error(codes.InvalidArgument, "Origin conflict between prefix and paths")
 	}
 
-	if err := config.PathsBlacklist.CheckPaths(prefix, paths); err != nil {
-		return err
-	}
-
 	if connectionKey, valid = connectionManager.Add(c.addr, query.String()); !valid {
 		return grpc.Errorf(codes.Unavailable, "Server connections are at capacity.")
 	}
@@ -230,6 +226,12 @@ func (c *Client) Run(stream gnmipb.GNMI_SubscribeServer, config *Config) (err er
 	ctx = stream.Context()
 	ctx, err = authenticate(config, ctx, authTarget, false)
 	if err != nil {
+		return err
+	}
+
+	// Checked after authenticate so unauthenticated callers get
+	// Unauthenticated instead of a policy result.
+	if err := checkPathsBlacklist(config.PathsBlacklist, prefix, paths); err != nil {
 		return err
 	}
 

--- a/gnmi_server/client_subscribe.go
+++ b/gnmi_server/client_subscribe.go
@@ -176,6 +176,10 @@ func (c *Client) Run(stream gnmipb.GNMI_SubscribeServer, config *Config) (err er
 		return status.Error(codes.InvalidArgument, "Origin conflict between prefix and paths")
 	}
 
+	if err := config.PathsBlacklist.CheckPaths(prefix, paths); err != nil {
+		return err
+	}
+
 	if connectionKey, valid = connectionManager.Add(c.addr, query.String()); !valid {
 		return grpc.Errorf(codes.Unavailable, "Server connections are at capacity.")
 	}

--- a/gnmi_server/paths_blacklist.go
+++ b/gnmi_server/paths_blacklist.go
@@ -1,0 +1,160 @@
+package gnmi
+
+// Paths blacklist support: rejects gNMI RPCs (Get/Set/Subscribe) that
+// reference blacklisted paths. The blacklist is loaded once at process
+// startup from a plain text file passed via the telemetry -paths_blacklist
+// flag.
+//
+// File format, one "TARGET /path/to/subtree" entry per line, e.g.:
+//
+//	COUNTERS_DB /COUNTERS/Ethernet0
+//	* /some/path
+//
+// TARGET is matched against the request prefix target; "*" matches any
+// target. Path elements are matched by name, "*" matches any element.
+// Matching is by subtree overlap: a request is rejected when the blacklist
+// entry covers the request path or the request path covers the entry, since
+// either way the response would include blacklisted data.
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	gnmipb "github.com/openconfig/gnmi/proto/gnmi"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const blacklistWildcard = "*"
+
+type blacklistEntry struct {
+	target string
+	elems  []string
+}
+
+// PathsBlacklist is an immutable set of blacklisted paths. A nil
+// *PathsBlacklist is valid and blocks nothing.
+type PathsBlacklist struct {
+	entries []blacklistEntry
+}
+
+// LoadPathsBlacklist reads and parses a blacklist file.
+func LoadPathsBlacklist(filename string) (*PathsBlacklist, error) {
+	f, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return ParsePathsBlacklist(f, filename)
+}
+
+// ParsePathsBlacklist reads blacklist entries from r. name is used in error
+// messages only.
+func ParsePathsBlacklist(r io.Reader, name string) (*PathsBlacklist, error) {
+	b := &PathsBlacklist{}
+	scanner := bufio.NewScanner(r)
+	lineNum := 0
+	for scanner.Scan() {
+		lineNum++
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			return nil, fmt.Errorf("%s:%d: expected 'TARGET PATH', got %q", name, lineNum, line)
+		}
+		trimmed := strings.TrimPrefix(fields[1], "/")
+		if trimmed == "" {
+			return nil, fmt.Errorf("%s:%d: empty path %q", name, lineNum, fields[1])
+		}
+		elems := strings.Split(trimmed, "/")
+		for _, elem := range elems {
+			if elem == "" {
+				return nil, fmt.Errorf("%s:%d: invalid path %q: empty element", name, lineNum, fields[1])
+			}
+			if strings.ContainsAny(elem, "[]") {
+				return nil, fmt.Errorf("%s:%d: invalid path %q: [key=value] qualifiers are not supported, use element names only", name, lineNum, fields[1])
+			}
+		}
+		b.entries = append(b.entries, blacklistEntry{target: fields[0], elems: elems})
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("%s: %v", name, err)
+	}
+	return b, nil
+}
+
+// Len returns the number of blacklist entries.
+func (b *PathsBlacklist) Len() int {
+	if b == nil {
+		return 0
+	}
+	return len(b.entries)
+}
+
+// CheckPaths returns a PermissionDenied error if any of the given request
+// paths, combined with the request prefix, is covered by the blacklist.
+// A nil PathsBlacklist allows everything.
+func (b *PathsBlacklist) CheckPaths(prefix *gnmipb.Path, paths []*gnmipb.Path) error {
+	if b == nil || len(b.entries) == 0 {
+		return nil
+	}
+	target := prefix.GetTarget()
+	for _, path := range paths {
+		reqElems := requestElemNames(prefix, path)
+		for _, e := range b.entries {
+			if e.target != blacklistWildcard && e.target != target {
+				continue
+			}
+			if blacklistOverlaps(e.elems, reqElems) {
+				return status.Errorf(codes.PermissionDenied,
+					"request path %q is blacklisted (matched entry %q)",
+					target+"/"+strings.Join(reqElems, "/"),
+					e.target+" /"+strings.Join(e.elems, "/"))
+			}
+		}
+	}
+	return nil
+}
+
+// blacklistOverlaps reports whether one path is a prefix of the other (or
+// both are equal), where "*" on either side matches any element name.
+// Blocking in both directions is deliberate: a request deeper than a
+// blacklisted subtree reads blacklisted data, and a request for an ancestor
+// of a blacklisted subtree would include that subtree in its response.
+func blacklistOverlaps(bl, req []string) bool {
+	n := len(bl)
+	if len(req) < n {
+		n = len(req)
+	}
+	for i := 0; i < n; i++ {
+		if bl[i] != blacklistWildcard && req[i] != blacklistWildcard && bl[i] != req[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// requestElemNames flattens prefix + path into a list of element names.
+// Paths using the deprecated Element field are supported for backward
+// compatibility. Key qualifiers on elements are ignored; matching is by
+// element name only.
+func requestElemNames(prefix, path *gnmipb.Path) []string {
+	var out []string
+	if len(prefix.GetElem()) > 0 || len(path.GetElem()) > 0 {
+		for _, pe := range prefix.GetElem() {
+			out = append(out, pe.GetName())
+		}
+		for _, pe := range path.GetElem() {
+			out = append(out, pe.GetName())
+		}
+		return out
+	}
+	out = append(out, prefix.GetElement()...)
+	out = append(out, path.GetElement()...)
+	return out
+}

--- a/gnmi_server/paths_blacklist.go
+++ b/gnmi_server/paths_blacklist.go
@@ -1,160 +1,78 @@
 package gnmi
 
-// Paths blacklist support: rejects gNMI RPCs (Get/Set/Subscribe) that
-// reference blacklisted paths. The blacklist is loaded once at process
-// startup from a plain text file passed via the telemetry -paths_blacklist
-// flag.
-//
-// File format, one "TARGET /path/to/subtree" entry per line, e.g.:
-//
-//	COUNTERS_DB /COUNTERS/Ethernet0
-//	* /some/path
-//
-// TARGET is matched against the request prefix target; "*" matches any
-// target. Path elements are matched by name, "*" matches any element.
-// Matching is by subtree overlap: a request is rejected when the blacklist
-// entry covers the request path or the request path covers the entry, since
-// either way the response would include blacklisted data.
+// Adapter between the pure pkg/pathblacklist policy and the gNMI server:
+// normalizes protobuf request paths into pathblacklist.Path values and
+// translates a policy match into a gRPC PermissionDenied error. The matched
+// entry is logged server-side only; clients receive a generic denial so the
+// policy contents cannot be enumerated.
 
 import (
-	"bufio"
-	"fmt"
-	"io"
-	"os"
-	"strings"
-
+	log "github.com/golang/glog"
 	gnmipb "github.com/openconfig/gnmi/proto/gnmi"
+	"github.com/sonic-net/sonic-gnmi/pkg/pathblacklist"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
-const blacklistWildcard = "*"
-
-type blacklistEntry struct {
-	target string
-	elems  []string
-}
-
-// PathsBlacklist is an immutable set of blacklisted paths. A nil
-// *PathsBlacklist is valid and blocks nothing.
-type PathsBlacklist struct {
-	entries []blacklistEntry
-}
-
-// LoadPathsBlacklist reads and parses a blacklist file.
-func LoadPathsBlacklist(filename string) (*PathsBlacklist, error) {
-	f, err := os.Open(filename)
-	if err != nil {
-		return nil, err
-	}
-	defer f.Close()
-	return ParsePathsBlacklist(f, filename)
-}
-
-// ParsePathsBlacklist reads blacklist entries from r. name is used in error
-// messages only.
-func ParsePathsBlacklist(r io.Reader, name string) (*PathsBlacklist, error) {
-	b := &PathsBlacklist{}
-	scanner := bufio.NewScanner(r)
-	lineNum := 0
-	for scanner.Scan() {
-		lineNum++
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" {
-			continue
-		}
-		fields := strings.Fields(line)
-		if len(fields) != 2 {
-			return nil, fmt.Errorf("%s:%d: expected 'TARGET PATH', got %q", name, lineNum, line)
-		}
-		trimmed := strings.TrimPrefix(fields[1], "/")
-		if trimmed == "" {
-			return nil, fmt.Errorf("%s:%d: empty path %q", name, lineNum, fields[1])
-		}
-		elems := strings.Split(trimmed, "/")
-		for _, elem := range elems {
-			if elem == "" {
-				return nil, fmt.Errorf("%s:%d: invalid path %q: empty element", name, lineNum, fields[1])
-			}
-			if strings.ContainsAny(elem, "[]") {
-				return nil, fmt.Errorf("%s:%d: invalid path %q: [key=value] qualifiers are not supported, use element names only", name, lineNum, fields[1])
-			}
-		}
-		b.entries = append(b.entries, blacklistEntry{target: fields[0], elems: elems})
-	}
-	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("%s: %v", name, err)
-	}
-	return b, nil
-}
-
-// Len returns the number of blacklist entries.
-func (b *PathsBlacklist) Len() int {
-	if b == nil {
-		return 0
-	}
-	return len(b.entries)
-}
-
-// CheckPaths returns a PermissionDenied error if any of the given request
-// paths, combined with the request prefix, is covered by the blacklist.
-// A nil PathsBlacklist allows everything.
-func (b *PathsBlacklist) CheckPaths(prefix *gnmipb.Path, paths []*gnmipb.Path) error {
-	if b == nil || len(b.entries) == 0 {
+// checkPathsBlacklist returns a PermissionDenied error if any of the given
+// request paths, combined with the request prefix, is covered by the policy.
+// A nil policy allows everything.
+func checkPathsBlacklist(policy *pathblacklist.Policy, prefix *gnmipb.Path, paths []*gnmipb.Path) error {
+	if policy.Len() == 0 {
 		return nil
 	}
-	target := prefix.GetTarget()
 	for _, path := range paths {
-		reqElems := requestElemNames(prefix, path)
-		for _, e := range b.entries {
-			if e.target != blacklistWildcard && e.target != target {
-				continue
-			}
-			if blacklistOverlaps(e.elems, reqElems) {
-				return status.Errorf(codes.PermissionDenied,
-					"request path %q is blacklisted (matched entry %q)",
-					target+"/"+strings.Join(reqElems, "/"),
-					e.target+" /"+strings.Join(e.elems, "/"))
-			}
+		req := normalizeRequestPath(prefix, path)
+		if entry, ok := policy.Match(req); ok {
+			log.V(2).Infof("Rejecting request: target %q path %v matched paths blacklist entry %q",
+				req.Target, req.Elems, entry)
+			return status.Error(codes.PermissionDenied, "request path is blocked by policy")
 		}
 	}
 	return nil
 }
 
-// blacklistOverlaps reports whether one path is a prefix of the other (or
-// both are equal), where "*" on either side matches any element name.
-// Blocking in both directions is deliberate: a request deeper than a
-// blacklisted subtree reads blacklisted data, and a request for an ancestor
-// of a blacklisted subtree would include that subtree in its response.
-func blacklistOverlaps(bl, req []string) bool {
-	n := len(bl)
-	if len(req) < n {
-		n = len(req)
+// normalizeRequestPath flattens prefix + path into a pathblacklist.Path,
+// mapping both wire forms of a DB request to the same normalized value:
+//
+//	prefix.target=CONFIG_DB, path=/PORT           -> {CONFIG_DB, [PORT]}
+//	origin=sonic-db, /CONFIG_DB/localhost/PORT    -> {CONFIG_DB, [PORT]}
+//
+// In the native sonic-db form the first element is the database and the
+// second is the namespace/container instance (see MixedDbClient.ParseDatabase).
+func normalizeRequestPath(prefix, path *gnmipb.Path) pathblacklist.Path {
+	elems := append(elemNames(prefix), elemNames(path)...)
+	target := prefix.GetTarget()
+	origin := prefix.GetOrigin()
+	if origin == "" {
+		origin = path.GetOrigin()
 	}
-	for i := 0; i < n; i++ {
-		if bl[i] != blacklistWildcard && req[i] != blacklistWildcard && bl[i] != req[i] {
-			return false
+	if IsNativeOrigin(origin) && len(elems) > 0 {
+		target = elems[0]
+		if len(elems) > 2 {
+			elems = elems[2:]
+		} else {
+			elems = nil
 		}
 	}
-	return true
+	return pathblacklist.Path{Target: target, Elems: elems}
 }
 
-// requestElemNames flattens prefix + path into a list of element names.
-// Paths using the deprecated Element field are supported for backward
-// compatibility. Key qualifiers on elements are ignored; matching is by
-// element name only.
-func requestElemNames(prefix, path *gnmipb.Path) []string {
-	var out []string
-	if len(prefix.GetElem()) > 0 || len(path.GetElem()) > 0 {
-		for _, pe := range prefix.GetElem() {
-			out = append(out, pe.GetName())
+// elemNames returns the element names of a single path part, supporting the
+// deprecated Element field for backward compatibility. Handling each part
+// independently keeps requests that mix encodings between prefix and path
+// from dropping elements. Key qualifiers on elements are ignored; matching
+// is by element name only.
+func elemNames(p *gnmipb.Path) []string {
+	if len(p.GetElem()) > 0 {
+		names := make([]string, 0, len(p.GetElem()))
+		for _, pe := range p.GetElem() {
+			names = append(names, pe.GetName())
 		}
-		for _, pe := range path.GetElem() {
-			out = append(out, pe.GetName())
-		}
-		return out
+		return names
 	}
-	out = append(out, prefix.GetElement()...)
-	out = append(out, path.GetElement()...)
-	return out
+	if len(p.GetElement()) > 0 {
+		return append([]string(nil), p.GetElement()...)
+	}
+	return nil
 }

--- a/gnmi_server/paths_blacklist_rpc_test.go
+++ b/gnmi_server/paths_blacklist_rpc_test.go
@@ -1,0 +1,221 @@
+package gnmi
+
+// RPC-level tests for paths blacklist enforcement: they start a gNMI server
+// with Config.PathsBlacklist set and assert that Get, Set, and Subscribe are
+// rejected with a generic PermissionDenied, and that authentication failures
+// take precedence over blacklist results.
+
+import (
+	"context"
+	"crypto/tls"
+	"strings"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/status"
+
+	pb "github.com/openconfig/gnmi/proto/gnmi"
+	testcert "github.com/sonic-net/sonic-gnmi/testdata/tls"
+
+	"github.com/sonic-net/sonic-gnmi/pkg/pathblacklist"
+	sdcfg "github.com/sonic-net/sonic-gnmi/sonic_db_config"
+)
+
+func createBlacklistServer(t *testing.T, port int64, policyContent string, userAuth AuthTypes) *Server {
+	t.Helper()
+	policy, err := pathblacklist.Parse(strings.NewReader(policyContent))
+	if err != nil {
+		t.Fatalf("failed to parse blacklist policy: %v", err)
+	}
+	certificate, err := testcert.NewCert()
+	if err != nil {
+		t.Fatalf("could not load server key pair: %s", err)
+	}
+	tlsCfg := &tls.Config{
+		ClientAuth:   tls.RequestClientCert,
+		Certificates: []tls.Certificate{certificate},
+	}
+	tlsOpts := []grpc.ServerOption{grpc.Creds(credentials.NewTLS(tlsCfg))}
+	cfg := &Config{
+		Port:                port,
+		EnableTranslibWrite: true,
+		EnableNativeWrite:   true,
+		Threshold:           100,
+		ImgDir:              "/tmp",
+		UserAuth:            userAuth,
+		PathsBlacklist:      policy,
+	}
+	s, err := NewServer(cfg, tlsOpts, nil)
+	if err != nil {
+		t.Fatalf("Failed to create gNMI server: %v", err)
+	}
+	return s
+}
+
+func dialBlacklistServer(t *testing.T) (pb.GNMIClient, *grpc.ClientConn) {
+	t.Helper()
+	tlsConfig := &tls.Config{InsecureSkipVerify: true}
+	opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
+	conn, err := grpc.Dial("127.0.0.1:8081", opts...)
+	if err != nil {
+		t.Fatalf("Dialing to 127.0.0.1:8081 failed: %v", err)
+	}
+	return pb.NewGNMIClient(conn), conn
+}
+
+func TestGetWithPathsBlacklist(t *testing.T) {
+	s := createBlacklistServer(t, 8081,
+		"COUNTERS_DB /COUNTERS/Ethernet68\nCONFIG_DB /PORT\n", nil)
+	go runServer(t, s)
+	defer s.ForceStop()
+
+	ns, _ := sdcfg.GetDbDefaultNamespace()
+	prepareDb(t, ns)
+
+	gClient, conn := dialBlacklistServer(t)
+	defer conn.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	tds := []struct {
+		desc        string
+		pathTarget  string
+		textPbPath  string
+		wantRetCode codes.Code
+	}{
+		{
+			desc:        "blacklisted path is rejected",
+			pathTarget:  "COUNTERS_DB",
+			textPbPath:  `elem: <name: "COUNTERS" > elem: <name: "Ethernet68" >`,
+			wantRetCode: codes.PermissionDenied,
+		},
+		{
+			desc:        "suffix glob covering blacklisted path is rejected",
+			pathTarget:  "COUNTERS_DB",
+			textPbPath:  `elem: <name: "COUNTERS" > elem: <name: "Ethernet*" >`,
+			wantRetCode: codes.PermissionDenied,
+		},
+		{
+			desc:        "ancestor of blacklisted path is rejected",
+			pathTarget:  "COUNTERS_DB",
+			textPbPath:  `elem: <name: "COUNTERS" >`,
+			wantRetCode: codes.PermissionDenied,
+		},
+		{
+			desc:        "sibling path is allowed",
+			pathTarget:  "COUNTERS_DB",
+			textPbPath:  `elem: <name: "COUNTERS" > elem: <name: "Ethernet1" >`,
+			wantRetCode: codes.OK,
+		},
+	}
+	for _, td := range tds {
+		t.Run(td.desc, func(t *testing.T) {
+			runTestGet(t, ctx, gClient, td.pathTarget, td.textPbPath, td.wantRetCode, nil, false)
+		})
+	}
+
+	t.Run("native sonic-db form is rejected", func(t *testing.T) {
+		req := &pb.GetRequest{
+			Prefix: &pb.Path{Origin: "sonic-db"},
+			Path: []*pb.Path{{Elem: []*pb.PathElem{
+				{Name: "CONFIG_DB"}, {Name: "localhost"}, {Name: "PORT"}}}},
+			Encoding: pb.Encoding_JSON_IETF,
+		}
+		_, err := gClient.Get(ctx, req)
+		if got := status.Code(err); got != codes.PermissionDenied {
+			t.Fatalf("got return code %v (err %v), want PermissionDenied", got, err)
+		}
+	})
+}
+
+func TestSetWithPathsBlacklist(t *testing.T) {
+	s := createBlacklistServer(t, 8081, "CONFIG_DB /PORT\n", nil)
+	go runServer(t, s)
+	defer s.ForceStop()
+
+	gClient, conn := dialBlacklistServer(t)
+	defer conn.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	req := &pb.SetRequest{
+		Prefix: &pb.Path{Origin: "sonic-db"},
+		Update: []*pb.Update{{
+			Path: &pb.Path{Elem: []*pb.PathElem{
+				{Name: "CONFIG_DB"}, {Name: "localhost"}, {Name: "PORT"}, {Name: "Ethernet0"}}},
+			Val: &pb.TypedValue{Value: &pb.TypedValue_JsonIetfVal{JsonIetfVal: []byte(`{"admin_status": "down"}`)}},
+		}},
+	}
+	_, err := gClient.Set(ctx, req)
+	if got := status.Code(err); got != codes.PermissionDenied {
+		t.Fatalf("got return code %v (err %v), want PermissionDenied", got, err)
+	}
+	if msg := status.Convert(err).Message(); strings.Contains(msg, "CONFIG_DB") {
+		t.Fatalf("error message leaks policy contents: %q", msg)
+	}
+}
+
+func TestSubscribeWithPathsBlacklist(t *testing.T) {
+	s := createBlacklistServer(t, 8081, "COUNTERS_DB /COUNTERS/Ethernet68\n", nil)
+	go runServer(t, s)
+	defer s.ForceStop()
+
+	ns, _ := sdcfg.GetDbDefaultNamespace()
+	prepareDb(t, ns)
+
+	gClient, conn := dialBlacklistServer(t)
+	defer conn.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	stream, err := gClient.Subscribe(ctx)
+	if err != nil {
+		t.Fatalf("Subscribe failed: %v", err)
+	}
+	sub := &pb.SubscribeRequest{Request: &pb.SubscribeRequest_Subscribe{
+		Subscribe: &pb.SubscriptionList{
+			Prefix: &pb.Path{Target: "COUNTERS_DB"},
+			Subscription: []*pb.Subscription{{
+				Path: &pb.Path{Elem: []*pb.PathElem{{Name: "COUNTERS"}, {Name: "Ethernet68"}}},
+			}},
+			Mode: pb.SubscriptionList_ONCE,
+		},
+	}}
+	if err := stream.Send(sub); err != nil {
+		t.Fatalf("Failed to send subscribe request: %v", err)
+	}
+	_, err = stream.Recv()
+	if got := status.Code(err); got != codes.PermissionDenied {
+		t.Fatalf("got return code %v (err %v), want PermissionDenied", got, err)
+	}
+}
+
+func TestPathsBlacklistUnauthenticated(t *testing.T) {
+	// With client auth enabled and no credentials supplied, an RPC for a
+	// blacklisted path must fail authentication, not report a policy result.
+	s := createBlacklistServer(t, 8081, "COUNTERS_DB /COUNTERS/Ethernet68\n",
+		AuthTypes{"password": true, "cert": true, "jwt": true})
+	go runServer(t, s)
+	defer s.ForceStop()
+
+	ns, _ := sdcfg.GetDbDefaultNamespace()
+	prepareDb(t, ns)
+
+	gClient, conn := dialBlacklistServer(t)
+	defer conn.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	req := &pb.GetRequest{
+		Prefix:   &pb.Path{Target: "COUNTERS_DB"},
+		Path:     []*pb.Path{{Elem: []*pb.PathElem{{Name: "COUNTERS"}, {Name: "Ethernet68"}}}},
+		Encoding: pb.Encoding_JSON_IETF,
+	}
+	_, err := gClient.Get(ctx, req)
+	if got := status.Code(err); got != codes.Unauthenticated {
+		t.Fatalf("got return code %v (err %v), want Unauthenticated", got, err)
+	}
+}

--- a/gnmi_server/paths_blacklist_test.go
+++ b/gnmi_server/paths_blacklist_test.go
@@ -1,0 +1,192 @@
+package gnmi
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	gnmipb "github.com/openconfig/gnmi/proto/gnmi"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func mustParseBlacklist(t *testing.T, content string) *PathsBlacklist {
+	t.Helper()
+	b, err := ParsePathsBlacklist(strings.NewReader(content), "test")
+	if err != nil {
+		t.Fatalf("ParsePathsBlacklist(%q) failed: %v", content, err)
+	}
+	return b
+}
+
+func elemPath(target string, names ...string) (*gnmipb.Path, *gnmipb.Path) {
+	prefix := &gnmipb.Path{Target: target}
+	path := &gnmipb.Path{}
+	for _, name := range names {
+		path.Elem = append(path.Elem, &gnmipb.PathElem{Name: name})
+	}
+	return prefix, path
+}
+
+func TestParsePathsBlacklist(t *testing.T) {
+	tests := []struct {
+		desc    string
+		content string
+		wantLen int
+		wantErr bool
+	}{
+		{desc: "empty file", content: "", wantLen: 0},
+		{desc: "blank lines skipped", content: "\n\nCOUNTERS_DB /COUNTERS\n\n", wantLen: 1},
+		{desc: "multiple entries", content: "COUNTERS_DB /COUNTERS/Ethernet0\n* /a/b\n", wantLen: 2},
+		{desc: "wildcard elements", content: "APPL_DB /PORT_TABLE/*/oper_status\n", wantLen: 1},
+		{desc: "keyed path rejected", content: "APPL_DB /interfaces/interface[name=Ethernet0]/state\n", wantErr: true},
+		{desc: "missing path", content: "COUNTERS_DB\n", wantErr: true},
+		{desc: "too many fields", content: "COUNTERS_DB /COUNTERS extra\n", wantErr: true},
+		{desc: "empty path", content: "COUNTERS_DB /\n", wantErr: true},
+		{desc: "empty element", content: "APPL_DB /a//b\n", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			b, err := ParsePathsBlacklist(strings.NewReader(tt.content), "test")
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if b.Len() != tt.wantLen {
+				t.Fatalf("Len() = %d, want %d", b.Len(), tt.wantLen)
+			}
+		})
+	}
+}
+
+func TestLoadPathsBlacklist(t *testing.T) {
+	if _, err := LoadPathsBlacklist("/nonexistent/blacklist.txt"); err == nil {
+		t.Fatal("expected error for missing file, got nil")
+	}
+
+	file := filepath.Join(t.TempDir(), "blacklist.txt")
+	if err := os.WriteFile(file, []byte("COUNTERS_DB /COUNTERS/Ethernet0\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	b, err := LoadPathsBlacklist(file)
+	if err != nil {
+		t.Fatalf("LoadPathsBlacklist failed: %v", err)
+	}
+	if b.Len() != 1 {
+		t.Fatalf("Len() = %d, want 1", b.Len())
+	}
+}
+
+func TestCheckPaths(t *testing.T) {
+	blacklist := mustParseBlacklist(t,
+		"COUNTERS_DB /COUNTERS/Ethernet0\n"+
+			"* /SECRET\n"+
+			"APPL_DB /PORT_TABLE/*/oper_status\n")
+
+	tests := []struct {
+		desc    string
+		target  string
+		elems   []string
+		blocked bool
+	}{
+		{desc: "exact match", target: "COUNTERS_DB", elems: []string{"COUNTERS", "Ethernet0"}, blocked: true},
+		{desc: "deeper than entry", target: "COUNTERS_DB", elems: []string{"COUNTERS", "Ethernet0", "SAI_PORT_STAT_IF_IN_ERRORS"}, blocked: true},
+		{desc: "ancestor of entry", target: "COUNTERS_DB", elems: []string{"COUNTERS"}, blocked: true},
+		{desc: "request wildcard covers entry", target: "COUNTERS_DB", elems: []string{"COUNTERS", "*"}, blocked: true},
+		{desc: "sibling allowed", target: "COUNTERS_DB", elems: []string{"COUNTERS", "Ethernet4"}, blocked: false},
+		{desc: "other target allowed", target: "CONFIG_DB", elems: []string{"COUNTERS", "Ethernet0"}, blocked: false},
+		{desc: "wildcard target blocks any target", target: "CONFIG_DB", elems: []string{"SECRET"}, blocked: true},
+		{desc: "wildcard entry element", target: "APPL_DB", elems: []string{"PORT_TABLE", "Ethernet12", "oper_status"}, blocked: true},
+		{desc: "wildcard entry element, other leaf", target: "APPL_DB", elems: []string{"PORT_TABLE", "Ethernet12", "admin_status"}, blocked: false},
+		{desc: "unrelated path allowed", target: "APPL_DB", elems: []string{"LLDP_ENTRY_TABLE"}, blocked: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			prefix, path := elemPath(tt.target, tt.elems...)
+			err := blacklist.CheckPaths(prefix, []*gnmipb.Path{path})
+			if tt.blocked {
+				if err == nil {
+					t.Fatal("expected PermissionDenied, got nil")
+				}
+				if status.Code(err) != codes.PermissionDenied {
+					t.Fatalf("expected PermissionDenied, got %v", err)
+				}
+			} else if err != nil {
+				t.Fatalf("expected nil, got %v", err)
+			}
+		})
+	}
+}
+
+func TestCheckPathsPrefixElems(t *testing.T) {
+	blacklist := mustParseBlacklist(t, "COUNTERS_DB /COUNTERS/Ethernet0\n")
+
+	// Path split across prefix elems and path elems.
+	prefix := &gnmipb.Path{
+		Target: "COUNTERS_DB",
+		Elem:   []*gnmipb.PathElem{{Name: "COUNTERS"}},
+	}
+	path := &gnmipb.Path{Elem: []*gnmipb.PathElem{{Name: "Ethernet0"}}}
+	if err := blacklist.CheckPaths(prefix, []*gnmipb.Path{path}); status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("expected PermissionDenied, got %v", err)
+	}
+}
+
+func TestCheckPathsDeprecatedElement(t *testing.T) {
+	blacklist := mustParseBlacklist(t, "COUNTERS_DB /COUNTERS/Ethernet0\n")
+
+	prefix := &gnmipb.Path{Target: "COUNTERS_DB"}
+	path := &gnmipb.Path{Element: []string{"COUNTERS", "Ethernet0"}}
+	if err := blacklist.CheckPaths(prefix, []*gnmipb.Path{path}); status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("expected PermissionDenied, got %v", err)
+	}
+
+	allowed := &gnmipb.Path{Element: []string{"COUNTERS", "Ethernet4"}}
+	if err := blacklist.CheckPaths(prefix, []*gnmipb.Path{allowed}); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+}
+
+func TestCheckPathsKeyedRequest(t *testing.T) {
+	// Keys on request elements are ignored; matching is by element name.
+	blacklist := mustParseBlacklist(t, "* /interfaces/interface/state\n")
+
+	prefix := &gnmipb.Path{}
+	path := &gnmipb.Path{Elem: []*gnmipb.PathElem{
+		{Name: "interfaces"},
+		{Name: "interface", Key: map[string]string{"name": "Ethernet0"}},
+		{Name: "state"},
+	}}
+	if err := blacklist.CheckPaths(prefix, []*gnmipb.Path{path}); status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("expected PermissionDenied, got %v", err)
+	}
+}
+
+func TestCheckPathsNilBlacklist(t *testing.T) {
+	var blacklist *PathsBlacklist
+	prefix, path := elemPath("COUNTERS_DB", "COUNTERS", "Ethernet0")
+	if err := blacklist.CheckPaths(prefix, []*gnmipb.Path{path}); err != nil {
+		t.Fatalf("nil blacklist must allow everything, got %v", err)
+	}
+}
+
+func TestCheckPathsMultiplePaths(t *testing.T) {
+	blacklist := mustParseBlacklist(t, "COUNTERS_DB /COUNTERS/Ethernet0\n")
+	prefix := &gnmipb.Path{Target: "COUNTERS_DB"}
+	allowed := &gnmipb.Path{Elem: []*gnmipb.PathElem{{Name: "COUNTERS"}, {Name: "Ethernet4"}}}
+	blocked := &gnmipb.Path{Elem: []*gnmipb.PathElem{{Name: "COUNTERS"}, {Name: "Ethernet0"}}}
+
+	// One blacklisted path anywhere in the request rejects the whole RPC.
+	if err := blacklist.CheckPaths(prefix, []*gnmipb.Path{allowed, blocked}); status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("expected PermissionDenied, got %v", err)
+	}
+	if err := blacklist.CheckPaths(prefix, []*gnmipb.Path{allowed}); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+}

--- a/gnmi_server/paths_blacklist_test.go
+++ b/gnmi_server/paths_blacklist_test.go
@@ -1,192 +1,171 @@
 package gnmi
 
 import (
-	"os"
-	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
 	gnmipb "github.com/openconfig/gnmi/proto/gnmi"
+	"github.com/sonic-net/sonic-gnmi/pkg/pathblacklist"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
-func mustParseBlacklist(t *testing.T, content string) *PathsBlacklist {
+func mustPolicy(t *testing.T, content string) *pathblacklist.Policy {
 	t.Helper()
-	b, err := ParsePathsBlacklist(strings.NewReader(content), "test")
+	p, err := pathblacklist.Parse(strings.NewReader(content))
 	if err != nil {
-		t.Fatalf("ParsePathsBlacklist(%q) failed: %v", content, err)
+		t.Fatalf("Parse(%q) failed: %v", content, err)
 	}
-	return b
+	return p
 }
 
-func elemPath(target string, names ...string) (*gnmipb.Path, *gnmipb.Path) {
-	prefix := &gnmipb.Path{Target: target}
-	path := &gnmipb.Path{}
-	for _, name := range names {
-		path.Elem = append(path.Elem, &gnmipb.PathElem{Name: name})
-	}
-	return prefix, path
-}
-
-func TestParsePathsBlacklist(t *testing.T) {
-	tests := []struct {
-		desc    string
-		content string
-		wantLen int
-		wantErr bool
-	}{
-		{desc: "empty file", content: "", wantLen: 0},
-		{desc: "blank lines skipped", content: "\n\nCOUNTERS_DB /COUNTERS\n\n", wantLen: 1},
-		{desc: "multiple entries", content: "COUNTERS_DB /COUNTERS/Ethernet0\n* /a/b\n", wantLen: 2},
-		{desc: "wildcard elements", content: "APPL_DB /PORT_TABLE/*/oper_status\n", wantLen: 1},
-		{desc: "keyed path rejected", content: "APPL_DB /interfaces/interface[name=Ethernet0]/state\n", wantErr: true},
-		{desc: "missing path", content: "COUNTERS_DB\n", wantErr: true},
-		{desc: "too many fields", content: "COUNTERS_DB /COUNTERS extra\n", wantErr: true},
-		{desc: "empty path", content: "COUNTERS_DB /\n", wantErr: true},
-		{desc: "empty element", content: "APPL_DB /a//b\n", wantErr: true},
-	}
-	for _, tt := range tests {
-		t.Run(tt.desc, func(t *testing.T) {
-			b, err := ParsePathsBlacklist(strings.NewReader(tt.content), "test")
-			if tt.wantErr {
-				if err == nil {
-					t.Fatalf("expected error, got nil")
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if b.Len() != tt.wantLen {
-				t.Fatalf("Len() = %d, want %d", b.Len(), tt.wantLen)
-			}
-		})
-	}
-}
-
-func TestLoadPathsBlacklist(t *testing.T) {
-	if _, err := LoadPathsBlacklist("/nonexistent/blacklist.txt"); err == nil {
-		t.Fatal("expected error for missing file, got nil")
-	}
-
-	file := filepath.Join(t.TempDir(), "blacklist.txt")
-	if err := os.WriteFile(file, []byte("COUNTERS_DB /COUNTERS/Ethernet0\n"), 0644); err != nil {
-		t.Fatal(err)
-	}
-	b, err := LoadPathsBlacklist(file)
-	if err != nil {
-		t.Fatalf("LoadPathsBlacklist failed: %v", err)
-	}
-	if b.Len() != 1 {
-		t.Fatalf("Len() = %d, want 1", b.Len())
-	}
-}
-
-func TestCheckPaths(t *testing.T) {
-	blacklist := mustParseBlacklist(t,
-		"COUNTERS_DB /COUNTERS/Ethernet0\n"+
-			"* /SECRET\n"+
-			"APPL_DB /PORT_TABLE/*/oper_status\n")
-
-	tests := []struct {
-		desc    string
-		target  string
-		elems   []string
-		blocked bool
-	}{
-		{desc: "exact match", target: "COUNTERS_DB", elems: []string{"COUNTERS", "Ethernet0"}, blocked: true},
-		{desc: "deeper than entry", target: "COUNTERS_DB", elems: []string{"COUNTERS", "Ethernet0", "SAI_PORT_STAT_IF_IN_ERRORS"}, blocked: true},
-		{desc: "ancestor of entry", target: "COUNTERS_DB", elems: []string{"COUNTERS"}, blocked: true},
-		{desc: "request wildcard covers entry", target: "COUNTERS_DB", elems: []string{"COUNTERS", "*"}, blocked: true},
-		{desc: "sibling allowed", target: "COUNTERS_DB", elems: []string{"COUNTERS", "Ethernet4"}, blocked: false},
-		{desc: "other target allowed", target: "CONFIG_DB", elems: []string{"COUNTERS", "Ethernet0"}, blocked: false},
-		{desc: "wildcard target blocks any target", target: "CONFIG_DB", elems: []string{"SECRET"}, blocked: true},
-		{desc: "wildcard entry element", target: "APPL_DB", elems: []string{"PORT_TABLE", "Ethernet12", "oper_status"}, blocked: true},
-		{desc: "wildcard entry element, other leaf", target: "APPL_DB", elems: []string{"PORT_TABLE", "Ethernet12", "admin_status"}, blocked: false},
-		{desc: "unrelated path allowed", target: "APPL_DB", elems: []string{"LLDP_ENTRY_TABLE"}, blocked: false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.desc, func(t *testing.T) {
-			prefix, path := elemPath(tt.target, tt.elems...)
-			err := blacklist.CheckPaths(prefix, []*gnmipb.Path{path})
-			if tt.blocked {
-				if err == nil {
-					t.Fatal("expected PermissionDenied, got nil")
-				}
-				if status.Code(err) != codes.PermissionDenied {
-					t.Fatalf("expected PermissionDenied, got %v", err)
-				}
-			} else if err != nil {
-				t.Fatalf("expected nil, got %v", err)
-			}
-		})
-	}
-}
-
-func TestCheckPathsPrefixElems(t *testing.T) {
-	blacklist := mustParseBlacklist(t, "COUNTERS_DB /COUNTERS/Ethernet0\n")
-
-	// Path split across prefix elems and path elems.
-	prefix := &gnmipb.Path{
-		Target: "COUNTERS_DB",
-		Elem:   []*gnmipb.PathElem{{Name: "COUNTERS"}},
-	}
-	path := &gnmipb.Path{Elem: []*gnmipb.PathElem{{Name: "Ethernet0"}}}
-	if err := blacklist.CheckPaths(prefix, []*gnmipb.Path{path}); status.Code(err) != codes.PermissionDenied {
-		t.Fatalf("expected PermissionDenied, got %v", err)
-	}
-}
-
-func TestCheckPathsDeprecatedElement(t *testing.T) {
-	blacklist := mustParseBlacklist(t, "COUNTERS_DB /COUNTERS/Ethernet0\n")
-
+func TestCheckPathsBlacklist(t *testing.T) {
+	policy := mustPolicy(t, "COUNTERS_DB /COUNTERS/Ethernet0\n")
 	prefix := &gnmipb.Path{Target: "COUNTERS_DB"}
-	path := &gnmipb.Path{Element: []string{"COUNTERS", "Ethernet0"}}
-	if err := blacklist.CheckPaths(prefix, []*gnmipb.Path{path}); status.Code(err) != codes.PermissionDenied {
-		t.Fatalf("expected PermissionDenied, got %v", err)
-	}
-
-	allowed := &gnmipb.Path{Element: []string{"COUNTERS", "Ethernet4"}}
-	if err := blacklist.CheckPaths(prefix, []*gnmipb.Path{allowed}); err != nil {
-		t.Fatalf("expected nil, got %v", err)
-	}
-}
-
-func TestCheckPathsKeyedRequest(t *testing.T) {
-	// Keys on request elements are ignored; matching is by element name.
-	blacklist := mustParseBlacklist(t, "* /interfaces/interface/state\n")
-
-	prefix := &gnmipb.Path{}
-	path := &gnmipb.Path{Elem: []*gnmipb.PathElem{
-		{Name: "interfaces"},
-		{Name: "interface", Key: map[string]string{"name": "Ethernet0"}},
-		{Name: "state"},
-	}}
-	if err := blacklist.CheckPaths(prefix, []*gnmipb.Path{path}); status.Code(err) != codes.PermissionDenied {
-		t.Fatalf("expected PermissionDenied, got %v", err)
-	}
-}
-
-func TestCheckPathsNilBlacklist(t *testing.T) {
-	var blacklist *PathsBlacklist
-	prefix, path := elemPath("COUNTERS_DB", "COUNTERS", "Ethernet0")
-	if err := blacklist.CheckPaths(prefix, []*gnmipb.Path{path}); err != nil {
-		t.Fatalf("nil blacklist must allow everything, got %v", err)
-	}
-}
-
-func TestCheckPathsMultiplePaths(t *testing.T) {
-	blacklist := mustParseBlacklist(t, "COUNTERS_DB /COUNTERS/Ethernet0\n")
-	prefix := &gnmipb.Path{Target: "COUNTERS_DB"}
-	allowed := &gnmipb.Path{Elem: []*gnmipb.PathElem{{Name: "COUNTERS"}, {Name: "Ethernet4"}}}
 	blocked := &gnmipb.Path{Elem: []*gnmipb.PathElem{{Name: "COUNTERS"}, {Name: "Ethernet0"}}}
+	allowed := &gnmipb.Path{Elem: []*gnmipb.PathElem{{Name: "COUNTERS"}, {Name: "Ethernet4"}}}
 
-	// One blacklisted path anywhere in the request rejects the whole RPC.
-	if err := blacklist.CheckPaths(prefix, []*gnmipb.Path{allowed, blocked}); status.Code(err) != codes.PermissionDenied {
+	err := checkPathsBlacklist(policy, prefix, []*gnmipb.Path{allowed, blocked})
+	if status.Code(err) != codes.PermissionDenied {
 		t.Fatalf("expected PermissionDenied, got %v", err)
 	}
-	if err := blacklist.CheckPaths(prefix, []*gnmipb.Path{allowed}); err != nil {
-		t.Fatalf("expected nil, got %v", err)
+	// The denial must be generic: no policy contents in the client-visible error.
+	if msg := status.Convert(err).Message(); strings.Contains(msg, "COUNTERS") {
+		t.Fatalf("error message leaks policy contents: %q", msg)
+	}
+
+	if err := checkPathsBlacklist(policy, prefix, []*gnmipb.Path{allowed}); err != nil {
+		t.Fatalf("expected nil for allowed path, got %v", err)
+	}
+	if err := checkPathsBlacklist(nil, prefix, []*gnmipb.Path{blocked}); err != nil {
+		t.Fatalf("nil policy must allow everything, got %v", err)
+	}
+}
+
+func TestNormalizeRequestPath(t *testing.T) {
+	tests := []struct {
+		desc   string
+		prefix *gnmipb.Path
+		path   *gnmipb.Path
+		want   pathblacklist.Path
+	}{
+		{
+			desc:   "target form",
+			prefix: &gnmipb.Path{Target: "CONFIG_DB"},
+			path:   &gnmipb.Path{Elem: []*gnmipb.PathElem{{Name: "PORT"}}},
+			want:   pathblacklist.Path{Target: "CONFIG_DB", Elems: []string{"PORT"}},
+		},
+		{
+			desc:   "path split between prefix and path elems",
+			prefix: &gnmipb.Path{Target: "COUNTERS_DB", Elem: []*gnmipb.PathElem{{Name: "COUNTERS"}}},
+			path:   &gnmipb.Path{Elem: []*gnmipb.PathElem{{Name: "Ethernet0"}}},
+			want:   pathblacklist.Path{Target: "COUNTERS_DB", Elems: []string{"COUNTERS", "Ethernet0"}},
+		},
+		{
+			desc:   "deprecated Element field",
+			prefix: &gnmipb.Path{Target: "COUNTERS_DB", Element: []string{"COUNTERS"}},
+			path:   &gnmipb.Path{Element: []string{"Ethernet0"}},
+			want:   pathblacklist.Path{Target: "COUNTERS_DB", Elems: []string{"COUNTERS", "Ethernet0"}},
+		},
+		{
+			desc:   "mixed encodings: prefix Element with path Elem",
+			prefix: &gnmipb.Path{Target: "COUNTERS_DB", Element: []string{"COUNTERS"}},
+			path:   &gnmipb.Path{Elem: []*gnmipb.PathElem{{Name: "Ethernet0"}}},
+			want:   pathblacklist.Path{Target: "COUNTERS_DB", Elems: []string{"COUNTERS", "Ethernet0"}},
+		},
+		{
+			desc:   "mixed encodings: prefix Elem with path Element",
+			prefix: &gnmipb.Path{Target: "COUNTERS_DB", Elem: []*gnmipb.PathElem{{Name: "COUNTERS"}}},
+			path:   &gnmipb.Path{Element: []string{"Ethernet0"}},
+			want:   pathblacklist.Path{Target: "COUNTERS_DB", Elems: []string{"COUNTERS", "Ethernet0"}},
+		},
+		{
+			desc:   "keys on elements are ignored",
+			prefix: &gnmipb.Path{},
+			path: &gnmipb.Path{Elem: []*gnmipb.PathElem{
+				{Name: "interfaces"},
+				{Name: "interface", Key: map[string]string{"name": "Ethernet0"}},
+			}},
+			want: pathblacklist.Path{Elems: []string{"interfaces", "interface"}},
+		},
+		{
+			desc:   "sonic-db origin in prefix",
+			prefix: &gnmipb.Path{Origin: "sonic-db"},
+			path: &gnmipb.Path{Elem: []*gnmipb.PathElem{
+				{Name: "CONFIG_DB"}, {Name: "localhost"}, {Name: "PORT"}}},
+			want: pathblacklist.Path{Target: "CONFIG_DB", Elems: []string{"PORT"}},
+		},
+		{
+			desc:   "sonic-db origin in path",
+			prefix: nil,
+			path: &gnmipb.Path{Origin: "sonic-db", Elem: []*gnmipb.PathElem{
+				{Name: "CONFIG_DB"}, {Name: "localhost"}, {Name: "PORT"}, {Name: "Ethernet0"}}},
+			want: pathblacklist.Path{Target: "CONFIG_DB", Elems: []string{"PORT", "Ethernet0"}},
+		},
+		{
+			desc:   "sonic-db origin without table maps to whole database",
+			prefix: &gnmipb.Path{Origin: "sonic-db"},
+			path:   &gnmipb.Path{Elem: []*gnmipb.PathElem{{Name: "CONFIG_DB"}, {Name: "localhost"}}},
+			want:   pathblacklist.Path{Target: "CONFIG_DB"},
+		},
+		{
+			desc:   "nil prefix and empty path",
+			prefix: nil,
+			path:   &gnmipb.Path{},
+			want:   pathblacklist.Path{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			got := normalizeRequestPath(tt.prefix, tt.path)
+			if got.Target != tt.want.Target || !reflect.DeepEqual(got.Elems, tt.want.Elems) {
+				t.Fatalf("normalizeRequestPath() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCheckPathsBlacklistSonicDbForm(t *testing.T) {
+	policy := mustPolicy(t, "CONFIG_DB /PORT\n")
+
+	// Both wire forms of the same request must be blocked.
+	targetForm := checkPathsBlacklist(policy,
+		&gnmipb.Path{Target: "CONFIG_DB"},
+		[]*gnmipb.Path{{Elem: []*gnmipb.PathElem{{Name: "PORT"}}}})
+	if status.Code(targetForm) != codes.PermissionDenied {
+		t.Fatalf("target form: expected PermissionDenied, got %v", targetForm)
+	}
+
+	nativeForm := checkPathsBlacklist(policy,
+		&gnmipb.Path{Origin: "sonic-db"},
+		[]*gnmipb.Path{{Elem: []*gnmipb.PathElem{
+			{Name: "CONFIG_DB"}, {Name: "localhost"}, {Name: "PORT"}}}})
+	if status.Code(nativeForm) != codes.PermissionDenied {
+		t.Fatalf("native form: expected PermissionDenied, got %v", nativeForm)
+	}
+
+	otherTable := checkPathsBlacklist(policy,
+		&gnmipb.Path{Origin: "sonic-db"},
+		[]*gnmipb.Path{{Elem: []*gnmipb.PathElem{
+			{Name: "CONFIG_DB"}, {Name: "localhost"}, {Name: "VLAN"}}}})
+	if otherTable != nil {
+		t.Fatalf("native form other table: expected nil, got %v", otherTable)
+	}
+}
+
+func TestCheckPathsBlacklistRootEntry(t *testing.T) {
+	policy := mustPolicy(t, "STATE_DB /\n")
+	blocked := checkPathsBlacklist(policy,
+		&gnmipb.Path{Target: "STATE_DB"},
+		[]*gnmipb.Path{{Elem: []*gnmipb.PathElem{{Name: "TRANSCEIVER_INFO"}}}})
+	if status.Code(blocked) != codes.PermissionDenied {
+		t.Fatalf("expected PermissionDenied for root entry, got %v", blocked)
+	}
+	allowed := checkPathsBlacklist(policy,
+		&gnmipb.Path{Target: "APPL_DB"},
+		[]*gnmipb.Path{{Elem: []*gnmipb.PathElem{{Name: "TRANSCEIVER_INFO"}}}})
+	if allowed != nil {
+		t.Fatalf("root entry must not affect other targets, got %v", allowed)
 	}
 }

--- a/gnmi_server/server.go
+++ b/gnmi_server/server.go
@@ -260,6 +260,9 @@ type Config struct {
 	// When empty, binds to all interfaces (0.0.0.0). Use "127.0.0.1" to
 	// restrict to localhost only (e.g. when running without TLS).
 	BindAddress string
+	// PathsBlacklist rejects Get/Set/Subscribe requests referencing
+	// blacklisted paths. Nil disables enforcement.
+	PathsBlacklist *PathsBlacklist
 }
 
 // DBusOSBackend is a concrete implementation of OSBackend
@@ -957,6 +960,10 @@ func (s *Server) Get(ctx context.Context, req *gnmipb.GetRequest) (*gnmipb.GetRe
 		common_utils.IncCounter(common_utils.GNMI_GET_FAIL)
 		return nil, status.Errorf(codes.Unimplemented, "unsupported request type: %s", gnmipb.GetRequest_DataType_name[int32(req.GetType())])
 	}
+	if err := s.config.PathsBlacklist.CheckPaths(req.GetPrefix(), req.GetPath()); err != nil {
+		common_utils.IncCounter(common_utils.GNMI_GET_FAIL)
+		return nil, err
+	}
 	// gNMI path based authorization
 	if s.config.PathzPolicy && len(req.GetPath()) != 0 {
 		newPaths := []*gnmipb.Path{}
@@ -1100,6 +1107,20 @@ func (s *Server) Set(ctx context.Context, req *gnmipb.SetRequest) (*gnmipb.SetRe
 	if s.config.EnableTranslibWrite == false && s.config.EnableNativeWrite == false {
 		common_utils.IncCounter(common_utils.GNMI_SET_FAIL)
 		return nil, grpc.Errorf(codes.Unimplemented, "GNMI is in read-only mode")
+	}
+	if s.config.PathsBlacklist != nil {
+		setPaths := make([]*gnmipb.Path, 0, len(req.GetDelete())+len(req.GetReplace())+len(req.GetUpdate()))
+		setPaths = append(setPaths, req.GetDelete()...)
+		for _, update := range req.GetReplace() {
+			setPaths = append(setPaths, update.GetPath())
+		}
+		for _, update := range req.GetUpdate() {
+			setPaths = append(setPaths, update.GetPath())
+		}
+		if err := s.config.PathsBlacklist.CheckPaths(req.GetPrefix(), setPaths); err != nil {
+			common_utils.IncCounter(common_utils.GNMI_SET_FAIL)
+			return nil, err
+		}
 	}
 	// gNMI path based authorization
 	if s.config.PathzPolicy {

--- a/gnmi_server/server.go
+++ b/gnmi_server/server.go
@@ -22,6 +22,7 @@ import (
 	gnsi_pathz_pb "github.com/openconfig/gnsi/pathz"
 	"github.com/sonic-net/sonic-gnmi/common_utils"
 	"github.com/sonic-net/sonic-gnmi/pkg/bypass"
+	"github.com/sonic-net/sonic-gnmi/pkg/pathblacklist"
 	operationalhandler "github.com/sonic-net/sonic-gnmi/pkg/server/operational-handler"
 	spb "github.com/sonic-net/sonic-gnmi/proto"
 	spb_gnoi "github.com/sonic-net/sonic-gnmi/proto/gnoi"
@@ -122,6 +123,11 @@ func (s *Server) handleOperationalGet(ctx context.Context, req *gnmipb.GetReques
 	authTarget := "gnoi"
 	ctx, err := authenticate(s.config, ctx, authTarget, false)
 	if err != nil {
+		common_utils.IncCounter(common_utils.GNMI_GET_FAIL)
+		return nil, err
+	}
+
+	if err := checkPathsBlacklist(s.config.PathsBlacklist, prefix, paths); err != nil {
 		common_utils.IncCounter(common_utils.GNMI_GET_FAIL)
 		return nil, err
 	}
@@ -262,7 +268,7 @@ type Config struct {
 	BindAddress string
 	// PathsBlacklist rejects Get/Set/Subscribe requests referencing
 	// blacklisted paths. Nil disables enforcement.
-	PathsBlacklist *PathsBlacklist
+	PathsBlacklist *pathblacklist.Policy
 }
 
 // DBusOSBackend is a concrete implementation of OSBackend
@@ -960,10 +966,6 @@ func (s *Server) Get(ctx context.Context, req *gnmipb.GetRequest) (*gnmipb.GetRe
 		common_utils.IncCounter(common_utils.GNMI_GET_FAIL)
 		return nil, status.Errorf(codes.Unimplemented, "unsupported request type: %s", gnmipb.GetRequest_DataType_name[int32(req.GetType())])
 	}
-	if err := s.config.PathsBlacklist.CheckPaths(req.GetPrefix(), req.GetPath()); err != nil {
-		common_utils.IncCounter(common_utils.GNMI_GET_FAIL)
-		return nil, err
-	}
 	// gNMI path based authorization
 	if s.config.PathzPolicy && len(req.GetPath()) != 0 {
 		newPaths := []*gnmipb.Path{}
@@ -1053,6 +1055,12 @@ func (s *Server) Get(ctx context.Context, req *gnmipb.GetRequest) (*gnmipb.GetRe
 		common_utils.IncCounter(common_utils.GNMI_GET_FAIL)
 		return nil, err
 	}
+	// Checked after authenticate so unauthenticated callers get
+	// Unauthenticated instead of a policy result.
+	if err := checkPathsBlacklist(s.config.PathsBlacklist, prefix, paths); err != nil {
+		common_utils.IncCounter(common_utils.GNMI_GET_FAIL)
+		return nil, err
+	}
 	spbValues, err := dc.Get(nil)
 	if err != nil {
 		common_utils.IncCounter(common_utils.GNMI_GET_FAIL)
@@ -1108,7 +1116,11 @@ func (s *Server) Set(ctx context.Context, req *gnmipb.SetRequest) (*gnmipb.SetRe
 		common_utils.IncCounter(common_utils.GNMI_SET_FAIL)
 		return nil, grpc.Errorf(codes.Unimplemented, "GNMI is in read-only mode")
 	}
-	if s.config.PathsBlacklist != nil {
+	// Unlike Get/Subscribe this runs before authenticate: the bypass fast
+	// path below executes writes before authenticate is reached, so a later
+	// check could be bypassed. The error is generic, so nothing about the
+	// policy contents is exposed to unauthenticated callers.
+	if s.config.PathsBlacklist.Len() != 0 {
 		setPaths := make([]*gnmipb.Path, 0, len(req.GetDelete())+len(req.GetReplace())+len(req.GetUpdate()))
 		setPaths = append(setPaths, req.GetDelete()...)
 		for _, update := range req.GetReplace() {
@@ -1117,7 +1129,7 @@ func (s *Server) Set(ctx context.Context, req *gnmipb.SetRequest) (*gnmipb.SetRe
 		for _, update := range req.GetUpdate() {
 			setPaths = append(setPaths, update.GetPath())
 		}
-		if err := s.config.PathsBlacklist.CheckPaths(req.GetPrefix(), setPaths); err != nil {
+		if err := checkPathsBlacklist(s.config.PathsBlacklist, req.GetPrefix(), setPaths); err != nil {
 			common_utils.IncCounter(common_utils.GNMI_SET_FAIL)
 			return nil, err
 		}

--- a/pkg/pathblacklist/pathblacklist.go
+++ b/pkg/pathblacklist/pathblacklist.go
@@ -1,0 +1,161 @@
+// Package pathblacklist implements parsing and matching of a gNMI paths
+// blacklist policy. The policy is a plain text file with one
+// "TARGET /path/to/subtree" entry per line, e.g.:
+//
+//	COUNTERS_DB /COUNTERS/Ethernet0
+//	APPL_DB /PORT_TABLE/Ethernet*
+//	* /some/path
+//	CONFIG_DB /
+//
+// TARGET is matched against the request target; "*" matches any target.
+// PATH "/" blocks the entire target. Path elements are matched by name:
+// "*" matches any element, and a trailing "*" acts as a prefix glob
+// (e.g. "Ethernet*" matches "Ethernet0"), mirroring the wildcard forms
+// accepted by the SONiC data clients.
+//
+// Matching is by subtree overlap: a request matches when the entry covers
+// the request path or the request path covers the entry, since either way
+// the response would include blacklisted data.
+//
+// This package is pure (no CGO, gRPC, or file I/O); callers open the policy
+// file and translate a match into a transport-level error.
+package pathblacklist
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strings"
+)
+
+const wildcard = "*"
+
+// Path is a normalized request path to match against the policy.
+type Path struct {
+	Target string
+	Elems  []string
+}
+
+type entry struct {
+	target string
+	elems  []string
+}
+
+// String renders an entry in the policy file format, for logging.
+func (e entry) String() string {
+	return e.target + " /" + strings.Join(e.elems, "/")
+}
+
+// Policy is an immutable set of blacklisted paths. A nil *Policy matches
+// nothing.
+type Policy struct {
+	entries []entry
+}
+
+// Parse reads blacklist entries from r.
+func Parse(r io.Reader) (*Policy, error) {
+	p := &Policy{}
+	scanner := bufio.NewScanner(r)
+	lineNum := 0
+	for scanner.Scan() {
+		lineNum++
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			return nil, fmt.Errorf("line %d: expected 'TARGET PATH', got %q", lineNum, line)
+		}
+		elems, err := parsePath(fields[1])
+		if err != nil {
+			return nil, fmt.Errorf("line %d: invalid path %q: %v", lineNum, fields[1], err)
+		}
+		p.entries = append(p.entries, entry{target: fields[0], elems: elems})
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return p, nil
+}
+
+// parsePath splits "/a/b/c" into element names. "/" yields no elements,
+// which blocks the entire target.
+func parsePath(s string) ([]string, error) {
+	if !strings.HasPrefix(s, "/") {
+		return nil, fmt.Errorf("path must start with '/'")
+	}
+	if s == "/" {
+		return nil, nil
+	}
+	elems := strings.Split(s[1:], "/")
+	for _, elem := range elems {
+		if elem == "" {
+			return nil, fmt.Errorf("empty element")
+		}
+		if strings.ContainsAny(elem, "[]") {
+			return nil, fmt.Errorf("[key=value] qualifiers are not supported, use element names only")
+		}
+	}
+	return elems, nil
+}
+
+// Len returns the number of policy entries.
+func (p *Policy) Len() int {
+	if p == nil {
+		return 0
+	}
+	return len(p.entries)
+}
+
+// Match reports whether the request path is covered by the policy. On a
+// match it returns the matched entry in policy file format, for server-side
+// logging.
+func (p *Policy) Match(req Path) (string, bool) {
+	if p == nil {
+		return "", false
+	}
+	for _, e := range p.entries {
+		if e.target != wildcard && e.target != req.Target {
+			continue
+		}
+		if overlaps(e.elems, req.Elems) {
+			return e.String(), true
+		}
+	}
+	return "", false
+}
+
+// overlaps reports whether one path is a prefix of the other (or both are
+// equal). Blocking in both directions is deliberate: a request deeper than
+// a blacklisted subtree reads blacklisted data, and a request for an
+// ancestor of a blacklisted subtree would include that subtree in its
+// response.
+func overlaps(entry, req []string) bool {
+	n := len(entry)
+	if len(req) < n {
+		n = len(req)
+	}
+	for i := 0; i < n; i++ {
+		if !elemMatch(entry[i], req[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// elemMatch reports whether two element names match. "*" matches anything,
+// and a trailing "*" on either side is a prefix glob, so a request for
+// "Ethernet*" cannot slip past a blacklisted "Ethernet0" (and vice versa).
+func elemMatch(a, b string) bool {
+	if a == b || a == wildcard || b == wildcard {
+		return true
+	}
+	if strings.HasSuffix(a, wildcard) && strings.HasPrefix(b, a[:len(a)-1]) {
+		return true
+	}
+	if strings.HasSuffix(b, wildcard) && strings.HasPrefix(a, b[:len(b)-1]) {
+		return true
+	}
+	return false
+}

--- a/pkg/pathblacklist/pathblacklist_test.go
+++ b/pkg/pathblacklist/pathblacklist_test.go
@@ -1,0 +1,133 @@
+package pathblacklist
+
+import (
+	"strings"
+	"testing"
+)
+
+func mustParse(t *testing.T, content string) *Policy {
+	t.Helper()
+	p, err := Parse(strings.NewReader(content))
+	if err != nil {
+		t.Fatalf("Parse(%q) failed: %v", content, err)
+	}
+	return p
+}
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		desc    string
+		content string
+		wantLen int
+		wantErr bool
+	}{
+		{desc: "empty file", content: "", wantLen: 0},
+		{desc: "blank lines skipped", content: "\n\nCOUNTERS_DB /COUNTERS\n\n", wantLen: 1},
+		{desc: "multiple entries", content: "COUNTERS_DB /COUNTERS/Ethernet0\n* /a/b\n", wantLen: 2},
+		{desc: "wildcard elements", content: "APPL_DB /PORT_TABLE/*/oper_status\n", wantLen: 1},
+		{desc: "suffix glob elements", content: "COUNTERS_DB /COUNTERS/Ethernet*\n", wantLen: 1},
+		{desc: "root path blocks whole target", content: "CONFIG_DB /\n", wantLen: 1},
+		{desc: "missing path", content: "COUNTERS_DB\n", wantErr: true},
+		{desc: "too many fields", content: "COUNTERS_DB /COUNTERS extra\n", wantErr: true},
+		{desc: "relative path rejected", content: "COUNTERS_DB COUNTERS/Ethernet0\n", wantErr: true},
+		{desc: "keyed path rejected", content: "APPL_DB /interfaces/interface[name=Ethernet0]/state\n", wantErr: true},
+		{desc: "empty element", content: "APPL_DB /a//b\n", wantErr: true},
+		{desc: "trailing slash rejected", content: "APPL_DB /a/b/\n", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			p, err := Parse(strings.NewReader(tt.content))
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if p.Len() != tt.wantLen {
+				t.Fatalf("Len() = %d, want %d", p.Len(), tt.wantLen)
+			}
+		})
+	}
+}
+
+func TestMatch(t *testing.T) {
+	policy := mustParse(t,
+		"COUNTERS_DB /COUNTERS/Ethernet0\n"+
+			"* /SECRET\n"+
+			"APPL_DB /PORT_TABLE/*/oper_status\n"+
+			"STATE_DB /\n")
+
+	tests := []struct {
+		desc    string
+		req     Path
+		blocked bool
+	}{
+		{desc: "exact match", req: Path{"COUNTERS_DB", []string{"COUNTERS", "Ethernet0"}}, blocked: true},
+		{desc: "deeper than entry", req: Path{"COUNTERS_DB", []string{"COUNTERS", "Ethernet0", "SAI_PORT_STAT_IF_IN_ERRORS"}}, blocked: true},
+		{desc: "ancestor of entry", req: Path{"COUNTERS_DB", []string{"COUNTERS"}}, blocked: true},
+		{desc: "empty request path overlaps", req: Path{"COUNTERS_DB", nil}, blocked: true},
+		{desc: "request wildcard covers entry", req: Path{"COUNTERS_DB", []string{"COUNTERS", "*"}}, blocked: true},
+		{desc: "request suffix glob covers entry", req: Path{"COUNTERS_DB", []string{"COUNTERS", "Ethernet*"}}, blocked: true},
+		{desc: "request suffix glob no overlap", req: Path{"COUNTERS_DB", []string{"COUNTERS", "PortChannel*"}}, blocked: false},
+		{desc: "sibling allowed", req: Path{"COUNTERS_DB", []string{"COUNTERS", "Ethernet4"}}, blocked: false},
+		{desc: "other target allowed", req: Path{"CONFIG_DB", []string{"COUNTERS", "Ethernet0"}}, blocked: false},
+		{desc: "wildcard target blocks any target", req: Path{"CONFIG_DB", []string{"SECRET"}}, blocked: true},
+		{desc: "wildcard entry element", req: Path{"APPL_DB", []string{"PORT_TABLE", "Ethernet12", "oper_status"}}, blocked: true},
+		{desc: "wildcard entry element, other leaf", req: Path{"APPL_DB", []string{"PORT_TABLE", "Ethernet12", "admin_status"}}, blocked: false},
+		{desc: "root entry blocks whole target", req: Path{"STATE_DB", []string{"TRANSCEIVER_INFO", "Ethernet0"}}, blocked: true},
+		{desc: "root entry other target unaffected", req: Path{"ASIC_DB", []string{"TRANSCEIVER_INFO"}}, blocked: false},
+		{desc: "unrelated path allowed", req: Path{"APPL_DB", []string{"LLDP_ENTRY_TABLE"}}, blocked: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			matched, got := policy.Match(tt.req)
+			if got != tt.blocked {
+				t.Fatalf("Match(%+v) = %v (entry %q), want %v", tt.req, got, matched, tt.blocked)
+			}
+			if got && matched == "" {
+				t.Fatal("blocked match must report the matched entry")
+			}
+		})
+	}
+}
+
+func TestSuffixGlobEntry(t *testing.T) {
+	policy := mustParse(t, "COUNTERS_DB /COUNTERS/Ethernet*\n")
+	if _, ok := policy.Match(Path{"COUNTERS_DB", []string{"COUNTERS", "Ethernet68"}}); !ok {
+		t.Fatal("glob entry must block matching element")
+	}
+	if _, ok := policy.Match(Path{"COUNTERS_DB", []string{"COUNTERS", "PortChannel1"}}); ok {
+		t.Fatal("glob entry must not block non-matching element")
+	}
+}
+
+func TestNilPolicy(t *testing.T) {
+	var policy *Policy
+	if policy.Len() != 0 {
+		t.Fatalf("nil policy Len() = %d, want 0", policy.Len())
+	}
+	if _, ok := policy.Match(Path{"COUNTERS_DB", []string{"COUNTERS"}}); ok {
+		t.Fatal("nil policy must match nothing")
+	}
+}
+
+func TestMatchedEntryFormat(t *testing.T) {
+	policy := mustParse(t, "COUNTERS_DB /COUNTERS/Ethernet0\n")
+	matched, ok := policy.Match(Path{"COUNTERS_DB", []string{"COUNTERS", "Ethernet0"}})
+	if !ok {
+		t.Fatal("expected match")
+	}
+	if matched != "COUNTERS_DB /COUNTERS/Ethernet0" {
+		t.Fatalf("matched entry = %q, want policy file format", matched)
+	}
+}
+
+func TestParseScannerError(t *testing.T) {
+	// A line longer than bufio.Scanner's max token size triggers a scanner error.
+	if _, err := Parse(strings.NewReader("A /" + strings.Repeat("x", 1024*1024))); err == nil {
+		t.Fatal("expected scanner error for oversized line")
+	}
+}

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -21,6 +21,7 @@ import (
 
 	gnmi "github.com/sonic-net/sonic-gnmi/gnmi_server"
 	"github.com/sonic-net/sonic-gnmi/pkg/interceptors"
+	"github.com/sonic-net/sonic-gnmi/pkg/pathblacklist"
 	testcert "github.com/sonic-net/sonic-gnmi/testdata/tls"
 
 	"github.com/fsnotify/fsnotify"
@@ -336,9 +337,14 @@ func setupFlags(fs *flag.FlagSet) (*TelemetryConfig, *gnmi.Config, error) {
 	}
 
 	if *telemetryCfg.PathsBlacklistFile != "" {
-		blacklist, err := gnmi.LoadPathsBlacklist(*telemetryCfg.PathsBlacklistFile)
+		blacklistFile, err := os.Open(*telemetryCfg.PathsBlacklistFile)
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to load paths_blacklist file: %v", err)
+			return nil, nil, fmt.Errorf("failed to open paths_blacklist file: %v", err)
+		}
+		blacklist, err := pathblacklist.Parse(blacklistFile)
+		blacklistFile.Close()
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to parse paths_blacklist file %s: %v", *telemetryCfg.PathsBlacklistFile, err)
 		}
 		cfg.PathsBlacklist = blacklist
 		log.V(1).Infof("Loaded %d blacklist entries from %s", blacklist.Len(), *telemetryCfg.PathsBlacklistFile)

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -81,6 +81,7 @@ type TelemetryConfig struct {
 	EnableStreamMultiplexing *bool
 	MaxRecvMsgSize           *int
 	MaxSendMsgSize           *int
+	PathsBlacklistFile       *string
 }
 
 func main() {
@@ -211,6 +212,7 @@ func setupFlags(fs *flag.FlagSet) (*TelemetryConfig, *gnmi.Config, error) {
 		EnableStreamMultiplexing: fs.Bool("enable_stream_multiplexing", false, "Allow multiple Subscribe RPCs on a single TCP connection via HTTP/2 stream multiplexing"),
 		MaxRecvMsgSize:           fs.Int("max_recv_msg_size", 4*1024*1024, "Maximum message size in bytes that the server can receive"),
 		MaxSendMsgSize:           fs.Int("max_send_msg_size", 4*1024*1024, "Maximum message size in bytes that the server can send"),
+		PathsBlacklistFile:       fs.String("paths_blacklist", "", "File with blacklisted gNMI paths, one 'TARGET PATH' entry per line. Requests referencing these paths are rejected. Empty disables the blacklist."),
 	}
 
 	fs.Var(&telemetryCfg.UserAuth, "client_auth", "Client auth mode(s) - none,cert,password")
@@ -331,6 +333,15 @@ func setupFlags(fs *flag.FlagSet) (*TelemetryConfig, *gnmi.Config, error) {
 	if *telemetryCfg.CaCert == "" && telemetryCfg.UserAuth.Enabled("cert") {
 		telemetryCfg.UserAuth.Unset("cert")
 		log.V(2).Info("client_auth mode cert requires ca_crt option. Disabling cert mode authentication.")
+	}
+
+	if *telemetryCfg.PathsBlacklistFile != "" {
+		blacklist, err := gnmi.LoadPathsBlacklist(*telemetryCfg.PathsBlacklistFile)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to load paths_blacklist file: %v", err)
+		}
+		cfg.PathsBlacklist = blacklist
+		log.V(1).Infof("Loaded %d blacklist entries from %s", blacklist.Len(), *telemetryCfg.PathsBlacklistFile)
 	}
 
 	cfg.AuthzMetaFile = string(*telemetryCfg.AuthzMetaFile)

--- a/telemetry/telemetry_test.go
+++ b/telemetry/telemetry_test.go
@@ -1507,3 +1507,52 @@ func TestMain(m *testing.M) {
 	defer test_utils.MemLeakCheck()
 	m.Run()
 }
+
+func TestPathsBlacklistFlag(t *testing.T) {
+	originalArgs := os.Args
+	defer func() {
+		os.Args = originalArgs
+	}()
+
+	validFile := filepath.Join(t.TempDir(), "blacklist.txt")
+	if err := os.WriteFile(validFile, []byte("COUNTERS_DB /COUNTERS/Ethernet0\n* /SECRET\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	malformedFile := filepath.Join(t.TempDir(), "malformed.txt")
+	if err := os.WriteFile(malformedFile, []byte("COUNTERS_DB\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	baseArgs := []string{"cmd", "-port", "9090", "-noTLS", "-bind_address", "127.0.0.1"}
+
+	tests := []struct {
+		desc    string
+		args    []string
+		wantLen int
+		wantErr bool
+	}{
+		{desc: "valid blacklist file", args: append(baseArgs, "-paths_blacklist", validFile), wantLen: 2},
+		{desc: "flag not passed disables blacklist", args: baseArgs, wantLen: 0},
+		{desc: "missing file", args: append(baseArgs, "-paths_blacklist", "/nonexistent/blacklist.txt"), wantErr: true},
+		{desc: "malformed file", args: append(baseArgs, "-paths_blacklist", malformedFile), wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			fs := flag.NewFlagSet("testPathsBlacklist", flag.ContinueOnError)
+			os.Args = tt.args
+			_, cfg, err := setupFlags(fs)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if cfg.PathsBlacklist.Len() != tt.wantLen {
+				t.Fatalf("PathsBlacklist.Len() = %d, want %d", cfg.PathsBlacklist.Len(), tt.wantLen)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Add the flag for paths_blacklist for the server to reject reads or writes to certain paths

#### How I did it

Add flag and parse paths from a file. Paths are then translate to gnmi paths which are then compared to requested path, if the requested path has the prefix of the blacklisted path, its rejected with a permission denined grpc error.

#### How to verify it

Before change:

Black listed path:
```
/# gnmi_get -xpath_target CONFIG_DB -xpath TACPLUS/global -target_addr 127.0.0.1:50051 -logtostderr -insecure true
== getRequest:
prefix: <
  target: "CONFIG_DB"
>
path: <
  elem: <
    name: "TACPLUS"
  >
  elem: <
    name: "global"
  >
>
encoding: JSON_IETF

== getResponse:
notification: <
  timestamp: 1787169640558475255
  prefix: <
    target: "CONFIG_DB"
  >
  update: <
    path: <
      elem: <
        name: "TACPLUS"
      >
      elem: <
        name: "global"
      >
    >
    val: <
      json_ietf_val: "{\"auth_type\":\"login\",\"passkey\":\"starlab\"}"
    >
  >
>
```

Non blacklist path:

```
/# gnmi_get -xpath_target CONFIG_DB -xpath PORT/Ethernet0 -target_addr 127.0.0.1:50051 -logtostderr -insecure true
== getRequest:
prefix: <
  target: "CONFIG_DB"
>
path: <
  elem: <
    name: "PORT"
  >
  elem: <
    name: "Ethernet0"
  >
>
encoding: JSON_IETF

== getResponse:
notification: <
  timestamp: 1787169726802550035
  prefix: <
    target: "CONFIG_DB"
  >
  update: <
    path: <
      elem: <
        name: "PORT"
      >
      elem: <
        name: "Ethernet0"
      >
    >
    val: <
      json_ietf_val: "{\"admin_status\":\"up\",\"alias\":\"etp0a\",\"description\":\"ARISTA01T0:Ethernet1\",\"fec\":\"rs\",\"index\":\"0\",\"lanes\":\"2304,2305,2306,2307\",\"mtu\":\"9100\",\"pfc_asym\":\"off\",\"speed\":\"100000\",\"subport\":\"1\",\"tpid\":\"0x8100\"}"
    >
  >
>
```




After change:

Blacklist path:

```
/# cat /etc/telemetry/paths_blacklist.txt 
CONFIG_DB /TACPLUS/global
CONFIG_DB /SNMP_COMMUNITY
```

```
/# gnmi_get -xpath_target CONFIG_DB -xpath TACPLUS/global -target_addr 127.0.0.1:50051 -logtostderr -insecure true
== getRequest:
prefix: <
  target: "CONFIG_DB"
>
path: <
  elem: <
    name: "TACPLUS"
  >
  elem: <
    name: "global"
  >
>
encoding: JSON_IETF

F0819 20:07:52.563110     107 gnmi_get.go:145] Get failed: rpc error: code = PermissionDenied desc = request path is blocked by policy

/# gnmi_get -xpath_target CONFIG_DB -xpath SNMP_COMMUNITY -target_addr 127.0.0.1:50051 -logtostderr -insecure true
== getRequest:
prefix: <
  target: "CONFIG_DB"
>
path: <
  elem: <
    name: "SNMP_COMMUNITY"
  >
>
encoding: JSON_IETF

F0819 20:08:15.226128     114 gnmi_get.go:145] Get failed: rpc error: code = PermissionDenied desc = request path is blocked by policy

/# gnmi_cli -client_types=gnmi -a 127.0.0.1:50051 -t CONFIG_DB -logtostderr -insecure -v 0 \
  -qt p -pi 10s -q SNMP_COMMUNITY
E0819 20:16:13.068130     121 gnmi_cli.go:250] sendQueryAndDisplay(ctx, {Addrs:[127.0.0.1:50051] AddressChains:[] Origin: Target:CONFIG_DB Replica:0 UpdatesOnly:false Queries:[[SNMP_COMMUNITY]] Type:poll Timeout:30s NotificationHandler:<nil> ProtoHandler:<nil> Credentials:<nil> TLS:0xfec260 Extra:map[] SubReq:<nil> Streaming_type:TARGET_DEFINED Streaming_sample_int:0 Heartbeat_int:0 Suppress_redundant:false}, &{PollingInterval:10s StreamingDuration:0s Count:0 countExhausted:false Delimiter:/ Display:0x8e7ac0 DisplayPrefix: DisplayIndent:   DisplayType:group DisplayPeer:false Timestamp: DisplaySize:false Latency:false ClientTypes:[gnmi]}):
        client had error while displaying results:
        rpc error: code = PermissionDenied desc = request path is blocked by policy

```


Non blacklist path:

```
/# gnmi_get -xpath_target CONFIG_DB -xpath PORT/Ethernet0 -target_addr 127.0.0.1:50051 -logtostderr -insecure true
== getRequest:
prefix: <
  target: "CONFIG_DB"
>
path: <
  elem: <
    name: "PORT"
  >
  elem: <
    name: "Ethernet0"
  >
>
encoding: JSON_IETF

== getResponse:
notification: <
  timestamp: 1787169986790728818
  prefix: <
    target: "CONFIG_DB"
  >
  update: <
    path: <
      elem: <
        name: "PORT"
      >
      elem: <
        name: "Ethernet0"
      >
    >
    val: <
      json_ietf_val: "{\"admin_status\":\"up\",\"alias\":\"etp0a\",\"description\":\"ARISTA01T0:Ethernet1\",\"fec\":\"rs\",\"index\":\"0\",\"lanes\":\"2304,2305,2306,2307\",\"mtu\":\"9100\",\"pfc_asym\":\"off\",\"speed\":\"100000\",\"subport\":\"1\",\"tpid\":\"0x8100\"}"
    >
  >
>

/# gnmi_cli -client_types=gnmi -a 127.0.0.1:50051 -t CONFIG_DB -logtostderr -insecure -v 0   -qt p -pi 10s -q PORT/Ethernet0
[
{
  "CONFIG_DB": {
    "PORT": {
      "Ethernet0": {
        "admin_status": "up",
        "alias": "etp0a",
        "description": "ARISTA01T0:Ethernet1",
        "fec": "rs",
        "index": "0",
        "lanes": "2304,2305,2306,2307",
        "mtu": "9100",
        "pfc_asym": "off",
        "speed": "100000",
        "subport": "1",
        "tpid": "0x8100"
      }
    }
  }
}
```


#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- If you request a backport/cherry-pick, provide both:
  1. A GitHub issue or Microsoft ADO work item describing the failure.
  2. Test evidence from the target release branch(es) requested below,
     not only from master.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605
- [ ] N/A

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

