### PR TITLE
COUNTERS_DB bare-table enumeration and BUFFER_POOL_WATERMARKS virtual path support

### DIFF
--- a/sonic_data_client/client_test.go
+++ b/sonic_data_client/client_test.go
@@ -2128,8 +2128,12 @@ func TestMixedDbClientGetBufferPoolWatermarks(t *testing.T) {
 		countersBufferPoolNameByNamespace = nil
 	}()
 
+	prefix := &gnmipb.Path{Elem: []*gnmipb.PathElem{
+		{Name: "COUNTERS_DB"}, {Name: "localhost"},
+	}}
 	gnmiPath := &gnmipb.Path{Elem: []*gnmipb.PathElem{{Name: "BUFFER_POOL_WATERMARKS"}}}
 	c := MixedDbClient{
+		prefix:   prefix,
 		mapkey:   mapkey,
 		target:   "COUNTERS_DB",
 		encoding: gnmipb.Encoding_JSON_IETF,

--- a/sonic_data_client/client_test.go
+++ b/sonic_data_client/client_test.go
@@ -2167,6 +2167,7 @@ func TestMakeJSONRedisSkipsNull(t *testing.T) {
 			}
 		})
 	}
+}
 
 func TestMain(m *testing.M) {
 	defer test_utils.MemLeakCheck()

--- a/sonic_data_client/client_test.go
+++ b/sonic_data_client/client_test.go
@@ -2110,6 +2110,101 @@ func TestMixedDbClientGet(t *testing.T) {
 	})
 }
 
+func TestMixedDbClientGetBufferPoolWatermarks(t *testing.T) {
+	sdcfg.Init()
+	mapkey := ":"
+	cleanup := setupMixedDbRedis(t, mapkey)
+	defer cleanup()
+	t.Setenv("UNIT_TEST", "1")
+
+	ns := ""
+	rclient := Target2RedisDb[ns]["COUNTERS_DB"]
+	oid := "oid:0x5000000000001"
+	rclient.HSet(context.Background(), "COUNTERS_BUFFER_POOL_NAME_MAP", "ingress_lossless_pool", oid)
+	rclient.HSet(context.Background(), "COUNTERS:"+oid, "SAI_BUFFER_POOL_STAT_WATERMARK_BYTES", "100")
+	defer func() {
+		rclient.Del(context.Background(), "COUNTERS_BUFFER_POOL_NAME_MAP")
+		rclient.Del(context.Background(), "COUNTERS:"+oid)
+		countersBufferPoolNameByNamespace = nil
+	}()
+
+	gnmiPath := &gnmipb.Path{Elem: []*gnmipb.PathElem{{Name: "BUFFER_POOL_WATERMARKS"}}}
+	c := MixedDbClient{
+		mapkey:   mapkey,
+		target:   "COUNTERS_DB",
+		encoding: gnmipb.Encoding_JSON_IETF,
+		paths:    []*gnmipb.Path{gnmiPath},
+	}
+	c.dbkey = swsscommon.NewSonicDBKey()
+	defer swsscommon.DeleteSonicDBKey(c.dbkey)
+
+	t.Run("GetDbtablePath_V2R", func(t *testing.T) {
+		tblPaths, err := c.getDbtablePath(gnmiPath, nil)
+		if err != nil {
+			t.Fatalf("getDbtablePath: %v", err)
+		}
+		if len(tblPaths) != 1 {
+			t.Fatalf("expected 1 table path, got %d", len(tblPaths))
+		}
+		tp := tblPaths[0]
+		if tp.tableName != "COUNTERS" || tp.tableKey != oid {
+			t.Fatalf("unexpected COUNTERS mapping: %+v", tp)
+		}
+		if tp.jsonTableKey != "ingress_lossless_pool" {
+			t.Errorf("jsonTableKey = %q, want ingress_lossless_pool", tp.jsonTableKey)
+		}
+		if !tp.isVirtualPath {
+			t.Error("expected isVirtualPath=true")
+		}
+	})
+
+	t.Run("Get_PoolNameKeyed", func(t *testing.T) {
+		c.paths = []*gnmipb.Path{gnmiPath}
+		values, err := c.Get(nil)
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		if len(values) != 1 {
+			t.Fatalf("expected 1 value, got %d", len(values))
+		}
+		jv := values[0].GetVal().GetJsonIetfVal()
+		var msi map[string]interface{}
+		if err := json.Unmarshal(jv, &msi); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		pool, ok := msi["ingress_lossless_pool"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected pool-name keyed output, got %v", msi)
+		}
+		if pool["SAI_BUFFER_POOL_STAT_WATERMARK_BYTES"] != "100" {
+			t.Errorf("watermark = %v, want 100", pool["SAI_BUFFER_POOL_STAT_WATERMARK_BYTES"])
+		}
+	})
+
+	t.Run("Get_SinglePool", func(t *testing.T) {
+		singlePath := &gnmipb.Path{Elem: []*gnmipb.PathElem{
+			{Name: "BUFFER_POOL_WATERMARKS"},
+			{Name: "ingress_lossless_pool"},
+		}}
+		c.paths = []*gnmipb.Path{singlePath}
+		values, err := c.Get(nil)
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		if len(values) != 1 {
+			t.Fatalf("expected 1 value, got %d", len(values))
+		}
+		jv := values[0].GetVal().GetJsonIetfVal()
+		var msi map[string]interface{}
+		if err := json.Unmarshal(jv, &msi); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if _, ok := msi["ingress_lossless_pool"]; !ok {
+			t.Fatalf("expected ingress_lossless_pool key, got %v", msi)
+		}
+	})
+}
+
 func setupMiniredisCountersDb(t *testing.T) (*miniredis.Miniredis, *redis.Client, func()) {
 	t.Helper()
 	mr := miniredis.RunT(t)

--- a/sonic_data_client/client_test.go
+++ b/sonic_data_client/client_test.go
@@ -2113,7 +2113,6 @@ func TestMixedDbClientGet(t *testing.T) {
 func setupMiniredisCountersDb(t *testing.T) (*miniredis.Miniredis, *redis.Client, func()) {
 	t.Helper()
 	mr := miniredis.RunT(t)
-	mr.SetNotifyKeyspaceEvents("KEA")
 	ns := ""
 	origTarget := Target2RedisDb
 	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr(), DB: 2})
@@ -2122,6 +2121,17 @@ func setupMiniredisCountersDb(t *testing.T) (*miniredis.Miniredis, *redis.Client
 	}
 	return mr, rdb, func() {
 		Target2RedisDb = origTarget
+	}
+}
+
+// publishKeyspaceEvent simulates a Redis keyspace notification. miniredis does
+// not implement CONFIG SET notify-keyspace-events, so subscribe tests publish
+// the __keyspace@<db>__ channel messages directly.
+func publishKeyspaceEvent(t *testing.T, rdb *redis.Client, db int, key, payload string) {
+	t.Helper()
+	channel := fmt.Sprintf("__keyspace@%d__:%s", db, key)
+	if err := rdb.Publish(context.Background(), channel, payload).Err(); err != nil {
+		t.Fatalf("publish keyspace event on %q: %v", channel, err)
 	}
 }
 
@@ -2217,6 +2227,7 @@ func runDbSingleTableKeySubscribeUpdate(t *testing.T, rsd redisSubData, mutate f
 	updateCh := make(chan map[string]interface{}, 1)
 	c := &DbClient{channel: make(chan struct{})}
 	go dbSingleTableKeySubscribe(c, rsd, updateCh)
+	time.Sleep(50 * time.Millisecond)
 	mutate(Target2RedisDb[rsd.tblPath.dbNamespace][rsd.tblPath.dbName])
 	select {
 	case msi := <-updateCh:
@@ -2251,8 +2262,10 @@ func TestDbSingleTableKeySubscribeBareTableDelimSkipped(t *testing.T) {
 		delimSkipped: true,
 	}
 	oid := "oid:0x100"
+	redisKey := "BUFFER_POOL_WATERMARKS:" + oid
 	msi := runDbSingleTableKeySubscribeUpdate(t, rsd, func(rdb *redis.Client) {
-		rdb.HSet(context.Background(), "BUFFER_POOL_WATERMARKS:"+oid, "SAI_BUFFER_POOL_STAT_WATERMARK_BYTES", "123")
+		rdb.HSet(context.Background(), redisKey, "SAI_BUFFER_POOL_STAT_WATERMARK_BYTES", "123")
+		publishKeyspaceEvent(t, rdb, 2, redisKey, "hset")
 	})
 	if _, ok := msi[oid]; !ok {
 		t.Fatalf("expected update keyed by %q, got %v", oid, msi)
@@ -2281,8 +2294,10 @@ func TestDbSingleTableKeySubscribePortPhyAttrKeepsDelimiter(t *testing.T) {
 		delimSkipped: false,
 	}
 	port := "Ethernet68"
+	redisKey := "PORT_PHY_ATTR:" + port
 	msi := runDbSingleTableKeySubscribeUpdate(t, rsd, func(rdb *redis.Client) {
-		rdb.HSet(context.Background(), "PORT_PHY_ATTR:"+port, "phy_rx_signal_detect", "1")
+		rdb.HSet(context.Background(), redisKey, "phy_rx_signal_detect", "1")
+		publishKeyspaceEvent(t, rdb, 2, redisKey, "hset")
 	})
 	if _, ok := msi[port]; !ok {
 		t.Fatalf("expected update keyed by %q, got %v", port, msi)
@@ -2317,9 +2332,12 @@ func TestMixedDbSingleTableKeySubscribeBareTableDelimSkipped(t *testing.T) {
 		delimSkipped: true,
 	}
 	go c.dbSingleTableKeySubscribe(rsd, updateCh)
+	time.Sleep(50 * time.Millisecond)
 
 	oid := "oid:0x200"
-	rdb.HSet(context.Background(), "BUFFER_POOL_WATERMARKS:"+oid, "SAI_BUFFER_POOL_STAT_WATERMARK_BYTES", "456")
+	redisKey := "BUFFER_POOL_WATERMARKS:" + oid
+	rdb.HSet(context.Background(), redisKey, "SAI_BUFFER_POOL_STAT_WATERMARK_BYTES", "456")
+	publishKeyspaceEvent(t, rdb, 2, redisKey, "hset")
 	select {
 	case msi := <-updateCh:
 		if _, ok := msi[oid]; !ok {

--- a/sonic_data_client/client_test.go
+++ b/sonic_data_client/client_test.go
@@ -8,12 +8,14 @@ import (
 	"io/ioutil"
 	"os"
 	"reflect"
+	"sort"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/Workiva/go-datastructures/queue"
 	"github.com/agiledragon/gomonkey/v2"
+	"github.com/alicebob/miniredis/v2"
 	"github.com/google/gnxi/utils/xpath"
 	gnmipb "github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/redis/go-redis/v9"
@@ -2106,6 +2108,227 @@ func TestMixedDbClientGet(t *testing.T) {
 			t.Errorf("expected no values for missing data, got %d", len(values))
 		}
 	})
+}
+
+func setupMiniredisCountersDb(t *testing.T) (*miniredis.Miniredis, *redis.Client, func()) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	mr.SetNotifyKeyspaceEvents("KEA")
+	ns := ""
+	origTarget := Target2RedisDb
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr(), DB: 2})
+	Target2RedisDb = map[string]map[string]*redis.Client{
+		ns: {"COUNTERS_DB": rdb},
+	}
+	return mr, rdb, func() {
+		Target2RedisDb = origTarget
+	}
+}
+
+func TestListBareTableKeys(t *testing.T) {
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	mr.HSet("BUFFER_POOL_WATERMARKS:oid:0x1", "field", "v")
+	mr.HSet("BUFFER_POOL_WATERMARKS", "NULL", "NULL")
+
+	keys, err := listBareTableKeys(rdb, "BUFFER_POOL_WATERMARKS", ":")
+	if err != nil {
+		t.Fatalf("listBareTableKeys: %v", err)
+	}
+	sort.Strings(keys)
+	want := []string{"BUFFER_POOL_WATERMARKS", "BUFFER_POOL_WATERMARKS:oid:0x1"}
+	if !reflect.DeepEqual(keys, want) {
+		t.Errorf("listBareTableKeys = %v, want %v", keys, want)
+	}
+}
+
+func TestTableData2MsiBareTablePath(t *testing.T) {
+	cleanup := setupTestTarget2RedisDb(t)
+	defer cleanup()
+	ns := ""
+	rclient := Target2RedisDb[ns]["COUNTERS_DB"]
+	oid := "oid:0xbeef"
+	rclient.HSet(context.Background(), "BUFFER_POOL_WATERMARKS:"+oid, "SAI_BUFFER_POOL_STAT_WATERMARK_BYTES", "100")
+	defer rclient.Del(context.Background(), "BUFFER_POOL_WATERMARKS:"+oid)
+
+	tblPath := tablePath{
+		dbNamespace: ns,
+		dbName:      "COUNTERS_DB",
+		tableName:   "BUFFER_POOL_WATERMARKS",
+		delimitor:   ":",
+	}
+	msi := make(map[string]interface{})
+	if err := TableData2Msi(&tblPath, false, nil, &msi); err != nil {
+		t.Fatalf("TableData2Msi: %v", err)
+	}
+	entry, ok := msi[oid].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected keyed entry %q in msi, got %v", oid, msi)
+	}
+	if entry["SAI_BUFFER_POOL_STAT_WATERMARK_BYTES"] != "100" {
+		t.Errorf("watermark bytes = %v, want 100", entry["SAI_BUFFER_POOL_STAT_WATERMARK_BYTES"])
+	}
+}
+
+func TestMixedDbClientTableData2MsiBareTablePath(t *testing.T) {
+	mapkey := ":"
+	cleanup := setupMixedDbRedis(t, mapkey)
+	defer cleanup()
+	ns := ""
+	rclient := Target2RedisDb[ns]["COUNTERS_DB"]
+	oid := "oid:0xabcd"
+	rclient.HSet(context.Background(), "BUFFER_POOL_WATERMARKS:"+oid, "SAI_BUFFER_POOL_STAT_WATERMARK_BYTES", "200")
+	defer rclient.Del(context.Background(), "BUFFER_POOL_WATERMARKS:"+oid)
+
+	c := MixedDbClient{mapkey: mapkey, encoding: gnmipb.Encoding_JSON_IETF}
+	tblPath := tablePath{
+		dbNamespace: ns,
+		dbName:      "COUNTERS_DB",
+		tableName:   "BUFFER_POOL_WATERMARKS",
+		delimitor:   ":",
+	}
+	msi := make(map[string]interface{})
+	if err := c.tableData2Msi(&tblPath, false, nil, &msi); err != nil {
+		t.Fatalf("tableData2Msi: %v", err)
+	}
+	entry, ok := msi[oid].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected keyed entry %q in msi, got %v", oid, msi)
+	}
+	if entry["SAI_BUFFER_POOL_STAT_WATERMARK_BYTES"] != "200" {
+		t.Errorf("watermark bytes = %v, want 200", entry["SAI_BUFFER_POOL_STAT_WATERMARK_BYTES"])
+	}
+}
+
+func waitForPubsubSubscribe(t *testing.T, pubsub *redis.PubSub, pattern string) {
+	t.Helper()
+	msgi, err := pubsub.ReceiveTimeout(context.Background(), time.Second)
+	if err != nil {
+		t.Fatalf("psubscribe receive: %v", err)
+	}
+	subscr, ok := msgi.(*redis.Subscription)
+	if !ok || subscr.Channel != pattern {
+		t.Fatalf("unexpected psubscribe ack: %v", msgi)
+	}
+}
+
+func runDbSingleTableKeySubscribeUpdate(t *testing.T, rsd redisSubData, mutate func(*redis.Client)) map[string]interface{} {
+	t.Helper()
+	updateCh := make(chan map[string]interface{}, 1)
+	c := &DbClient{channel: make(chan struct{})}
+	go dbSingleTableKeySubscribe(c, rsd, updateCh)
+	mutate(Target2RedisDb[rsd.tblPath.dbNamespace][rsd.tblPath.dbName])
+	select {
+	case msi := <-updateCh:
+		close(c.channel)
+		return msi
+	case <-time.After(3 * time.Second):
+		close(c.channel)
+		t.Fatal("timed out waiting for keyspace update")
+		return nil
+	}
+}
+
+func TestDbSingleTableKeySubscribeBareTableDelimSkipped(t *testing.T) {
+	_, rdb, restore := setupMiniredisCountersDb(t)
+	defer restore()
+
+	tblPath := tablePath{
+		dbName:    "COUNTERS_DB",
+		tableName: "BUFFER_POOL_WATERMARKS",
+		delimitor: ":",
+	}
+	pattern := "__keyspace@2__:BUFFER_POOL_WATERMARKS*"
+	prefixLen := len("__keyspace@2__:BUFFER_POOL_WATERMARKS")
+	pubsub := rdb.PSubscribe(context.Background(), pattern)
+	defer pubsub.Close()
+	waitForPubsubSubscribe(t, pubsub, pattern)
+
+	rsd := redisSubData{
+		tblPath:      tblPath,
+		pubsub:       pubsub,
+		prefixLen:    prefixLen,
+		delimSkipped: true,
+	}
+	oid := "oid:0x100"
+	msi := runDbSingleTableKeySubscribeUpdate(t, rsd, func(rdb *redis.Client) {
+		rdb.HSet(context.Background(), "BUFFER_POOL_WATERMARKS:"+oid, "SAI_BUFFER_POOL_STAT_WATERMARK_BYTES", "123")
+	})
+	if _, ok := msi[oid]; !ok {
+		t.Fatalf("expected update keyed by %q, got %v", oid, msi)
+	}
+}
+
+func TestDbSingleTableKeySubscribePortPhyAttrKeepsDelimiter(t *testing.T) {
+	_, rdb, restore := setupMiniredisCountersDb(t)
+	defer restore()
+
+	tblPath := tablePath{
+		dbName:    "COUNTERS_DB",
+		tableName: "PORT_PHY_ATTR",
+		delimitor: ":",
+	}
+	pattern := "__keyspace@2__:PORT_PHY_ATTR:*"
+	prefixLen := len("__keyspace@2__:PORT_PHY_ATTR:")
+	pubsub := rdb.PSubscribe(context.Background(), pattern)
+	defer pubsub.Close()
+	waitForPubsubSubscribe(t, pubsub, pattern)
+
+	rsd := redisSubData{
+		tblPath:      tblPath,
+		pubsub:       pubsub,
+		prefixLen:    prefixLen,
+		delimSkipped: false,
+	}
+	port := "Ethernet68"
+	msi := runDbSingleTableKeySubscribeUpdate(t, rsd, func(rdb *redis.Client) {
+		rdb.HSet(context.Background(), "PORT_PHY_ATTR:"+port, "phy_rx_signal_detect", "1")
+	})
+	if _, ok := msi[port]; !ok {
+		t.Fatalf("expected update keyed by %q, got %v", port, msi)
+	}
+}
+
+func TestMixedDbSingleTableKeySubscribeBareTableDelimSkipped(t *testing.T) {
+	_, rdb, restore := setupMiniredisCountersDb(t)
+	defer restore()
+	mapkey := ":"
+	origRedisDbMap := RedisDbMap
+	RedisDbMap = map[string]*redis.Client{mapkey + ":COUNTERS_DB": rdb}
+	defer func() { RedisDbMap = origRedisDbMap }()
+
+	tblPath := tablePath{
+		dbName:    "COUNTERS_DB",
+		tableName: "BUFFER_POOL_WATERMARKS",
+		delimitor: ":",
+	}
+	pattern := "__keyspace@2__:BUFFER_POOL_WATERMARKS*"
+	prefixLen := len("__keyspace@2__:BUFFER_POOL_WATERMARKS")
+	pubsub := rdb.PSubscribe(context.Background(), pattern)
+	defer pubsub.Close()
+	waitForPubsubSubscribe(t, pubsub, pattern)
+
+	updateCh := make(chan map[string]interface{}, 1)
+	c := &MixedDbClient{mapkey: mapkey, channel: make(chan struct{})}
+	rsd := redisSubData{
+		tblPath:      tblPath,
+		pubsub:       pubsub,
+		prefixLen:    prefixLen,
+		delimSkipped: true,
+	}
+	go c.dbSingleTableKeySubscribe(rsd, updateCh)
+
+	oid := "oid:0x200"
+	rdb.HSet(context.Background(), "BUFFER_POOL_WATERMARKS:"+oid, "SAI_BUFFER_POOL_STAT_WATERMARK_BYTES", "456")
+	select {
+	case msi := <-updateCh:
+		if _, ok := msi[oid]; !ok {
+			t.Fatalf("expected update keyed by %q, got %v", oid, msi)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for mixed-db keyspace update")
+	}
+	close(c.channel)
 }
 
 // TestMakeJSONRedisSkipsNull verifies that makeJSON_redis strips the SONiC

--- a/sonic_data_client/client_test.go
+++ b/sonic_data_client/client_test.go
@@ -2251,6 +2251,71 @@ func TestListBareTableKeys(t *testing.T) {
 	}
 }
 
+func TestListBareTableKeysClosedClient(t *testing.T) {
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	mr.Close()
+
+	_, err := listBareTableKeys(rdb, "BUFFER_POOL_WATERMARKS", ":")
+	if err == nil {
+		t.Fatal("expected error from closed redis client")
+	}
+}
+
+func TestTableData2MsiListBareTableKeysError(t *testing.T) {
+	cleanup := setupTestTarget2RedisDb(t)
+	defer cleanup()
+	ns := ""
+
+	patches := gomonkey.ApplyFunc(listBareTableKeys, func(_ *redis.Client, _, _ string) ([]string, error) {
+		return nil, errors.New("mock listBareTableKeys error")
+	})
+	defer patches.Reset()
+
+	tblPath := tablePath{
+		dbNamespace: ns,
+		dbName:      "COUNTERS_DB",
+		tableName:   "BUFFER_POOL_WATERMARKS",
+		delimitor:   ":",
+	}
+	msi := make(map[string]interface{})
+	if err := TableData2Msi(&tblPath, false, nil, &msi); err == nil {
+		t.Fatal("expected listBareTableKeys error")
+	}
+}
+
+func TestTableData2MsiJsonFieldAndTableKey(t *testing.T) {
+	cleanup := setupTestTarget2RedisDb(t)
+	defer cleanup()
+	ns := ""
+	rclient := Target2RedisDb[ns]["COUNTERS_DB"]
+	redisKey := "COUNTERS:oid:0x1000000000040"
+	rclient.HSet(context.Background(), redisKey, "SAI_PORT_STAT_IF_IN_ERRORS", "42")
+	defer rclient.Del(context.Background(), redisKey)
+
+	tblPath := tablePath{
+		dbNamespace:  ns,
+		dbName:       "COUNTERS_DB",
+		tableName:    "COUNTERS",
+		tableKey:     "oid:0x1000000000040",
+		delimitor:    ":",
+		field:        "SAI_PORT_STAT_IF_IN_ERRORS",
+		jsonField:    "SAI_PORT_STAT_IF_IN_ERRORS",
+		jsonTableKey: "Ethernet70",
+	}
+	msi := make(map[string]interface{})
+	if err := TableData2Msi(&tblPath, false, nil, &msi); err != nil {
+		t.Fatalf("TableData2Msi: %v", err)
+	}
+	entry, ok := msi["Ethernet70"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected jsonTableKey entry, got %v", msi)
+	}
+	if entry["SAI_PORT_STAT_IF_IN_ERRORS"] != "42" {
+		t.Errorf("field value = %v, want 42", entry["SAI_PORT_STAT_IF_IN_ERRORS"])
+	}
+}
+
 func TestTableData2MsiBareTablePath(t *testing.T) {
 	cleanup := setupTestTarget2RedisDb(t)
 	defer cleanup()
@@ -2306,6 +2371,92 @@ func TestMixedDbClientTableData2MsiBareTablePath(t *testing.T) {
 	}
 	if entry["SAI_BUFFER_POOL_STAT_WATERMARK_BYTES"] != "200" {
 		t.Errorf("watermark bytes = %v, want 200", entry["SAI_BUFFER_POOL_STAT_WATERMARK_BYTES"])
+	}
+}
+
+func TestMixedDbClientTableData2MsiListBareTableKeysError(t *testing.T) {
+	mapkey := ":"
+	cleanup := setupMixedDbRedis(t, mapkey)
+	defer cleanup()
+	ns := ""
+
+	patches := gomonkey.ApplyFunc(listBareTableKeys, func(_ *redis.Client, _, _ string) ([]string, error) {
+		return nil, errors.New("mock listBareTableKeys error")
+	})
+	defer patches.Reset()
+
+	c := MixedDbClient{mapkey: mapkey, encoding: gnmipb.Encoding_JSON_IETF}
+	tblPath := tablePath{
+		dbNamespace: ns,
+		dbName:      "COUNTERS_DB",
+		tableName:   "BUFFER_POOL_WATERMARKS",
+		delimitor:   ":",
+	}
+	msi := make(map[string]interface{})
+	if err := c.tableData2Msi(&tblPath, false, nil, &msi); err == nil {
+		t.Fatal("expected listBareTableKeys error")
+	}
+}
+
+func TestMixedDbClientTableData2MsiJsonFieldAndTableKey(t *testing.T) {
+	mapkey := ":"
+	cleanup := setupMixedDbRedis(t, mapkey)
+	defer cleanup()
+	ns := ""
+	rclient := Target2RedisDb[ns]["COUNTERS_DB"]
+	redisKey := "COUNTERS:oid:0x1000000000050"
+	rclient.HSet(context.Background(), redisKey, "SAI_PORT_STAT_IF_OUT_ERRORS", "99")
+	defer rclient.Del(context.Background(), redisKey)
+
+	c := MixedDbClient{mapkey: mapkey, encoding: gnmipb.Encoding_JSON_IETF}
+	tblPath := tablePath{
+		dbNamespace:  ns,
+		dbName:       "COUNTERS_DB",
+		tableName:    "COUNTERS",
+		tableKey:     "oid:0x1000000000050",
+		delimitor:    ":",
+		field:        "SAI_PORT_STAT_IF_OUT_ERRORS",
+		jsonField:    "SAI_PORT_STAT_IF_OUT_ERRORS",
+		jsonTableKey: "Ethernet71",
+	}
+	msi := make(map[string]interface{})
+	if err := c.tableData2Msi(&tblPath, false, nil, &msi); err != nil {
+		t.Fatalf("tableData2Msi: %v", err)
+	}
+	entry, ok := msi["Ethernet71"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected jsonTableKey entry, got %v", msi)
+	}
+	if entry["SAI_PORT_STAT_IF_OUT_ERRORS"] != "99" {
+		t.Errorf("field value = %v, want 99", entry["SAI_PORT_STAT_IF_OUT_ERRORS"])
+	}
+}
+
+func TestMixedDbClientTableData2MsiMalformedDbkey(t *testing.T) {
+	mapkey := ":"
+	cleanup := setupMixedDbRedis(t, mapkey)
+	defer cleanup()
+	ns := ""
+
+	patches := gomonkey.ApplyFunc(listBareTableKeys, func(_ *redis.Client, _, _ string) ([]string, error) {
+		return []string{"malformed-no-delimiter"}, nil
+	})
+	defer patches.Reset()
+
+	c := MixedDbClient{mapkey: mapkey, encoding: gnmipb.Encoding_JSON_IETF}
+	tblPath := tablePath{
+		dbNamespace: ns,
+		dbName:      "COUNTERS_DB",
+		tableName:   "BUFFER_POOL_WATERMARKS",
+		delimitor:   ":",
+	}
+	msi := make(map[string]interface{})
+	rclient := Target2RedisDb[ns]["COUNTERS_DB"]
+	rclient.HSet(context.Background(), "malformed-no-delimiter", "SAI_BUFFER_POOL_STAT_WATERMARK_BYTES", "1")
+	defer rclient.Del(context.Background(), "malformed-no-delimiter")
+
+	if err := c.tableData2Msi(&tblPath, false, nil, &msi); err == nil {
+		t.Fatal("expected split error for malformed dbkey")
 	}
 }
 
@@ -2369,6 +2520,47 @@ func TestDbSingleTableKeySubscribeBareTableDelimSkipped(t *testing.T) {
 	if _, ok := msi[oid]; !ok {
 		t.Fatalf("expected update keyed by %q, got %v", oid, msi)
 	}
+}
+
+func TestDbSingleTableKeySubscribeBareTableDel(t *testing.T) {
+	_, rdb, restore := setupMiniredisCountersDb(t)
+	defer restore()
+
+	tblPath := tablePath{
+		dbName:    "COUNTERS_DB",
+		tableName: "BUFFER_POOL_WATERMARKS",
+		delimitor: ":",
+	}
+	pattern := "__keyspace@2__:BUFFER_POOL_WATERMARKS*"
+	prefixLen := len("__keyspace@2__:BUFFER_POOL_WATERMARKS")
+	pubsub := rdb.PSubscribe(context.Background(), pattern)
+	defer pubsub.Close()
+	waitForPubsubSubscribe(t, pubsub, pattern)
+
+	updateCh := make(chan map[string]interface{}, 1)
+	c := &DbClient{channel: make(chan struct{})}
+	rsd := redisSubData{
+		tblPath:      tblPath,
+		pubsub:       pubsub,
+		prefixLen:    prefixLen,
+		delimSkipped: true,
+	}
+	go dbSingleTableKeySubscribe(c, rsd, updateCh)
+	time.Sleep(50 * time.Millisecond)
+
+	oid := "oid:0x101"
+	redisKey := "BUFFER_POOL_WATERMARKS:" + oid
+	rdb.HSet(context.Background(), redisKey, "SAI_BUFFER_POOL_STAT_WATERMARK_BYTES", "1")
+	publishKeyspaceEvent(t, rdb, 2, redisKey, "del")
+	select {
+	case msi := <-updateCh:
+		if _, ok := msi[oid]; !ok {
+			t.Fatalf("expected delete update keyed by %q, got %v", oid, msi)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for bare-table delete update")
+	}
+	close(c.channel)
 }
 
 func TestDbSingleTableKeySubscribePortPhyAttrKeepsDelimiter(t *testing.T) {
@@ -2444,6 +2636,54 @@ func TestMixedDbSingleTableKeySubscribeBareTableDelimSkipped(t *testing.T) {
 		}
 	case <-time.After(3 * time.Second):
 		t.Fatal("timed out waiting for mixed-db keyspace update")
+	}
+	close(c.channel)
+}
+
+func TestMixedDbSingleTableKeySubscribeBareTableDel(t *testing.T) {
+	_, rdb, restore := setupMiniredisCountersDb(t)
+	defer restore()
+	mapkey := ":"
+	origRedisDbMap := RedisDbMap
+	RedisDbMap = map[string]*redis.Client{mapkey + ":COUNTERS_DB": rdb}
+	defer func() { RedisDbMap = origRedisDbMap }()
+
+	tblPath := tablePath{
+		dbName:    "COUNTERS_DB",
+		tableName: "BUFFER_POOL_WATERMARKS",
+		delimitor: ":",
+	}
+	pattern := "__keyspace@2__:BUFFER_POOL_WATERMARKS*"
+	prefixLen := len("__keyspace@2__:BUFFER_POOL_WATERMARKS")
+	pubsub := rdb.PSubscribe(context.Background(), pattern)
+	defer pubsub.Close()
+	waitForPubsubSubscribe(t, pubsub, pattern)
+
+	updateCh := make(chan map[string]interface{}, 1)
+	c := &MixedDbClient{mapkey: mapkey, channel: make(chan struct{})}
+	rsd := redisSubData{
+		tblPath:      tblPath,
+		pubsub:       pubsub,
+		prefixLen:    prefixLen,
+		delimSkipped: true,
+	}
+	go c.dbSingleTableKeySubscribe(rsd, updateCh)
+	time.Sleep(50 * time.Millisecond)
+
+	oid := "oid:0x201"
+	redisKey := "BUFFER_POOL_WATERMARKS:" + oid
+	rdb.HSet(context.Background(), redisKey, "SAI_BUFFER_POOL_STAT_WATERMARK_BYTES", "1")
+	publishKeyspaceEvent(t, rdb, 2, redisKey, "del")
+	select {
+	case msi := <-updateCh:
+		if _, ok := msi[oid]; !ok {
+			t.Fatalf("expected delete update keyed by %q, got %v", oid, msi)
+		}
+		if msi["delete"] != "null_value" {
+			t.Errorf("expected delete marker, got %v", msi["delete"])
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for mixed-db bare-table delete update")
 	}
 	close(c.channel)
 }

--- a/sonic_data_client/client_test.go
+++ b/sonic_data_client/client_test.go
@@ -2108,6 +2108,66 @@ func TestMixedDbClientGet(t *testing.T) {
 	})
 }
 
+// TestMakeJSONRedisSkipsNull verifies that makeJSON_redis strips the SONiC
+// "NULL"/"NULL" placeholder field that Redis hashes carry when they would
+// otherwise be empty.
+func TestMakeJSONRedisSkipsNull(t *testing.T) {
+	key := "PortChannel1|Ethernet4"
+	op := "ADD"
+
+	tests := []struct {
+		name string
+		key  *string
+		op   *string
+		mfv  map[string]string
+		want map[string]interface{}
+	}{
+		{
+			name: "key and op nil, only NULL field",
+			key:  nil,
+			op:   nil,
+			mfv:  map[string]string{"NULL": "NULL"},
+			want: map[string]interface{}{},
+		},
+		{
+			name: "key and op nil, NULL mixed with real field",
+			key:  nil,
+			op:   nil,
+			mfv:  map[string]string{"NULL": "NULL", "admin_status": "up"},
+			want: map[string]interface{}{"admin_status": "up"},
+		},
+		{
+			name: "key set, only NULL field",
+			key:  &key,
+			op:   nil,
+			mfv:  map[string]string{"NULL": "NULL"},
+			want: map[string]interface{}{key: map[string]interface{}{}},
+		},
+		{
+			name: "key and op set, NULL mixed with real field",
+			key:  &key,
+			op:   &op,
+			mfv:  map[string]string{"NULL": "NULL", "admin_status": "up"},
+			want: map[string]interface{}{
+				key: map[string]interface{}{
+					op: map[string]interface{}{"admin_status": "up"},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := map[string]interface{}{}
+			if err := makeJSON_redis(&got, tc.key, tc.op, tc.mfv); err != nil {
+				t.Fatalf("makeJSON_redis returned error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("makeJSON_redis = %v, want %v", got, tc.want)
+			}
+		})
+	}
+
 func TestMain(m *testing.M) {
 	defer test_utils.MemLeakCheck()
 	m.Run()

--- a/sonic_data_client/db_client.go
+++ b/sonic_data_client/db_client.go
@@ -102,6 +102,22 @@ func CreateTablePath(dbName string, tableName string, delimitor string, tableKey
 	return tblPath
 }
 
+// listBareTableKeys returns all Redis keys for a bare table path,
+// matching both keyed (<table><delim>*) and flat-hash (<table>) layouts.
+func listBareTableKeys(rdb *redis.Client, tableName, delimitor string) ([]string, error) {
+	pattern := tableName + delimitor + "*"
+	keys, err := rdb.Keys(pattern).Result()
+	if err != nil {
+		return nil, fmt.Errorf("redis Keys failed for pattern %q: %v", pattern, err)
+	}
+	if n, err := rdb.Exists(tableName).Result(); err != nil {
+		return nil, fmt.Errorf("redis Exists failed for key %q: %v", tableName, err)
+	} else if n == 1 {
+		keys = append(keys, tableName)
+	}
+	return keys, nil
+}
+
 // Define a new function to set the IntervalTicker variable
 func SetIntervalTicker(f func(interval time.Duration) <-chan time.Time) {
 	if NeedMock == true {
@@ -921,6 +937,9 @@ func resolveSubscribePath(prefix, path *gnmipb.Path, pathG2S *map[*gnmipb.Path][
 func makeJSON_redis(msi *map[string]interface{}, key *string, op *string, mfv map[string]string) error {
 	if key == nil && op == nil {
 		for f, v := range mfv {
+			if f == "NULL" {
+				continue
+			}
 			(*msi)[f] = v
 		}
 		return nil
@@ -928,6 +947,9 @@ func makeJSON_redis(msi *map[string]interface{}, key *string, op *string, mfv ma
 
 	fp := map[string]interface{}{}
 	for f, v := range mfv {
+		if f == "NULL" {
+			continue
+		}
 		fp[f] = v
 	}
 
@@ -969,26 +991,18 @@ func emitJSON(v *map[string]interface{}) ([]byte, error) {
 func TableData2Msi(tblPath *tablePath, useKey bool, op *string, msi *map[string]interface{}) error {
 	redisDb := Target2RedisDb[tblPath.dbNamespace][tblPath.dbName]
 
-	var pattern string
 	var dbkeys []string
 	var err error
 	var fv map[string]string
 
-	//Only table name provided
 	if tblPath.tableKey == "" {
-		// tables in COUNTERS_DB other than COUNTERS/PORT_PHY_ATTR don't have keys
-		if tblPath.dbName == "COUNTERS_DB" && !countersDbHasTableKeys(tblPath.tableName) {
-			pattern = tblPath.tableName
-		} else {
-			pattern = tblPath.tableName + tblPath.delimitor + "*"
-		}
-		dbkeys, err = redisDb.Keys(context.Background(), pattern).Result()
+		// Bare table path: collect both keyed and flat-hash entries.
+		dbkeys, err = listBareTableKeys(redisDb, tblPath.tableName, tblPath.delimitor)
 		if err != nil {
-			log.V(2).Infof("redis Keys failed for %v, pattern %s", tblPath, pattern)
-			return fmt.Errorf("redis Keys failed for %v, pattern %s %v", tblPath, pattern, err)
+			log.V(2).Infof("listBareTableKeys failed for %v: %v", tblPath, err)
+			return err
 		}
 	} else {
-		// both table name and key provided
 		dbkeys = []string{tblPath.tableName + tblPath.delimitor + tblPath.tableKey}
 	}
 
@@ -1347,9 +1361,10 @@ func dbFieldSubscribe(c *DbClient, gnmiPath *gnmipb.Path, onChange bool, interva
 }
 
 type redisSubData struct {
-	tblPath   tablePath
-	pubsub    *redis.PubSub
-	prefixLen int
+	tblPath      tablePath
+	pubsub       *redis.PubSub
+	prefixLen    int
+	delimSkipped bool // PSUBSCRIBE pattern omitted the delimiter
 }
 
 // TODO: For delete operation, the exact content returned is to be clarified.
@@ -1357,7 +1372,19 @@ func dbSingleTableKeySubscribe(c *DbClient, rsd redisSubData, updateChannel chan
 	tblPath := rsd.tblPath
 	pubsub := rsd.pubsub
 	prefixLen := rsd.prefixLen
-	msi := make(map[string]interface{})
+	delimSkipped := rsd.delimSkipped
+	// Leave nil so the first event always sends, even when newMsi is empty
+	// (e.g. a NULL-only hash stripped by makeJSON_redis).
+	var msi map[string]interface{}
+
+	// Strip the leading delimiter only when the PSUBSCRIBE pattern omitted it.
+	keyFromChannel := func(channel string) string {
+		key := channel[prefixLen:]
+		if delimSkipped {
+			key = strings.TrimPrefix(key, tblPath.delimitor)
+		}
+		return key
+	}
 
 	log.V(2).Infof("Starting dbSingleTableKeySubscribe routine for %+v", tblPath)
 
@@ -1393,7 +1420,7 @@ func dbSingleTableKeySubscribe(c *DbClient, rsd redisSubData, updateChannel chan
 						log.V(2).Infof("Invalid psubscribe channel notification %v, shorter than %v", subscr.Channel, prefixLen)
 						continue
 					}
-					key := subscr.Channel[prefixLen:]
+					key := keyFromChannel(subscr.Channel)
 					newMsi[key] = fp
 				}
 			} else if subscr.Payload == "hset" {
@@ -1410,7 +1437,7 @@ func dbSingleTableKeySubscribe(c *DbClient, rsd redisSubData, updateChannel chan
 						log.V(2).Infof("Invalid psubscribe channel notification %v, shorter than %v", subscr.Channel, prefixLen)
 						continue
 					}
-					tblPath.tableKey = subscr.Channel[prefixLen:]
+					tblPath.tableKey = keyFromChannel(subscr.Channel)
 					err = TableData2Msi(&tblPath, true, nil, &newMsi)
 					if err != nil {
 						enqueueFatalMsg(c, err.Error())
@@ -1422,6 +1449,9 @@ func dbSingleTableKeySubscribe(c *DbClient, rsd redisSubData, updateChannel chan
 					continue
 				}
 				msi = newMsi
+				// Forward even empty newMsi (NULL-only hash) -- still a real change.
+				updateChannel <- newMsi
+				continue
 			} else {
 				log.V(2).Infof("Invalid psubscribe payload notification:  %v", subscr.Payload)
 				continue
@@ -1490,11 +1520,15 @@ func dbTableKeySubscribe(c *DbClient, gnmiPath *gnmipb.Path, interval time.Durat
 		// Subscribe to keyspace notification
 		pattern := "__keyspace@" + strconv.Itoa(int(spb.Target_value[tblPath.dbName])) + "__:"
 		pattern += tblPath.tableName
-		if tblPath.dbName == "COUNTERS_DB" && !countersDbHasTableKeys(tblPath.tableName) {
-			// tables in COUNTERS_DB without per-object keys, skip delimitor
+		// COUNTERS_DB non-COUNTERS: skip delim so wildcard matches keyed and flat rows.
+		if tblPath.dbName == "COUNTERS_DB" && tblPath.tableName != "COUNTERS" {
 		} else {
 			pattern += tblPath.delimitor
 		}
+		// Bare-table subs: strip leading delim from event channel suffix.
+		delimSkipped := tblPath.dbName == "COUNTERS_DB" &&
+			tblPath.tableName != "COUNTERS" &&
+			tblPath.tableKey == ""
 
 		var prefixLen int
 		if tblPath.tableKey != "" {
@@ -1526,9 +1560,10 @@ func dbTableKeySubscribe(c *DbClient, gnmiPath *gnmipb.Path, interval time.Durat
 			return
 		}
 		rsd := redisSubData{
-			tblPath:   tblPath,
-			pubsub:    pubsub,
-			prefixLen: prefixLen,
+			tblPath:      tblPath,
+			pubsub:       pubsub,
+			prefixLen:    prefixLen,
+			delimSkipped: delimSkipped,
 		}
 		rsdList = append(rsdList, rsd)
 	}

--- a/sonic_data_client/db_client.go
+++ b/sonic_data_client/db_client.go
@@ -106,11 +106,11 @@ func CreateTablePath(dbName string, tableName string, delimitor string, tableKey
 // matching both keyed (<table><delim>*) and flat-hash (<table>) layouts.
 func listBareTableKeys(rdb *redis.Client, tableName, delimitor string) ([]string, error) {
 	pattern := tableName + delimitor + "*"
-	keys, err := rdb.Keys(pattern).Result()
+	keys, err := rdb.Keys(context.Background(), pattern).Result()
 	if err != nil {
 		return nil, fmt.Errorf("redis Keys failed for pattern %q: %v", pattern, err)
 	}
-	if n, err := rdb.Exists(tableName).Result(); err != nil {
+	if n, err := rdb.Exists(context.Background(), tableName).Result(); err != nil {
 		return nil, fmt.Errorf("redis Exists failed for key %q: %v", tableName, err)
 	} else if n == 1 {
 		keys = append(keys, tableName)

--- a/sonic_data_client/db_client.go
+++ b/sonic_data_client/db_client.go
@@ -1520,14 +1520,15 @@ func dbTableKeySubscribe(c *DbClient, gnmiPath *gnmipb.Path, interval time.Durat
 		// Subscribe to keyspace notification
 		pattern := "__keyspace@" + strconv.Itoa(int(spb.Target_value[tblPath.dbName])) + "__:"
 		pattern += tblPath.tableName
-		// COUNTERS_DB non-COUNTERS: skip delim so wildcard matches keyed and flat rows.
-		if tblPath.dbName == "COUNTERS_DB" && tblPath.tableName != "COUNTERS" {
+		// COUNTERS_DB bare tables (no per-object keys): skip delim so wildcard
+		// matches both flat-hash rows and keyed rows.
+		if tblPath.dbName == "COUNTERS_DB" && !countersDbHasTableKeys(tblPath.tableName) {
 		} else {
 			pattern += tblPath.delimitor
 		}
 		// Bare-table subs: strip leading delim from event channel suffix.
 		delimSkipped := tblPath.dbName == "COUNTERS_DB" &&
-			tblPath.tableName != "COUNTERS" &&
+			!countersDbHasTableKeys(tblPath.tableName) &&
 			tblPath.tableKey == ""
 
 		var prefixLen int

--- a/sonic_data_client/mixed_db_client.go
+++ b/sonic_data_client/mixed_db_client.go
@@ -977,20 +977,13 @@ func (c *MixedDbClient) tableData2Msi(tblPath *tablePath, useKey bool, op *strin
 			return fmt.Errorf("redis Keys failed for %v, pattern %s %v", tblPath, pattern, err)
 		}
 	} else if tblPath.tableKey == "" {
-		// Only table name provided
-		// tables in COUNTERS_DB other than COUNTERS/PORT_PHY_ATTR don't have keys
-		if tblPath.dbName == "COUNTERS_DB" && !countersDbHasTableKeys(tblPath.tableName) {
-			pattern = tblPath.tableName
-		} else {
-			pattern = tblPath.tableName + tblPath.delimitor + "*"
-		}
-		dbkeys, err = redisDb.Keys(context.Background(), pattern).Result()
+		// Bare table path: collect both keyed and flat-hash entries.
+		dbkeys, err = listBareTableKeys(redisDb, tblPath.tableName, tblPath.delimitor)
 		if err != nil {
-			log.V(2).Infof("redis Keys failed for %v, pattern %s", tblPath, pattern)
-			return fmt.Errorf("redis Keys failed for %v, pattern %s %v", tblPath, pattern, err)
+			log.V(2).Infof("listBareTableKeys failed for %v: %v", tblPath, err)
+			return err
 		}
 	} else {
-		// both table name and key provided
 		dbkeys = []string{tblPath.tableName + tblPath.delimitor + tblPath.tableKey}
 	}
 
@@ -1187,7 +1180,6 @@ func ConvertDbEntry(inputData map[string]interface{}) map[string]string {
 }
 
 func (c *MixedDbClient) handleTableData(tblPaths []tablePath) error {
-	var pattern string
 	var dbkeys []string
 	var err error
 	var res interface{}
@@ -1210,22 +1202,15 @@ func (c *MixedDbClient) handleTableData(tblPaths []tablePath) error {
 		}
 
 		if tblPath.operation == opRemove {
-			//Only table name provided
 			if tblPath.tableKey == "" {
-				// tables in COUNTERS_DB other than COUNTERS/PORT_PHY_ATTR don't have keys
-				if tblPath.dbName == "COUNTERS_DB" && !countersDbHasTableKeys(tblPath.tableName) {
-					pattern = tblPath.tableName
-				} else {
-					pattern = tblPath.tableName + tblPath.delimitor + "*"
-				}
-				// Can't remove entry in temporary state table
+				// Bare-table delete: keyed rows only.
+				pattern := tblPath.tableName + tblPath.delimitor + "*"
 				dbkeys, err = redisDb.Keys(context.Background(), pattern).Result()
 				if err != nil {
 					log.V(2).Infof("redis Keys failed for %v, pattern %s", tblPath, pattern)
 					return fmt.Errorf("redis Keys failed for %v, pattern %s %v", tblPath, pattern, err)
 				}
 			} else {
-				// both table name and key provided
 				dbkeys = []string{tblPath.tableName + tblPath.delimitor + tblPath.tableKey}
 			}
 
@@ -2105,7 +2090,19 @@ func (c *MixedDbClient) dbSingleTableKeySubscribe(rsd redisSubData, updateChanne
 	tblPath := rsd.tblPath
 	pubsub := rsd.pubsub
 	prefixLen := rsd.prefixLen
-	msi := make(map[string]interface{})
+	delimSkipped := rsd.delimSkipped
+	// Leave nil so the first event always sends, even when newMsi is empty
+	// (e.g. a NULL-only hash stripped by makeJSON_redis).
+	var msi map[string]interface{}
+
+	// Strip the leading delimiter only when the PSUBSCRIBE pattern omitted it.
+	keyFromChannel := func(channel string) string {
+		key := channel[prefixLen:]
+		if delimSkipped {
+			key = strings.TrimPrefix(key, tblPath.delimitor)
+		}
+		return key
+	}
 
 	log.V(2).Infof("Starting dbSingleTableKeySubscribe routine for %+v", tblPath)
 
@@ -2141,7 +2138,7 @@ func (c *MixedDbClient) dbSingleTableKeySubscribe(rsd redisSubData, updateChanne
 						log.V(2).Infof("Invalid psubscribe channel notification %v, shorter than %v", subscr.Channel, prefixLen)
 						continue
 					}
-					key := subscr.Channel[prefixLen:]
+					key := keyFromChannel(subscr.Channel)
 					newMsi[key] = fp
 					newMsi["delete"] = "null_value"
 				}
@@ -2159,7 +2156,7 @@ func (c *MixedDbClient) dbSingleTableKeySubscribe(rsd redisSubData, updateChanne
 						log.V(2).Infof("Invalid psubscribe channel notification %v, shorter than %v", subscr.Channel, prefixLen)
 						continue
 					}
-					tblPath.tableKey = subscr.Channel[prefixLen:]
+					tblPath.tableKey = keyFromChannel(subscr.Channel)
 					err = c.tableData2Msi(&tblPath, true, nil, &newMsi)
 					if err != nil {
 						putFatalMsg(c.q, err.Error())
@@ -2171,6 +2168,9 @@ func (c *MixedDbClient) dbSingleTableKeySubscribe(rsd redisSubData, updateChanne
 					continue
 				}
 				msi = newMsi
+				// Forward even empty newMsi (NULL-only hash) -- still a real change.
+				updateChannel <- newMsi
+				continue
 			} else {
 				log.V(2).Infof("Invalid psubscribe payload notification:  %v", subscr.Payload)
 				continue
@@ -2252,11 +2252,21 @@ func (c *MixedDbClient) dbTableKeySubscribe(gnmiPath *gnmipb.Path, interval time
 		// Subscribe to keyspace notification
 		pattern := "__keyspace@" + strconv.Itoa(int(spb.Target_value[tblPath.dbName])) + "__:"
 		pattern += tblPath.tableName
-		if tblPath.dbName == "COUNTERS_DB" && !countersDbHasTableKeys(tblPath.tableName) {
-			// tables in COUNTERS_DB without per-object keys, skip delimitor
+		// Legacy: COUNTERS_DB non-COUNTERS PSUBSCRIBE pattern omits the
+		// delimiter so the wildcard matches both flat-hash rows
+		// (e.g. COUNTERS_PORT_NAME_MAP) and keyed rows
+		// (e.g. BUFFER_POOL_WATERMARKS:<oid>).
+		if tblPath.dbName == "COUNTERS_DB" && tblPath.tableName != "COUNTERS" {
+			// skip delimitor
 		} else {
 			pattern += tblPath.delimitor
 		}
+		// On bare-table subs the keyspace event channel still carries the
+		// table delimiter after prefixLen; strip it when extracting the key
+		// so tableData2Msi gets the correct row.
+		delimSkipped := tblPath.dbName == "COUNTERS_DB" &&
+			tblPath.tableName != "COUNTERS" &&
+			tblPath.tableKey == ""
 
 		var prefixLen int
 		if tblPath.tableKey != "" {
@@ -2292,9 +2302,10 @@ func (c *MixedDbClient) dbTableKeySubscribe(gnmiPath *gnmipb.Path, interval time
 			return
 		}
 		rsd := redisSubData{
-			tblPath:   tblPath,
-			pubsub:    pubsub,
-			prefixLen: prefixLen,
+			tblPath:      tblPath,
+			pubsub:       pubsub,
+			prefixLen:    prefixLen,
+			delimSkipped: delimSkipped,
 		}
 		rsdList = append(rsdList, rsd)
 	}

--- a/sonic_data_client/mixed_db_client.go
+++ b/sonic_data_client/mixed_db_client.go
@@ -2252,11 +2252,10 @@ func (c *MixedDbClient) dbTableKeySubscribe(gnmiPath *gnmipb.Path, interval time
 		// Subscribe to keyspace notification
 		pattern := "__keyspace@" + strconv.Itoa(int(spb.Target_value[tblPath.dbName])) + "__:"
 		pattern += tblPath.tableName
-		// Legacy: COUNTERS_DB non-COUNTERS PSUBSCRIBE pattern omits the
-		// delimiter so the wildcard matches both flat-hash rows
-		// (e.g. COUNTERS_PORT_NAME_MAP) and keyed rows
-		// (e.g. BUFFER_POOL_WATERMARKS:<oid>).
-		if tblPath.dbName == "COUNTERS_DB" && tblPath.tableName != "COUNTERS" {
+		// COUNTERS_DB bare tables (no per-object keys): omit the delimiter so
+		// the wildcard matches both flat-hash rows (e.g. COUNTERS_PORT_NAME_MAP)
+		// and keyed rows (e.g. BUFFER_POOL_WATERMARKS:<oid>).
+		if tblPath.dbName == "COUNTERS_DB" && !countersDbHasTableKeys(tblPath.tableName) {
 			// skip delimitor
 		} else {
 			pattern += tblPath.delimitor
@@ -2265,7 +2264,7 @@ func (c *MixedDbClient) dbTableKeySubscribe(gnmiPath *gnmipb.Path, interval time
 		// table delimiter after prefixLen; strip it when extracting the key
 		// so tableData2Msi gets the correct row.
 		delimSkipped := tblPath.dbName == "COUNTERS_DB" &&
-			tblPath.tableName != "COUNTERS" &&
+			!countersDbHasTableKeys(tblPath.tableName) &&
 			tblPath.tableKey == ""
 
 		var prefixLen int

--- a/sonic_data_client/mixed_db_client.go
+++ b/sonic_data_client/mixed_db_client.go
@@ -797,6 +797,17 @@ func (c *MixedDbClient) getDbtablePath(path *gnmipb.Path, value *gnmipb.TypedVal
 
 	tblPath.dbNamespace = c.dbkey.GetNetns()
 	tblPath.dbName = c.target
+
+	// Virtual-to-real path mapping for COUNTERS_DB datasets (e.g. BUFFER_POOL_WATERMARKS).
+	if tblPath.dbName == "COUNTERS_DB" && len(stringSlice) > 1 {
+		if v2rPaths, err := lookupV2R(stringSlice); err == nil {
+			for i := range v2rPaths {
+				v2rPaths[i].isVirtualPath = true
+			}
+			return v2rPaths, nil
+		}
+	}
+
 	tblPath.tableName = ""
 	if len(stringSlice) > 1 {
 		tblPath.tableName = stringSlice[1]
@@ -994,6 +1005,25 @@ func (c *MixedDbClient) tableData2Msi(tblPath *tablePath, useKey bool, op *strin
 			return err
 		}
 
+		if len(fv) == 0 {
+			log.V(6).Infof("No data for dbkey %s, skipping", dbkey)
+			continue
+		}
+
+		if tblPath.jsonField != "" && tblPath.jsonTableKey != "" {
+			val, err := redisDb.HGet(context.Background(), dbkey, tblPath.field).Result()
+			if err != nil {
+				log.V(3).Infof("redis HGet failed for %v %v", tblPath, err)
+				continue
+			}
+			fieldFv := map[string]string{tblPath.jsonField: val}
+			err = c.makeJSON_redis(msi, &tblPath.jsonTableKey, op, fieldFv)
+			if err != nil {
+				return err
+			}
+			continue
+		}
+
 		if tblPath.tableName == "" {
 			// Split dbkey string into two parts
 			// First part is table name and second part is key in table
@@ -1007,6 +1037,12 @@ func (c *MixedDbClient) tableData2Msi(tblPath *tablePath, useKey bool, op *strin
 				(*msi)[tableName] = table_msi
 			}
 			err = c.makeJSON_redis(table_msi, &key, op, fv)
+			if err != nil {
+				log.V(2).Infof("makeJSON err %s for fv %v", err, fv)
+				return err
+			}
+		} else if tblPath.jsonTableKey != "" {
+			err = c.makeJSON_redis(msi, &tblPath.jsonTableKey, op, fv)
 			if err != nil {
 				log.V(2).Infof("makeJSON err %s for fv %v", err, fv)
 				return err
@@ -1030,6 +1066,9 @@ func (c *MixedDbClient) tableData2Msi(tblPath *tablePath, useKey bool, op *strin
 			var key string
 			// Split dbkey string into two parts and second part is key in table
 			keys := strings.SplitN(dbkey, tblPath.delimitor, 2)
+			if len(keys) < 2 {
+				return fmt.Errorf("dbkey: %s, failed split from delimitor %v", dbkey, tblPath.delimitor)
+			}
 			key = keys[1]
 			err = c.makeJSON_redis(msi, &key, op, fv)
 			if err != nil {

--- a/sonic_data_client/virtual_db.go
+++ b/sonic_data_client/virtual_db.go
@@ -193,6 +193,7 @@ func initCountersPGNameMap() error {
 			initErr = err
 			return
 		}
+		local := make(map[string]map[string]string)
 		for pg, oid := range pgOidMap {
 			// pg is in format of "Ethernet64:7"
 			pg_parts := strings.Split(pg, ":")
@@ -200,11 +201,12 @@ func initCountersPGNameMap() error {
 				initErr = fmt.Errorf("invalid pg name %v", pg)
 				return
 			}
-			if _, ok := countersPGNameMap[pg_parts[0]]; !ok {
-				countersPGNameMap[pg_parts[0]] = make(map[string]string)
+			if _, ok := local[pg_parts[0]]; !ok {
+				local[pg_parts[0]] = make(map[string]string)
 			}
-			countersPGNameMap[pg_parts[0]][pg_parts[1]] = oid
+			local[pg_parts[0]][pg_parts[1]] = oid
 		}
+		countersPGNameMap = local
 	})
 	return initErr
 }
@@ -389,7 +391,7 @@ func initCountersBufferPoolNameMap() error {
 	if err != nil {
 		return err
 	}
-	countersBufferPoolNameByNamespace = make(map[string]map[string]string)
+	local := make(map[string]map[string]string)
 	for namespace, redisDb := range redis_client_map {
 		_, err := redisDb.Ping().Result()
 		if err != nil {
@@ -408,8 +410,9 @@ func initCountersBufferPoolNameMap() error {
 		for k, v := range fv {
 			poolMap[k] = v
 		}
-		countersBufferPoolNameByNamespace[namespace] = poolMap
+		local[namespace] = poolMap
 	}
+	countersBufferPoolNameByNamespace = local
 	return nil
 }
 

--- a/sonic_data_client/virtual_db.go
+++ b/sonic_data_client/virtual_db.go
@@ -85,6 +85,9 @@ var (
 	// Mutex to protect ClearMappings from racing with init functions
 	clearMappingsMu sync.RWMutex
 
+	// Per-namespace buffer pool name to oid (COUNTERS_BUFFER_POOL_NAME_MAP in COUNTERS_DB)
+	countersBufferPoolNameByNamespace map[string]map[string]string
+
 	// path2TFuncTbl is used to populate trie tree which is reponsible
 	// for virtual path to real data path translation
 	pathTransFuncTbl = []pathTransFunc{
@@ -135,6 +138,12 @@ var (
 		}, { // specific field stats for PORT_PHY_ATTR for one or all Ethernet ports (no alias translation)
 			path:      []string{"COUNTERS_DB", "PORT_PHY_ATTR", "Ethernet*", "*"},
 			transFunc: v2rTranslate(v2rPortPhyAttrFieldStats),
+		}, { // Buffer pool watermarks - bare path returns all pools
+			path:      []string{"COUNTERS_DB", "BUFFER_POOL_WATERMARKS"},
+			transFunc: v2rTranslate(v2rBufferPoolWatermarks),
+		}, { // Buffer pool watermarks - specific pool or wildcard
+			path:      []string{"COUNTERS_DB", "BUFFER_POOL_WATERMARKS", "*"},
+			transFunc: v2rTranslate(v2rBufferPoolWatermarks),
 		},
 	}
 )
@@ -368,6 +377,47 @@ func initDebugNameSwitchStatMap() error {
 		}
 	}
 	return nil
+}
+
+func initCountersBufferPoolNameMap() error {
+	value := os.Getenv("UNIT_TEST")
+	if len(countersBufferPoolNameByNamespace) > 0 && value != "1" {
+		return nil
+	}
+	dbName := "COUNTERS_DB"
+	redis_client_map, err := GetRedisClientsForDb(dbName)
+	if err != nil {
+		return err
+	}
+	countersBufferPoolNameByNamespace = make(map[string]map[string]string)
+	for namespace, redisDb := range redis_client_map {
+		_, err := redisDb.Ping().Result()
+		if err != nil {
+			log.V(1).Infof("Can not connect to %v in namespace %v, err: %v", dbName, namespace, err)
+			return err
+		}
+		fv, err := redisDb.HGetAll("COUNTERS_BUFFER_POOL_NAME_MAP").Result()
+		if err != nil {
+			log.V(2).Infof("redis HGetAll failed for COUNTERS_DB in namespace %v, table COUNTERS_BUFFER_POOL_NAME_MAP: %v", namespace, err)
+			return err
+		}
+		if len(fv) == 0 {
+			continue
+		}
+		poolMap := make(map[string]string, len(fv))
+		for k, v := range fv {
+			poolMap[k] = v
+		}
+		countersBufferPoolNameByNamespace[namespace] = poolMap
+	}
+	return nil
+}
+
+func bufferPoolJSONKey(namespace, poolName string) string {
+	if namespace == "" {
+		return poolName
+	}
+	return poolName + "-" + namespace
 }
 
 // Get the mapping between sonic interface name and oids of their PFC-WD enabled queues in COUNTERS_DB
@@ -1512,6 +1562,57 @@ func v2rSystemPortVoQStats(paths []string) ([]tablePath, error) {
 		}
 	}
 	log.V(6).Infof("v2rSystemPortVoQStats: %v", tblPaths)
+	return tblPaths, nil
+}
+
+// v2rBufferPoolWatermarks resolves /BUFFER_POOL_WATERMARKS[/*|/<pool>]
+// to COUNTERS:<oid> rows via COUNTERS_BUFFER_POOL_NAME_MAP.
+// Bare and wildcard forms return all pools keyed by pool name.
+func v2rBufferPoolWatermarks(paths []string) ([]tablePath, error) {
+	if err := initCountersBufferPoolNameMap(); err != nil {
+		return nil, err
+	}
+	var tblPaths []tablePath
+	allPools := uint(len(paths)) <= KeyIdx || paths[KeyIdx] == "*"
+	if allPools {
+		for ns, pools := range countersBufferPoolNameByNamespace {
+			separator, _ := GetTableKeySeparator(paths[DbIdx], ns)
+			for poolName, oid := range pools {
+				tblPaths = append(tblPaths, tablePath{
+					dbNamespace:  ns,
+					dbName:       paths[DbIdx],
+					tableName:    "COUNTERS",
+					tableKey:     oid,
+					delimitor:    separator,
+					jsonTableKey: bufferPoolJSONKey(ns, poolName),
+				})
+			}
+		}
+		if len(tblPaths) == 0 {
+			return nil, fmt.Errorf("no buffer pools in COUNTERS_BUFFER_POOL_NAME_MAP")
+		}
+	} else {
+		key := paths[KeyIdx]
+		for ns, pools := range countersBufferPoolNameByNamespace {
+			oid, ok := pools[key]
+			if !ok {
+				continue
+			}
+			separator, _ := GetTableKeySeparator(paths[DbIdx], ns)
+			tblPaths = append(tblPaths, tablePath{
+				dbNamespace:  ns,
+				dbName:       paths[DbIdx],
+				tableName:    "COUNTERS",
+				tableKey:     oid,
+				delimitor:    separator,
+				jsonTableKey: bufferPoolJSONKey(ns, key),
+			})
+		}
+		if len(tblPaths) == 0 {
+			return nil, fmt.Errorf("%v not found in COUNTERS_BUFFER_POOL_NAME_MAP", key)
+		}
+	}
+	log.V(6).Infof("v2rBufferPoolWatermarks: %v", tblPaths)
 	return tblPaths, nil
 }
 

--- a/sonic_data_client/virtual_db.go
+++ b/sonic_data_client/virtual_db.go
@@ -385,10 +385,6 @@ func initCountersBufferPoolNameMap() error {
 	clearMappingsMu.Lock()
 	defer clearMappingsMu.Unlock()
 
-	value := os.Getenv("UNIT_TEST")
-	if len(countersBufferPoolNameByNamespace) > 0 && value != "1" {
-		return nil
-	}
 	dbName := "COUNTERS_DB"
 	redis_client_map, err := GetRedisClientsForDb(dbName)
 	if err != nil {
@@ -1387,6 +1383,7 @@ func ClearMappings() {
 	initAliasMapOnce = sync.Once{}
 	initCountersPfcwdNameMapOnce = sync.Once{}
 	initCountersFabricPortNameMapOnce = sync.Once{}
+	countersBufferPoolNameByNamespace = nil
 }
 
 func InitCountersPortNameMap() error       { return initCountersPortNameMap() }

--- a/sonic_data_client/virtual_db.go
+++ b/sonic_data_client/virtual_db.go
@@ -382,6 +382,9 @@ func initDebugNameSwitchStatMap() error {
 }
 
 func initCountersBufferPoolNameMap() error {
+	clearMappingsMu.Lock()
+	defer clearMappingsMu.Unlock()
+
 	value := os.Getenv("UNIT_TEST")
 	if len(countersBufferPoolNameByNamespace) > 0 && value != "1" {
 		return nil
@@ -393,12 +396,12 @@ func initCountersBufferPoolNameMap() error {
 	}
 	local := make(map[string]map[string]string)
 	for namespace, redisDb := range redis_client_map {
-		_, err := redisDb.Ping().Result()
+		_, err := redisDb.Ping(context.Background()).Result()
 		if err != nil {
 			log.V(1).Infof("Can not connect to %v in namespace %v, err: %v", dbName, namespace, err)
 			return err
 		}
-		fv, err := redisDb.HGetAll("COUNTERS_BUFFER_POOL_NAME_MAP").Result()
+		fv, err := redisDb.HGetAll(context.Background(), "COUNTERS_BUFFER_POOL_NAME_MAP").Result()
 		if err != nil {
 			log.V(2).Infof("redis HGetAll failed for COUNTERS_DB in namespace %v, table COUNTERS_BUFFER_POOL_NAME_MAP: %v", namespace, err)
 			return err

--- a/sonic_data_client/virtual_db_test.go
+++ b/sonic_data_client/virtual_db_test.go
@@ -1412,3 +1412,135 @@ func TestGetPfcwdMap_PortQosMapEmpty(t *testing.T) {
 		t.Fatalf("expected nil map when PORT_QOS_MAP keys are absent, got %#v", m)
 	}
 }
+
+// --------------------------------------------------------------------------
+// Tests for v2rBufferPoolWatermarks / initCountersBufferPoolNameMap
+// --------------------------------------------------------------------------
+
+func setupBufferPoolMaps(t *testing.T) (*miniredis.Miniredis, func()) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	sdcfg.Init()
+	ns, _ := sdcfg.GetDbDefaultNamespace()
+	mr.HSet("COUNTERS_BUFFER_POOL_NAME_MAP", "ingress_lossless_pool", "oid:0x5000000000001")
+	mr.HSet("COUNTERS_BUFFER_POOL_NAME_MAP", "egress_lossy_pool", "oid:0x5000000000002")
+
+	origTarget := Target2RedisDb
+	origMaps := countersBufferPoolNameByNamespace
+	Target2RedisDb = map[string]map[string]*redis.Client{
+		ns: {
+			"COUNTERS_DB": redis.NewClient(&redis.Options{Addr: mr.Addr()}),
+		},
+	}
+	countersBufferPoolNameByNamespace = nil
+	t.Setenv("UNIT_TEST", "1")
+
+	return mr, func() {
+		Target2RedisDb = origTarget
+		countersBufferPoolNameByNamespace = origMaps
+	}
+}
+
+func TestBufferPoolJSONKey(t *testing.T) {
+	if got := bufferPoolJSONKey("", "ingress_lossless_pool"); got != "ingress_lossless_pool" {
+		t.Errorf("bufferPoolJSONKey empty ns = %q", got)
+	}
+	if got := bufferPoolJSONKey("ns1", "ingress_lossless_pool"); got != "ingress_lossless_pool-ns1" {
+		t.Errorf("bufferPoolJSONKey with ns = %q", got)
+	}
+}
+
+func TestInitCountersBufferPoolNameMap(t *testing.T) {
+	sdcfg.Init()
+	_, restore := setupBufferPoolMaps(t)
+	defer restore()
+
+	if err := initCountersBufferPoolNameMap(); err != nil {
+		t.Fatalf("initCountersBufferPoolNameMap: %v", err)
+	}
+	ns, _ := sdcfg.GetDbDefaultNamespace()
+	pools, ok := countersBufferPoolNameByNamespace[ns]
+	if !ok {
+		t.Fatalf("namespace %q missing from buffer pool map", ns)
+	}
+	if pools["ingress_lossless_pool"] != "oid:0x5000000000001" {
+		t.Errorf("ingress_lossless_pool oid = %q", pools["ingress_lossless_pool"])
+	}
+}
+
+func TestV2rBufferPoolWatermarks_AllPools(t *testing.T) {
+	sdcfg.Init()
+	_, restore := setupBufferPoolMaps(t)
+	defer restore()
+
+	paths := []string{"COUNTERS_DB", "BUFFER_POOL_WATERMARKS"}
+	tblPaths, err := v2rBufferPoolWatermarks(paths)
+	if err != nil {
+		t.Fatalf("v2rBufferPoolWatermarks: %v", err)
+	}
+	if len(tblPaths) != 2 {
+		t.Fatalf("expected 2 table paths, got %d", len(tblPaths))
+	}
+	sort.Slice(tblPaths, func(i, j int) bool {
+		return tblPaths[i].jsonTableKey < tblPaths[j].jsonTableKey
+	})
+	if tblPaths[0].tableName != "COUNTERS" || tblPaths[0].tableKey != "oid:0x5000000000002" {
+		t.Errorf("unexpected first path: %+v", tblPaths[0])
+	}
+	if tblPaths[1].tableKey != "oid:0x5000000000001" {
+		t.Errorf("unexpected second path: %+v", tblPaths[1])
+	}
+}
+
+func TestV2rBufferPoolWatermarks_SinglePool(t *testing.T) {
+	sdcfg.Init()
+	_, restore := setupBufferPoolMaps(t)
+	defer restore()
+
+	paths := []string{"COUNTERS_DB", "BUFFER_POOL_WATERMARKS", "ingress_lossless_pool"}
+	tblPaths, err := v2rBufferPoolWatermarks(paths)
+	if err != nil {
+		t.Fatalf("v2rBufferPoolWatermarks: %v", err)
+	}
+	if len(tblPaths) != 1 {
+		t.Fatalf("expected 1 table path, got %d", len(tblPaths))
+	}
+	if tblPaths[0].jsonTableKey != "ingress_lossless_pool" {
+		t.Errorf("jsonTableKey = %q, want ingress_lossless_pool", tblPaths[0].jsonTableKey)
+	}
+}
+
+func TestV2rBufferPoolWatermarks_NotFound(t *testing.T) {
+	sdcfg.Init()
+	_, restore := setupBufferPoolMaps(t)
+	defer restore()
+
+	paths := []string{"COUNTERS_DB", "BUFFER_POOL_WATERMARKS", "missing_pool"}
+	_, err := v2rBufferPoolWatermarks(paths)
+	if err == nil {
+		t.Fatal("expected error for unknown pool")
+	}
+}
+
+func TestV2rBufferPoolWatermarks_EmptyMap(t *testing.T) {
+	sdcfg.Init()
+	mr := miniredis.RunT(t)
+	ns, _ := sdcfg.GetDbDefaultNamespace()
+	origTarget := Target2RedisDb
+	origMaps := countersBufferPoolNameByNamespace
+	Target2RedisDb = map[string]map[string]*redis.Client{
+		ns: {"COUNTERS_DB": redis.NewClient(&redis.Options{Addr: mr.Addr()})},
+	}
+	countersBufferPoolNameByNamespace = nil
+	t.Setenv("UNIT_TEST", "1")
+	defer func() {
+		Target2RedisDb = origTarget
+		countersBufferPoolNameByNamespace = origMaps
+	}()
+
+	paths := []string{"COUNTERS_DB", "BUFFER_POOL_WATERMARKS"}
+	_, err := v2rBufferPoolWatermarks(paths)
+	if err == nil {
+		t.Fatal("expected error when COUNTERS_BUFFER_POOL_NAME_MAP is empty")
+	}
+}

--- a/sonic_data_client/virtual_db_test.go
+++ b/sonic_data_client/virtual_db_test.go
@@ -1468,6 +1468,78 @@ func TestInitCountersBufferPoolNameMap(t *testing.T) {
 	}
 }
 
+func TestInitCountersPGNameMapSuccess(t *testing.T) {
+	sdcfg.Init()
+	origCounters := getCountersMapFn
+	initCountersPGNameMapOnce = sync.Once{}
+	getCountersMapFn = func(string) (map[string]string, error) {
+		return map[string]string{"Ethernet64:7": "oid:0x100"}, nil
+	}
+	defer func() { getCountersMapFn = origCounters }()
+
+	if err := initCountersPGNameMap(); err != nil {
+		t.Fatalf("initCountersPGNameMap: %v", err)
+	}
+	if countersPGNameMap["Ethernet64"]["7"] != "oid:0x100" {
+		t.Errorf("unexpected pg map: %#v", countersPGNameMap)
+	}
+}
+
+func TestInitCountersPGNameMapInvalidPgName(t *testing.T) {
+	sdcfg.Init()
+	origCounters := getCountersMapFn
+	initCountersPGNameMapOnce = sync.Once{}
+	getCountersMapFn = func(string) (map[string]string, error) {
+		return map[string]string{"invalid_pg_name": "oid:0x200"}, nil
+	}
+	defer func() { getCountersMapFn = origCounters }()
+
+	if err := initCountersPGNameMap(); err == nil {
+		t.Fatal("expected error for invalid pg name")
+	}
+}
+
+func TestInitCountersBufferPoolNameMapPingFailure(t *testing.T) {
+	sdcfg.Init()
+	ns, _ := sdcfg.GetDbDefaultNamespace()
+	origTarget := Target2RedisDb
+	origMaps := countersBufferPoolNameByNamespace
+	Target2RedisDb = map[string]map[string]*redis.Client{
+		ns: {"COUNTERS_DB": redis.NewClient(&redis.Options{Addr: "127.0.0.1:1"})},
+	}
+	countersBufferPoolNameByNamespace = nil
+	t.Setenv("UNIT_TEST", "1")
+	defer func() {
+		Target2RedisDb = origTarget
+		countersBufferPoolNameByNamespace = origMaps
+	}()
+
+	if err := initCountersBufferPoolNameMap(); err == nil {
+		t.Fatal("expected ping error")
+	}
+}
+
+func TestV2rBufferPoolWatermarks_InitFailure(t *testing.T) {
+	sdcfg.Init()
+	ns, _ := sdcfg.GetDbDefaultNamespace()
+	origTarget := Target2RedisDb
+	origMaps := countersBufferPoolNameByNamespace
+	Target2RedisDb = map[string]map[string]*redis.Client{
+		ns: {"COUNTERS_DB": redis.NewClient(&redis.Options{Addr: "127.0.0.1:1"})},
+	}
+	countersBufferPoolNameByNamespace = nil
+	t.Setenv("UNIT_TEST", "1")
+	defer func() {
+		Target2RedisDb = origTarget
+		countersBufferPoolNameByNamespace = origMaps
+	}()
+
+	paths := []string{"COUNTERS_DB", "BUFFER_POOL_WATERMARKS"}
+	if _, err := v2rBufferPoolWatermarks(paths); err == nil {
+		t.Fatal("expected initCountersBufferPoolNameMap error")
+	}
+}
+
 func TestV2rBufferPoolWatermarks_AllPools(t *testing.T) {
 	sdcfg.Init()
 	_, restore := setupBufferPoolMaps(t)

--- a/sonic_data_client/virtual_db_test.go
+++ b/sonic_data_client/virtual_db_test.go
@@ -1544,3 +1544,42 @@ func TestV2rBufferPoolWatermarks_EmptyMap(t *testing.T) {
 		t.Fatal("expected error when COUNTERS_BUFFER_POOL_NAME_MAP is empty")
 	}
 }
+
+func TestInitCountersBufferPoolNameMap_RefreshesOnChange(t *testing.T) {
+	sdcfg.Init()
+	mr, restore := setupBufferPoolMaps(t)
+	defer restore()
+
+	ns, _ := sdcfg.GetDbDefaultNamespace()
+	if err := initCountersBufferPoolNameMap(); err != nil {
+		t.Fatalf("initCountersBufferPoolNameMap: %v", err)
+	}
+	pools, ok := countersBufferPoolNameByNamespace[ns]
+	if !ok || pools["ingress_lossless_pool"] == "" {
+		t.Fatalf("expected initial pool map, got %#v", countersBufferPoolNameByNamespace)
+	}
+
+	mr.HSet("COUNTERS_BUFFER_POOL_NAME_MAP", "egress_lossy_pool", "oid:0x5000000000003")
+	if err := initCountersBufferPoolNameMap(); err != nil {
+		t.Fatalf("init after add: %v", err)
+	}
+	pools = countersBufferPoolNameByNamespace[ns]
+	if pools["egress_lossy_pool"] != "oid:0x5000000000003" {
+		t.Errorf("new pool not visible after refresh: %#v", pools)
+	}
+
+	mr.Del("COUNTERS_BUFFER_POOL_NAME_MAP", "ingress_lossless_pool")
+	if err := initCountersBufferPoolNameMap(); err != nil {
+		t.Fatalf("init after delete: %v", err)
+	}
+	pools = countersBufferPoolNameByNamespace[ns]
+	if _, ok := pools["ingress_lossless_pool"]; ok {
+		t.Errorf("deleted pool still present after refresh: %#v", pools)
+	}
+
+	paths := []string{"COUNTERS_DB", "BUFFER_POOL_WATERMARKS", "ingress_lossless_pool"}
+	_, err := v2rBufferPoolWatermarks(paths)
+	if err == nil {
+		t.Fatal("expected error resolving deleted pool name")
+	}
+}

--- a/sonic_data_client/virtual_db_test.go
+++ b/sonic_data_client/virtual_db_test.go
@@ -1568,7 +1568,7 @@ func TestInitCountersBufferPoolNameMap_RefreshesOnChange(t *testing.T) {
 		t.Errorf("new pool not visible after refresh: %#v", pools)
 	}
 
-	mr.Del("COUNTERS_BUFFER_POOL_NAME_MAP", "ingress_lossless_pool")
+	mr.HDel("COUNTERS_BUFFER_POOL_NAME_MAP", "ingress_lossless_pool")
 	if err := initCountersBufferPoolNameMap(); err != nil {
 		t.Fatalf("init after delete: %v", err)
 	}


### PR DESCRIPTION
## Summary
Fix bare-path Get/Subscribe for keyed COUNTERS_DB tables (notably `BUFFER_POOL_WATERMARKS`) and strip SONiC NULL placeholders from JSON.

## Before

**gNMI Get** on bare path `/COUNTERS_DB/BUFFER_POOL_WATERMARKS` returned empty or incomplete results (pools required an explicit wildcard).

**gNMI JSON output** for hashes carrying only a SONiC placeholder:
```json
{"NULL": "NULL"}
```

**Subscribe / ONCE mode** (`gnmic --mode once`) on keyed COUNTERS_DB tables could hang or miss updates because PSUBSCRIBE patterns did not match keyed rows like `BUFFER_POOL_WATERMARKS:<oid>`.

**gnmi.log** (when key enumeration failed):
```
listBareTableKeys failed for {dbName:COUNTERS_DB tableName:BUFFER_POOL_WATERMARKS ...}: ...
```

## After

**gNMI Get** on `/COUNTERS_DB/BUFFER_POOL_WATERMARKS` returns all buffer pools by name (via `COUNTERS_BUFFER_POOL_NAME_MAP` → `COUNTERS:<oid>`).

**gNMI JSON output** — NULL placeholder stripped:
```json
{}
```
or with real fields:
```json
{"ingress_lossless_pool": {"SAI_BUFFER_POOL_STAT_WATERMARK_BYTES": "1234"}}
```

**Subscribe** uses corrected keyspace patterns with `delimSkipped` for COUNTERS_DB non-`COUNTERS` tables; ONCE-mode subscriptions exit cleanly.

## Test plan
- [ ] `go test ./sonic_data_client/... -run TestMakeJSONRedisSkipsNull`
- [ ] gNMI Get on `/COUNTERS_DB/BUFFER_POOL_WATERMARKS` → all pools
- [ ] `gnmic --mode once` subscribe on buffer pool watermarks → exits cleanly
