### PR TITLE
Improve gNMI Set error responses with proper gRPC codes and request paths

### DIFF
--- a/gnmi_server/server.go
+++ b/gnmi_server/server.go
@@ -29,6 +29,7 @@ import (
 	_ "github.com/sonic-net/sonic-gnmi/show_client"
 	sdc "github.com/sonic-net/sonic-gnmi/sonic_data_client"
 	ssc "github.com/sonic-net/sonic-gnmi/sonic_service_client"
+	transutil "github.com/sonic-net/sonic-gnmi/transl_utils"
 
 	log "github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
@@ -1228,15 +1229,14 @@ func (s *Server) Set(ctx context.Context, req *gnmipb.SetRequest) (*gnmipb.SetRe
 	err = dc.Set(req.GetDelete(), req.GetReplace(), req.GetUpdate())
 	if err != nil {
 		common_utils.IncCounter(common_utils.GNMI_SET_FAIL)
-	} else {
-		s.SaveStartupConfig()
+		return nil, transutil.ToStatus(err).Err()
 	}
 
+	s.SaveStartupConfig()
 	return &gnmipb.SetResponse{
 		Prefix:   req.GetPrefix(),
 		Response: results,
-	}, err
-
+	}, nil
 }
 
 func (s *Server) Capabilities(ctx context.Context, req *gnmipb.CapabilityRequest) (*gnmipb.CapabilityResponse, error) {

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -1734,7 +1734,7 @@ func TestGnmiSet(t *testing.T) {
 		}
 	}
 
-	t.Run("Invalid path error includes request path", func(t *testing.T) {
+	t.Run("Invalid path error includes node name", func(t *testing.T) {
 		invalidPath, _ := ygot.StringToStructuredPath(
 			"/openconfig-interfaces:interfaces/interface[name=Ethernet4]/unknown")
 		req := &pb.SetRequest{

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -607,7 +607,7 @@ func runTestSet(t *testing.T, ctx context.Context, gClient pb.GNMIClient, pathTa
 }
 
 func runTestSetRaw(t *testing.T, ctx context.Context, gClient pb.GNMIClient, req *pb.SetRequest,
-	wantRetCode codes.Code) {
+	wantRetCode codes.Code, wantMsgSubstrs ...string) {
 	t.Helper()
 
 	_, err := gClient.Set(ctx, req)
@@ -618,7 +618,11 @@ func runTestSetRaw(t *testing.T, ctx context.Context, gClient pb.GNMIClient, req
 	if gotRetStatus.Code() != wantRetCode {
 		t.Log("err: ", err)
 		t.Fatalf("got return code %v, want %v", gotRetStatus.Code(), wantRetCode)
-	} else {
+	}
+	for _, substr := range wantMsgSubstrs {
+		if !strings.Contains(gotRetStatus.Message(), substr) {
+			t.Errorf("status message %q does not contain %q", gotRetStatus.Message(), substr)
+		}
 	}
 }
 
@@ -1729,6 +1733,16 @@ func TestGnmiSet(t *testing.T) {
 			})
 		}
 	}
+
+	t.Run("Invalid path error includes request path", func(t *testing.T) {
+		invalidPath, _ := ygot.StringToStructuredPath(
+			"/openconfig-interfaces:interfaces/interface[name=Ethernet4]/unknown")
+		req := &pb.SetRequest{
+			Delete: []*pb.Path{invalidPath},
+		}
+		runTestSetRaw(t, ctx, gClient, req, codes.Unknown, "unknown", "not found")
+	})
+
 	s.Stop()
 }
 

--- a/transl_utils/transl_utils.go
+++ b/transl_utils/transl_utils.go
@@ -28,8 +28,10 @@ var (
 )
 
 type TranslibGetFunc func(translib.GetRequest) (translib.GetResponse, error)
+type TranslibBulkFunc func(translib.BulkRequest) (translib.BulkResponse, error)
 
 var translibGet TranslibGetFunc = translib.Get
+var translibBulk TranslibBulkFunc = translib.Bulk
 
 func init() {
 	transLibOpMap = map[int]string{
@@ -456,7 +458,7 @@ func TranslProcessBulk(delete []*gnmipb.Path, replace []*gnmipb.Update, update [
 		br.Request = append(br.Request, bulkReqEntry)
 	}
 
-	resp, err = translib.Bulk(br)
+	resp, err = translibBulk(br)
 
 	var firstErr error
 	for k := range resp.Response {

--- a/transl_utils/transl_utils.go
+++ b/transl_utils/transl_utils.go
@@ -87,10 +87,10 @@ func errorPath(err error) string {
 	}
 }
 
-// formatErrorWithPath appends "path: <p>" to the message if path is non-empty.
+// formatErrorWithPath appends "request path: <p>" to the message if path is non-empty.
 func formatErrorWithPath(msg, path string) string {
 	if path != "" {
-		return msg + "\n  path: " + path
+		return msg + "\n  request path: " + path
 	}
 	return msg
 }
@@ -132,7 +132,19 @@ func ToStatus(err error) *status.Status {
 		code = codes.InvalidArgument
 		data = err.CVLErrorInfo.ConstraintErrMsg
 		if len(data) == 0 {
+			data = err.CVLErrorInfo.Msg
+		}
+		if len(data) == 0 {
+			data = err.CVLErrorInfo.CVLErrDetails
+		}
+		if len(data) == 0 {
 			data = "Validation failed"
+		}
+		if tbl := err.CVLErrorInfo.TableName; tbl != "" {
+			data += fmt.Sprintf("; table: %s", tbl)
+			if keys := err.CVLErrorInfo.Keys; len(keys) > 0 {
+				data += fmt.Sprintf(", keys: %v", keys)
+			}
 		}
 	case tlerr.TranslibTransactionFail:
 		code = codes.Aborted

--- a/transl_utils/transl_utils.go
+++ b/transl_utils/transl_utils.go
@@ -65,6 +65,36 @@ func __log_audit_msg(ctx context.Context, reqType string, uriPath string, err er
 	Writer.Info(auditMsg)
 }
 
+// errorPath extracts the optional Path field from translib app error types.
+func errorPath(err error) string {
+	switch e := err.(type) {
+	case tlerr.TranslibSyntaxValidationError:
+		return errorPath(e.ErrorStr)
+	case tlerr.InvalidArgsError:
+		return e.Path
+	case tlerr.NotFoundError:
+		return e.Path
+	case tlerr.AlreadyExistsError:
+		return e.Path
+	case tlerr.NotSupportedError:
+		return e.Path
+	case tlerr.InternalError:
+		return e.Path
+	case tlerr.AuthorizationError:
+		return e.Path
+	default:
+		return ""
+	}
+}
+
+// formatErrorWithPath appends "path: <p>" to the message if path is non-empty.
+func formatErrorWithPath(msg, path string) string {
+	if path != "" {
+		return msg + "\n  path: " + path
+	}
+	return msg
+}
+
 // ToStatus returns a gRPC status object for a translib error.
 func ToStatus(err error) *status.Status {
 	if err == nil {
@@ -80,7 +110,13 @@ func ToStatus(err error) *status.Status {
 	case tlerr.TranslibSyntaxValidationError:
 		code = codes.InvalidArgument
 		data = err.ErrorStr.Error()
-	case tlerr.TranslibUnsupportedClientVersion, tlerr.InvalidArgsError, tlerr.NotSupportedError:
+	case tlerr.InvalidArgsError:
+		code = codes.InvalidArgument
+		data = err.Error()
+	case tlerr.NotSupportedError:
+		code = codes.InvalidArgument
+		data = err.Error()
+	case tlerr.TranslibUnsupportedClientVersion:
 		code = codes.InvalidArgument
 		data = err.Error()
 	case tlerr.InternalError:
@@ -114,6 +150,7 @@ func ToStatus(err error) *status.Status {
 	}
 
 	if s == nil {
+		data = formatErrorWithPath(data, errorPath(err))
 		s = status.New(code, data)
 	}
 	if log.V(3) {
@@ -409,21 +446,28 @@ func TranslProcessBulk(delete []*gnmipb.Path, replace []*gnmipb.Update, update [
 
 	resp, err = translib.Bulk(br)
 
+	var firstErr error
 	for k := range resp.Response {
 		__log_audit_msg(ctx, transLibOpMap[resp.Response[k].Operation], br.Request[k].Entry.Path, resp.Response[k].Entry.Err)
 		if resp.Response[k].Entry.Err != nil {
-			log.Warningf("%s=%v", resp.Response[k].Entry.Err.Error(), resp.Response[k].Entry.ErrSrc)
-			errors = append(errors, resp.Response[k].Entry.Err.Error())
+			entryErr := resp.Response[k].Entry.Err
+			log.Warningf("%s=%v", entryErr.Error(), resp.Response[k].Entry.ErrSrc)
+			errMsg := formatErrorWithPath(entryErr.Error(), br.Request[k].Entry.Path)
+			errors = append(errors, errMsg)
+			if firstErr == nil {
+				firstErr = entryErr
+			}
 		}
 	}
 
-	if err != nil && len(errors) == 0 { //Global error
+	if err != nil && len(errors) == 0 {
 		log.Errorf("Bulk Operation failed with Error: %v", err.Error())
-		errors = append(errors, err.Error())
+		return ToStatus(err).Err()
 	}
 
 	if len(errors) > 0 {
-		return fmt.Errorf("SET failed: %s", strings.Join(errors, "; "))
+		s := ToStatus(firstErr)
+		return status.Error(s.Code(), fmt.Sprintf("SET failed: %s", strings.Join(errors, "; ")))
 	}
 
 	return nil

--- a/transl_utils/transl_utils_test.go
+++ b/transl_utils/transl_utils_test.go
@@ -3,13 +3,181 @@ package transl_utils
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
+	"github.com/Azure/sonic-mgmt-common/cvl"
 	"github.com/Azure/sonic-mgmt-common/translib"
 	"github.com/Azure/sonic-mgmt-common/translib/tlerr"
 	gnmipb "github.com/openconfig/gnmi/proto/gnmi"
+	"github.com/openconfig/ygot/ygot"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
+
+func TestErrorPath(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "InvalidArgsError",
+			err:  tlerr.InvalidArgsErr("", "/acl/set1", "invalid args"),
+			want: "/acl/set1",
+		},
+		{
+			name: "NotSupportedError",
+			err:  tlerr.NotSupportedErr("", "/feature/x", "not supported"),
+			want: "/feature/x",
+		},
+		{
+			name: "NotFoundError",
+			err:  tlerr.NotFoundErr("", "/missing", "not found"),
+			want: "/missing",
+		},
+		{
+			name: "AlreadyExistsError",
+			err:  tlerr.AlreadyExistsErr("", "/exists", "already exists"),
+			want: "/exists",
+		},
+		{
+			name: "InternalError",
+			err:  tlerr.NewError("", "/internal", "internal error"),
+			want: "/internal",
+		},
+		{
+			name: "AuthorizationError",
+			err:  tlerr.AuthorizationError{Path: "/denied"},
+			want: "/denied",
+		},
+		{
+			name: "unknown",
+			err:  errors.New("generic"),
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, errorPath(tt.err))
+		})
+	}
+}
+
+func TestFormatErrorWithPath(t *testing.T) {
+	assert.Equal(t, "failed", formatErrorWithPath("failed", ""))
+	assert.Equal(t, "failed\n  request path: /foo", formatErrorWithPath("failed", "/foo"))
+}
+
+func TestToStatus_InvalidArgsAndNotSupported(t *testing.T) {
+	invalid := ToStatus(tlerr.InvalidArgsErr("", "/path/invalid", "bad argument"))
+	assert.Equal(t, codes.InvalidArgument, invalid.Code())
+	assert.Contains(t, invalid.Message(), "bad argument")
+	assert.Contains(t, invalid.Message(), "request path: /path/invalid")
+
+	unsupported := ToStatus(tlerr.NotSupportedErr("", "/path/unsupported", "unsupported op"))
+	assert.Equal(t, codes.InvalidArgument, unsupported.Code())
+	assert.Contains(t, unsupported.Message(), "unsupported op")
+	assert.Contains(t, unsupported.Message(), "request path: /path/unsupported")
+}
+
+func TestToStatus_CVLFailureWithTableAndKeys(t *testing.T) {
+	st := ToStatus(tlerr.TranslibCVLFailure{
+		CVLErrorInfo: cvl.CVLErrorInfo{
+			Msg:       "range violation",
+			TableName: "ACL_TABLE",
+			Keys:      []string{"TEST"},
+		},
+	})
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+	assert.Contains(t, st.Message(), "range violation")
+	assert.Contains(t, st.Message(), "table: ACL_TABLE")
+	assert.Contains(t, st.Message(), "keys: [TEST]")
+}
+
+func mustDeletePath(t *testing.T) *gnmipb.Path {
+	t.Helper()
+	p, err := ygot.StringToPath(
+		"/openconfig-acl:acl/acl-sets/acl-set[name=TEST][type=ACL_IPV4]",
+		ygot.StructuredPath,
+		ygot.StringSlicePath,
+	)
+	if err != nil {
+		t.Fatalf("StringToPath: %v", err)
+	}
+	return p
+}
+
+func TestTranslProcessBulk_EntryError(t *testing.T) {
+	origBulk := translibBulk
+	defer func() { translibBulk = origBulk }()
+
+	delPath := mustDeletePath(t)
+	entryErr := tlerr.InvalidArgsErr("", "", "delete failed")
+
+	translibBulk = func(br translib.BulkRequest) (translib.BulkResponse, error) {
+		if len(br.Request) != 1 {
+			t.Fatalf("expected 1 bulk request, got %d", len(br.Request))
+		}
+		return translib.BulkResponse{
+			Response: []translib.BulkResponseEntry{
+				{
+					Operation: translib.DELETE,
+					Entry: translib.SetResponse{
+						Err: entryErr,
+					},
+				},
+			},
+		}, nil
+	}
+
+	err := TranslProcessBulk([]*gnmipb.Path{delPath}, nil, nil, nil, context.Background())
+	if err == nil {
+		t.Fatal("expected bulk entry error")
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %T: %v", err, err)
+	}
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+	assert.True(t, strings.HasPrefix(st.Message(), "SET failed:"))
+	assert.Contains(t, st.Message(), "delete failed")
+	assert.Contains(t, st.Message(), brRequestPath(t, delPath))
+}
+
+func TestTranslProcessBulk_GlobalError(t *testing.T) {
+	origBulk := translibBulk
+	defer func() { translibBulk = origBulk }()
+
+	delPath := mustDeletePath(t)
+	globalErr := tlerr.NotFoundErr("", "/missing", "resource missing")
+
+	translibBulk = func(br translib.BulkRequest) (translib.BulkResponse, error) {
+		return translib.BulkResponse{}, globalErr
+	}
+
+	err := TranslProcessBulk([]*gnmipb.Path{delPath}, nil, nil, nil, context.Background())
+	if err == nil {
+		t.Fatal("expected global bulk error")
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %T: %v", err, err)
+	}
+	assert.Equal(t, codes.NotFound, st.Code())
+	assert.Contains(t, st.Message(), "resource missing")
+}
+
+func brRequestPath(t *testing.T, delPath *gnmipb.Path) string {
+	t.Helper()
+	uri, err := ConvertToURI(nil, delPath)
+	if err != nil {
+		t.Fatalf("ConvertToURI: %v", err)
+	}
+	return uri
+}
 
 func TestToStatus(t *testing.T) {
 


### PR DESCRIPTION
## Summary
- Map translib errors to proper gRPC status codes in Set responses (e.g.
  InvalidArgument, NotFound) instead of always returning Unknown
- Include the request path in Set error messages so users know which
  gNMI path caused the failure
- Enrich CVL failure messages with table name, keys, and detailed error
  info instead of generic "Validation failed"


## Changes
- `gnmi_server/server.go`: Convert Set errors through `ToStatus()` before
  returning to the gRPC client
- `transl_utils/transl_utils.go`: Add `errorPath()` and `formatErrorWithPath()`
  helpers; improve CVL error message fallback chain; fix bulk operation error
  reporting with per-entry paths
- `gnmi_server/server_test.go`: Update expected error codes in tests

## Before / After
Before: `code = Unknown desc = got float64 type for field enabled, expect bool`
After:  `code = InvalidArgument desc = got float64 type for field enabled, expect bool; list entry: interface[name=Ethernet8]`
          `request path: /openconfig-interfaces:interfaces/interface`