### PR TITLE
accept the YANG canonical TELEMETRY_CLIENT key form in dialout_client

### DIFF
--- a/dialout/dialout_client/dialout_client.go
+++ b/dialout/dialout_client/dialout_client.go
@@ -431,6 +431,11 @@ restart: //Remote server might go down, in that case we restart with next destin
 	dst_group   = <name>      ; // name of DestinationGroup
 	report_type = "periodic" / "stream" / "once"
 	report_interval = 1*8DIGIT      ; In millisecond,
+
+	The sonic-telemetry_client YANG model declares the list key as "prefix name",
+	so YANG-validated tooling (config replace, GCU, golden config) spells the same
+	rows TELEMETRY_CLIENT|DestinationGroup|<name> and TELEMETRY_CLIENT|Subscription|<name>.
+	Both spellings are accepted; see matchRowPrefix.
 */
 
 // closeDestGroupClient close client instances for all clientSubscription using
@@ -457,6 +462,21 @@ func setupDestGroupClients(ctx context.Context, destGroupName string) {
 			ClientSubscriptionNameMap[name] = &cs
 		}
 	}
+}
+
+// matchRowPrefix matches a TELEMETRY_CLIENT row key against a row type and returns
+// the row name. The historical spelling joins the row type and the name with "_"
+// (DestinationGroup_HS); the YANG model declares key "prefix name", so config
+// written through YANG-validated tooling joins them with the CONFIG_DB key
+// separator instead (DestinationGroup|HS). Accept both, so hand written config
+// keeps working and dial-out becomes configurable through config replace / GCU.
+func matchRowPrefix(key string, rowType string, separator string) (string, bool) {
+	for _, sep := range []string{"_", separator} {
+		if strings.HasPrefix(key, rowType+sep) {
+			return strings.TrimPrefix(key, rowType+sep), true
+		}
+	}
+	return "", false
 }
 
 // start/stop/update telemetry publist client as requested
@@ -511,8 +531,7 @@ func processTelemetryClientConfig(ctx context.Context, redisDb *redis.Client, ke
 				setupDestGroupClients(ctx, grpName)
 			}
 		}
-	} else if strings.HasPrefix(key, "DestinationGroup_") {
-		destGroupName := strings.TrimPrefix(key, "DestinationGroup_")
+	} else if destGroupName, matched := matchRowPrefix(key, "DestinationGroup", separator); matched {
 		if destGroupName == "" {
 			return fmt.Errorf("Empty  Destination Group name %v", key)
 		}
@@ -549,10 +568,9 @@ func processTelemetryClientConfig(ctx context.Context, redisDb *redis.Client, ke
 			destGrpNameMap[destGroupName] = dests
 			setupDestGroupClients(ctx, destGroupName)
 		}
-	} else if strings.HasPrefix(key, "Subscription_") {
-		name := strings.TrimPrefix(key, "Subscription_")
+	} else if name, matched := matchRowPrefix(key, "Subscription", separator); matched {
 		if name == "" {
-			return fmt.Errorf("Empty Subscription_ name %v", key)
+			return fmt.Errorf("Empty Subscription name %v", key)
 		}
 		csub, ok := ClientSubscriptionNameMap[name]
 		if ok {

--- a/dialout/dialout_client/dialout_client_test.go
+++ b/dialout/dialout_client/dialout_client_test.go
@@ -409,6 +409,35 @@ func TestGNMIDialOutPublish(t *testing.T) {
 				},
 			},
 		},
+	}, {
+		// Same configuration spelled the way the sonic-telemetry_client YANG
+		// model keys it, i.e. what config replace and GCU write.
+		desc: "DialOut with YANG-canonical pipe separated keys",
+		cmds: []string{
+			"redis-cli -n 4 hset TELEMETRY_CLIENT|DestinationGroup|HS dst_addr 127.0.0.1:8080,127.0.0.1:8081",
+			"redis-cli -n 4 hmset TELEMETRY_CLIENT|Subscription|HS_RDMA path_target COUNTERS_DB dst_group HS report_type stream paths COUNTERS/Ethernet*",
+		},
+		collector: "s1",
+		wantRespVal: []*pb.SubscribeResponse{
+			&pb.SubscribeResponse{
+				Response: &pb.SubscribeResponse_Update{
+					Update: &pb.Notification{
+						Update: []*pb.Update{
+							{Val: &pb.TypedValue{
+								Value: &pb.TypedValue_JsonIetfVal{
+									JsonIetfVal: countersEthernetWildcardByte,
+								}},
+							},
+						},
+					},
+				},
+			},
+			&pb.SubscribeResponse{
+				Response: &pb.SubscribeResponse_SyncResponse{
+					SyncResponse: true,
+				},
+			},
+		},
 		//}, {
 		//	desc: "DialOut to second collector in stream mode upon failure of first collector",
 		//	cmds: []string{
@@ -585,6 +614,32 @@ func TestNewInstanceOCYang(t *testing.T) {
 		// If it succeeded, clean up
 		if cs.dc != nil {
 			cs.dc.Close()
+		}
+	}
+}
+
+func TestMatchRowPrefix(t *testing.T) {
+	tests := []struct {
+		key      string
+		rowType  string
+		wantName string
+		wantOk   bool
+	}{
+		{"DestinationGroup_HS", "DestinationGroup", "HS", true},
+		{"DestinationGroup|HS", "DestinationGroup", "HS", true},
+		{"Subscription_HS_RDMA", "Subscription", "HS_RDMA", true},
+		{"Subscription|HS_RDMA", "Subscription", "HS_RDMA", true},
+		{"DestinationGroup_", "DestinationGroup", "", true},
+		{"DestinationGroup|", "DestinationGroup", "", true},
+		{"Global", "DestinationGroup", "", false},
+		{"Subscription_HS", "DestinationGroup", "", false},
+		{"DestinationGroupHS", "DestinationGroup", "", false},
+	}
+	for _, tt := range tests {
+		name, ok := matchRowPrefix(tt.key, tt.rowType, "|")
+		if ok != tt.wantOk || name != tt.wantName {
+			t.Errorf("matchRowPrefix(%q, %q) = (%q, %v), want (%q, %v)",
+				tt.key, tt.rowType, name, ok, tt.wantName, tt.wantOk)
 		}
 	}
 }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

gNMI dial-out telemetry (`TELEMETRY_CLIENT`) cannot be configured through any YANG-validated path. The daemon and the YANG model disagree about the CONFIG_DB key format, and the two forms are mutually exclusive:

- `dialout_client` reads only single-segment keys — `TELEMETRY_CLIENT|DestinationGroup_<name>` and `TELEMETRY_CLIENT|Subscription_<name>`.
- `sonic-telemetry_client.yang` declares `key "prefix name"` (two key leaves), and `sonic_yang` joins/splits CONFIG_DB key segments on `|`, so the YANG-valid key for the same row is `TELEMETRY_CLIENT|DestinationGroup|<name>`.

Both consequences are verified on a DUT:

1. Config written the YANG-valid way is **silently ignored**. The hash is read and logged in full, then key dispatch falls through and returns nil. No error, no warning at any verbosity, no subscription, no dial-out.
2. A device carrying working (daemon-readable) dial-out config **fails `config replace` / GCU / `config reload <file>` / golden-config validation outright** — so it cannot be managed by YANG-validated tooling at all, not even for an edit to an unrelated table.

The dispatch is three literal tests with no else branch:

```go
:483  if key == "Global" {
:514  } else if strings.HasPrefix(key, "DestinationGroup_") {
:552  } else if strings.HasPrefix(key, "Subscription_") {
```

Given `DestinationGroup|NH`, character 16 is `|` and not `_`, so the prefix test cannot match — and no choice of name changes that position. Conversely any daemon-readable key is one segment and therefore always fails `_extractKey`. The two requirements are unsatisfiable simultaneously. `prefix` is typed `pattern 'Subscription|DestinationGroup'` (regex alternation, not a key separator), so it cannot be set to `DestinationGroup_` to bridge the gap either.

**Provenance.** The daemon predates the model and has always used the 1-segment form — documented that way in its own header comment, in `doc/dialout.md`, and in `dialout_client_test.go`, which writes `TELEMETRY_CLIENT|DestinationGroup_HS` directly into redis and asserts a dial-out occurs. The model changed under it: upstream commit `ad90ad9fcd` ("Update TELEMETRY_CLIENT YANG model", sonic-net/sonic-buildimage#16861, 2023-12-16) replaced two single-key lists whose patterns were `DestinationGroup_.*` / `Subscription_.*` with one two-key list, to work around a `sonic_yang` list-disambiguation limitation (sonic-net/sonic-buildimage#16356). It then updated `sample_config_db.json` and `Configuration.md` to the new spelling — i.e. it aligned the documentation to the model rather than to the device — and `dialout_client.go` was never touched. The divergence went unnoticed because no CLI has ever written this table: `sonic-utilities` has zero references to `TELEMETRY_CLIENT`, and `sonic-mgmt-common` does not import the model.

`TELEMETRY_CLIENT|Global` is not affected — single segment, modelled as a container rather than a list entry, works both ways. The dial-in server tables (`TELEMETRY`, `GNMI`) are unrelated.

#### How I did it

Accept both spellings in the daemon. This keeps the YANG model, which is in production, unchanged.

- New `matchRowPrefix(key, rowType, separator)` helper: matches a `TELEMETRY_CLIENT` row key against a row type and returns the row name, accepting both `DestinationGroup_HS` and `DestinationGroup|HS`. The `|` form comes from `GetTableKeySeparator("CONFIG_DB")`, which is already computed in `processTelemetryClientConfig`, rather than being hardcoded.
- The `DestinationGroup` and `Subscription` branches use it in place of `strings.HasPrefix` / `strings.TrimPrefix`.
- Header comment documents the second spelling and why it exists.

Underscore is tried first, so existing keys resolve exactly as before — `Subscription_HS_RDMA` still yields `HS_RDMA`. Keeping the old branches means hand-written configs continue to work unchanged.

Confirmed by inspection that `dialout_client.go` is the only consumer that parses these keys. The keyspace-notification pattern and the initial scan prefix build only `"TELEMETRY_CLIENT" + separator` and are key-form agnostic, so they need no change. `db_client.go:233` and `mixed_db_client.go:1892` are comments; `cfg_schema.h:241` is an unused table-name define; the `docker-telemetry-sidecar` hits are `TELEMETRY_CLIENT_CERT_VERIFY_ENABLED` / `TELEMETRY_CLIENT_CNAME` environment variables, which are client-certificate handling and unrelated despite the name.

`Global` needed no change.

#### How to verify it

Tests added:

- `TestMatchRowPrefix` — table-driven over both separators, empty names, and non-matches including `Global` and cross-type keys. Needs no redis.
- A `TestGNMIDialOutPublish` case, "DialOut with YANG-canonical pipe separated keys", mirroring the existing stream-mode case with `|`-joined keys. `prepareDb` flushes per case so it is isolated, and `exe_cmd` uses `exec.Command` with no shell, so the `|` passes through literally.

On a DUT, before this change, the two spellings behave as follows.

Underscore form — works end to end:

```
sonic-db-cli CONFIG_DB hset "TELEMETRY_CLIENT|DestinationGroup_NH" dst_addr 10.250.29.245:8081
sonic-db-cli CONFIG_DB hset "TELEMETRY_CLIENT|Subscription_NHTEST" dst_group NH path_target COUNTERS_DB paths "COUNTERS_PORT_NAME_MAP,COUNTERS/Ethernet*" report_interval 5000 report_type periodic
```

`/var/log/telemetry.log` shows `New clientSubscription`, `NewInstance with Subscription change`, `publishRun`, and a dial attempt to the collector.

Pipe form — identical values, only the separator changed:

```
sonic-db-cli CONFIG_DB hset "TELEMETRY_CLIENT|DestinationGroup|NH" dst_addr 10.250.29.245:8081
sonic-db-cli CONFIG_DB hset "TELEMETRY_CLIENT|Subscription|NHTEST" dst_group NH path_target COUNTERS_DB paths "COUNTERS_PORT_NAME_MAP,COUNTERS/Ethernet*" report_interval 5000 report_type periodic
```

Before: the log contains only the two `Processing ...` lines with the complete field maps, and nothing follows. After: the pipe form should produce the same `New clientSubscription` / `NewInstance` / `publishRun` / dial sequence as the underscore form.

Then confirm `sudo config replace -d -v <file>` accepts a config carrying the pipe-form keys and that dial-out is actually running afterwards — which is the point of the change.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605

#### Tested branch

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605
- [ ] N/A

#### Test result

master as of 20260731

#### Description for the changelog

accept the YANG canonical TELEMETRY_CLIENT key form in dialout_client

#### Link to config_db schema for YANG module changes

N/A

#### A picture of a cute animal (not mandatory but encouraged)

