### PR TITLE
gnmi: reduce log noise for expected conditions at default verbosity

### DIFF
--- a/gnmi_server/server.go
+++ b/gnmi_server/server.go
@@ -991,7 +991,7 @@ func (s *Server) Get(ctx context.Context, req *gnmipb.GetRequest) (*gnmipb.GetRe
 	paths := req.GetPath()
 	extensions := req.GetExtension()
 	encoding := req.GetEncoding()
-	log.V(2).Infof("GetRequest paths: %v", paths)
+	log.V(3).Infof("GetRequest paths: %v", paths)
 
 	var dc sdc.Client
 	var err error

--- a/sonic_data_client/virtual_db.go
+++ b/sonic_data_client/virtual_db.go
@@ -397,7 +397,7 @@ func GetPfcwdMap() (map[string]map[string]string, error) {
 
 		if len(resp) == 0 {
 			// PFC WD service not enabled on device
-			log.V(1).Infof("PFC WD not enabled on device")
+			log.V(3).Infof("PFC WD not enabled on device")
 			return nil, nil
 		}
 
@@ -417,7 +417,7 @@ func GetPfcwdMap() (map[string]map[string]string, error) {
 			return nil, err
 		}
 		if len(resp) == 0 {
-			log.V(1).Infof("PFC WD not enabled on device")
+			log.V(3).Infof("PFC WD not enabled on device")
 			return nil, nil
 		}
 

--- a/sonic_data_client/virtual_db_test.go
+++ b/sonic_data_client/virtual_db_test.go
@@ -1356,3 +1356,59 @@ func TestTrieBacktracking_DeadEndAtNonTerminal(t *testing.T) {
 		t.Fatal("expected trie NOT to find path ending at non-terminal node")
 	}
 }
+
+// --------------------------------------------------------------------------
+// Tests for GetPfcwdMap (virtual_db.go) - uses miniredis
+// --------------------------------------------------------------------------
+
+func setupMiniredisForConfigDb(t *testing.T) (*miniredis.Miniredis, string, func()) {
+	t.Helper()
+
+	mr := miniredis.RunT(t)
+	sdcfg.Init()
+	ns, _ := sdcfg.GetDbDefaultNamespace()
+	sep, err := GetTableKeySeparator("CONFIG_DB", ns)
+	if err != nil {
+		t.Fatalf("GetTableKeySeparator: %v", err)
+	}
+
+	origTarget := Target2RedisDb
+	Target2RedisDb = map[string]map[string]*redis.Client{
+		ns: {
+			"CONFIG_DB": redis.NewClient(&redis.Options{Addr: mr.Addr()}),
+		},
+	}
+
+	return mr, sep, func() {
+		Target2RedisDb = origTarget
+	}
+}
+
+func TestGetPfcwdMap_PfcWdNotEnabled(t *testing.T) {
+	_, _, restore := setupMiniredisForConfigDb(t)
+	defer restore()
+
+	m, err := GetPfcwdMap()
+	if err != nil {
+		t.Fatalf("GetPfcwdMap returned error: %v", err)
+	}
+	if m != nil {
+		t.Fatalf("expected nil map when PFC_WD keys are absent, got %#v", m)
+	}
+}
+
+func TestGetPfcwdMap_PortQosMapEmpty(t *testing.T) {
+	mr, sep, restore := setupMiniredisForConfigDb(t)
+	defer restore()
+
+	// PFC_WD entries exist, but PORT_QOS_MAP* is absent.
+	mr.Set("PFC_WD"+sep+"Ethernet0", "1")
+
+	m, err := GetPfcwdMap()
+	if err != nil {
+		t.Fatalf("GetPfcwdMap returned error: %v", err)
+	}
+	if m != nil {
+		t.Fatalf("expected nil map when PORT_QOS_MAP keys are absent, got %#v", m)
+	}
+}


### PR DESCRIPTION
## Summary
Move expected-condition messages from default-visible log levels to debug (V(3)).

## Before (`gnmi -v=2`, default production verbosity)

Every GET and every device without PFC Watchdog flooded gnmi.log:

```
gnmi.log on the switch is growing very fast rate 1.8MB per hour.

/var/log/gnmi.log
Leaf-1	/var/log/gnmi.log sonic	1.7 MB	+1.2 MB (+221.4%)	60 archived
config rotate 5000 

Watch	Steady growth (+1.2 MB since last collection)
```

sonic-db is subscribed to get on-change, periodic data. Corresponding to that two logs are repetitively printed 
```
2026 Jul 14 13:06:04.366397 Leaf-1 INFO gnmi#supervisord: gnmi-native I0714 13:06:04.366054      21 server.go:456] GetRequest paths: [elem:{name:"RATES:oid*"}]
2026 Jul 14 13:06:04.366719 Leaf-1 INFO gnmi#supervisord: gnmi-native I0714 13:06:04.366513      21 virtual_db.go:302] PFC WD not enabled on device
```

These are normal operational states, not faults, but they dominated log volume on busy devices.

## After (`gnmi -v=2`)
Neither message appears at default verbosity.

## After (`gnmi -v=3`, debug)
Messages still available when needed:
```
GetRequest paths: [...]
PFC WD not enabled on device
```

## Test plan
- [x] Run gnmi at `-v=2`; confirm the two message types above are absent
- [x] Run gnmi at `-v=3`; confirm both appear on GET / PFC-WD paths
- [x] `go test ./sonic_data_client/... ./gnmi_server/...`
