### PR TITLE
ONCE Subscribe: close stream after initial sync response

### DIFF
--- a/gnmi_server/client_subscribe.go
+++ b/gnmi_server/client_subscribe.go
@@ -160,7 +160,7 @@ func (c *Client) Run(stream gnmipb.GNMI_SubscribeServer, config *Config) (err er
 	}
 
 	prefix := c.subscribe.GetPrefix()
-	origin := normalizeOrigin(prefix.GetOrigin())
+	origin := prefix.GetOrigin()
 	target := prefix.GetTarget()
 
 	paths, err := c.populateDbPathSubscrition(c.subscribe)

--- a/gnmi_server/client_subscribe.go
+++ b/gnmi_server/client_subscribe.go
@@ -160,7 +160,7 @@ func (c *Client) Run(stream gnmipb.GNMI_SubscribeServer, config *Config) (err er
 	}
 
 	prefix := c.subscribe.GetPrefix()
-	origin := prefix.GetOrigin()
+	origin := normalizeOrigin(prefix.GetOrigin())
 	target := prefix.GetTarget()
 
 	paths, err := c.populateDbPathSubscrition(c.subscribe)
@@ -254,7 +254,10 @@ func (c *Client) Run(stream gnmipb.GNMI_SubscribeServer, config *Config) (err er
 	c.Close()
 	// Wait until all child go routines exited
 	c.w.Wait()
-	return grpc.Errorf(codes.InvalidArgument, "%s", err)
+	if err != nil {
+		return grpc.Errorf(codes.InvalidArgument, "%s", err)
+	}
+	return nil
 }
 
 // Closing of client queue is triggered upon end of stream receive or stream error
@@ -361,5 +364,13 @@ func (c *Client) send(stream gnmipb.GNMI_SubscribeServer, dc sdc.Client) error {
 
 		dc.SentOne(val)
 		log.V(5).Infof("Client %s done sending, msg count %d, msg %v", c, c.sendMsg, resp)
+
+		// gNMI spec §3.5.1.5.1: after sending sync_response for a ONCE
+		// subscription the server MUST close the RPC.  Without this return
+		// the send loop blocks on the next queue.Get() forever because
+		// OnceRun has already exited and no further items will be enqueued.
+		if resp.GetSyncResponse() && c.subscribe.GetMode() == gnmipb.SubscriptionList_ONCE {
+			return nil
+		}
 	}
 }

--- a/gnmi_server/db_once_subscribe_test.go
+++ b/gnmi_server/db_once_subscribe_test.go
@@ -1,0 +1,214 @@
+package gnmi
+
+// Tests for gNMI ONCE subscription mode against raw DB targets (COUNTERS_DB,
+// STATE_DB, etc.) - paths served by DbClient rather than TranslClient.
+//
+// Per gNMI spec §3.5.1.5.2, ONCE samples each subscribed path once, emits
+// sync_response, and the server closes the RPC. For the openconfig gnmi/client
+// consumer the sync_response triggers client.ErrStopReading on the receive
+// side, which closes the stream and ends Subscribe() -- so these tests assert:
+//
+//   1. Connected + Update(s) + Sync are observed in that order.
+//   2. Subscribe() returns (stream is closed, RPC does not hang).
+//
+// Failure mode: if DbClient.OnceRun never enqueues sync_response, c.Subscribe
+// hangs and the test deadline kicks in producing a clear failure instead of
+// an indefinite wait.
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	"crypto/tls"
+
+	"github.com/openconfig/gnmi/client"
+	sdcfg "github.com/sonic-net/sonic-gnmi/sonic_db_config"
+)
+
+// onceTimeout is the upper bound on how long ONCE Subscribe() may block.
+// Normal completion is sub-second; the timeout exists only to surface a hang
+// (e.g., missing sync_response) quickly rather than stalling CI.
+const onceTimeout = 5 * time.Second
+
+// runOnce executes a ONCE Subscribe against the given server and returns the
+// ordered notifications. It fails the test if Subscribe does not return within
+// onceTimeout. The server address is read from s.Address() so tests bound to
+// an OS-assigned port (0) can still connect - avoiding collisions on fixed
+// ports like 8081 that are shared by other tests and can flake under CI load.
+func runOnce(t *testing.T, s *Server, q client.Query) []client.Notification {
+	t.Helper()
+
+	var (
+		mu    sync.Mutex
+		notis []client.Notification
+	)
+	q.Addrs = []string{s.Address()}
+	q.Type = client.Once
+	q.TLS = &tls.Config{InsecureSkipVerify: true}
+	q.NotificationHandler = func(n client.Notification) error {
+		mu.Lock()
+		// Normalise Update timestamps so test assertions are deterministic,
+		// matching the convention used by poll_mode_test.go.
+		if up, ok := n.(client.Update); ok {
+			up.TS = time.Unix(0, 200)
+			notis = append(notis, up)
+		} else {
+			notis = append(notis, n)
+		}
+		mu.Unlock()
+		return nil
+	}
+
+	c := client.New()
+	defer c.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), onceTimeout)
+	defer cancel()
+
+	if err := c.Subscribe(ctx, q); err != nil {
+		t.Fatalf("ONCE subscribe failed: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	out := make([]client.Notification, len(notis))
+	copy(out, notis)
+	return out
+}
+
+// TestOnceSubscribeCountersDB verifies ONCE mode against COUNTERS_DB for a
+// table that is pre-populated by prepareDb (COUNTERS_PORT_NAME_MAP lives in
+// COUNTERS_DB as a flat hash).
+func TestOnceSubscribeCountersDB(t *testing.T) {
+	s := createServer(t, 0)
+	go runServer(t, s)
+	defer s.ForceStop()
+
+	ns, _ := sdcfg.GetDbDefaultNamespace()
+	prepareDb(t, ns)
+
+	got := runOnce(t, s, client.Query{
+		Target:  "COUNTERS_DB",
+		Queries: []client.Path{{"COUNTERS_PORT_NAME_MAP"}},
+	})
+
+	// Expected sequence: Connected -> Update (the port name map) -> Sync.
+	if len(got) < 3 {
+		t.Fatalf("want >=3 notifications (Connected, Update, Sync); got %d: %+v", len(got), got)
+	}
+	if _, ok := got[0].(client.Connected); !ok {
+		t.Errorf("notification[0] = %T, want client.Connected", got[0])
+	}
+
+	var (
+		sawUpdate, sawSync bool
+		updatePath         []string
+	)
+	for _, n := range got[1:] {
+		switch v := n.(type) {
+		case client.Update:
+			sawUpdate = true
+			updatePath = v.Path
+		case client.Sync:
+			sawSync = true
+		}
+	}
+	if !sawUpdate {
+		t.Errorf("expected an Update for COUNTERS_PORT_NAME_MAP, got: %+v", got)
+	} else if len(updatePath) < 2 || updatePath[0] != "COUNTERS_DB" || updatePath[1] != "COUNTERS_PORT_NAME_MAP" {
+		t.Errorf("update path = %v, want prefix [COUNTERS_DB COUNTERS_PORT_NAME_MAP]", updatePath)
+	}
+	if !sawSync {
+		t.Errorf("expected Sync, got: %+v", got)
+	}
+}
+
+// TestOnceSubscribeStateDB verifies ONCE mode against STATE_DB using a key
+// written into NEIGH_STATE_TABLE (same table used by the POLL mode tests).
+func TestOnceSubscribeStateDB(t *testing.T) {
+	s := createServer(t, 0)
+	go runServer(t, s)
+	defer s.ForceStop()
+
+	ns, _ := sdcfg.GetDbDefaultNamespace()
+	// STATE_DB is redis logical DB 6 in the default sonic layout.
+	rclient := getRedisClientN(t, 6, ns)
+	defer rclient.Close()
+	rclient.FlushDB()
+
+	rclient.HSet("NEIGH_STATE_TABLE|10.0.0.57", "peerType", "e-BGP")
+	rclient.HSet("NEIGH_STATE_TABLE|10.0.0.57", "state", "Established")
+
+	var wantVal interface{}
+	if err := json.Unmarshal([]byte(`{"peerType":"e-BGP","state":"Established"}`), &wantVal); err != nil {
+		t.Fatalf("failed to build expected value: %v", err)
+	}
+
+	got := runOnce(t, s, client.Query{
+		Target:  "STATE_DB",
+		Queries: []client.Path{{"NEIGH_STATE_TABLE", "10.0.0.57"}},
+	})
+
+	wantPath := client.Path{"STATE_DB", "NEIGH_STATE_TABLE", "10.0.0.57"}
+	var (
+		sawSync bool
+		updates []client.Update
+	)
+	for _, n := range got {
+		switch v := n.(type) {
+		case client.Update:
+			updates = append(updates, v)
+		case client.Sync:
+			sawSync = true
+		}
+	}
+	if len(updates) != 1 {
+		t.Fatalf("want exactly 1 Update for STATE_DB key, got %d: %+v", len(updates), got)
+	}
+	if !reflect.DeepEqual(updates[0].Path, wantPath) {
+		t.Errorf("update path = %v, want %v", updates[0].Path, wantPath)
+	}
+	if !reflect.DeepEqual(updates[0].Val, wantVal) {
+		t.Errorf("update value = %v, want %v", updates[0].Val, wantVal)
+	}
+	if !sawSync {
+		t.Errorf("expected Sync after Update, got: %+v", got)
+	}
+}
+
+// TestOnceSubscribeStateDBMissingKey verifies ONCE mode with a missing key:
+// no Update is sent, Sync is still produced, and the RPC closes cleanly. This
+// matches PollRun's first-poll semantics for absent data (see
+// TestPollStateDBMissingKey in poll_mode_test.go).
+func TestOnceSubscribeStateDBMissingKey(t *testing.T) {
+	s := createServer(t, 0)
+	go runServer(t, s)
+	defer s.ForceStop()
+
+	ns, _ := sdcfg.GetDbDefaultNamespace()
+	rclient := getRedisClientN(t, 6, ns)
+	defer rclient.Close()
+	rclient.FlushDB()
+
+	got := runOnce(t, s, client.Query{
+		Target:  "STATE_DB",
+		Queries: []client.Path{{"NEIGH_STATE_TABLE", "10.0.0.57"}},
+	})
+
+	var sawSync bool
+	for _, n := range got {
+		if _, ok := n.(client.Update); ok {
+			t.Errorf("unexpected Update for missing STATE_DB key: %+v", n)
+		}
+		if _, ok := n.(client.Sync); ok {
+			sawSync = true
+		}
+	}
+	if !sawSync {
+		t.Errorf("expected Sync even when key is absent, got: %+v", got)
+	}
+}

--- a/gnmi_server/db_once_subscribe_test.go
+++ b/gnmi_server/db_once_subscribe_test.go
@@ -138,10 +138,10 @@ func TestOnceSubscribeStateDB(t *testing.T) {
 	// STATE_DB is redis logical DB 6 in the default sonic layout.
 	rclient := getRedisClientN(t, 6, ns)
 	defer rclient.Close()
-	rclient.FlushDB()
+	rclient.FlushDB(context.Background())
 
-	rclient.HSet("NEIGH_STATE_TABLE|10.0.0.57", "peerType", "e-BGP")
-	rclient.HSet("NEIGH_STATE_TABLE|10.0.0.57", "state", "Established")
+	rclient.HSet(context.Background(), "NEIGH_STATE_TABLE|10.0.0.57", "peerType", "e-BGP")
+	rclient.HSet(context.Background(), "NEIGH_STATE_TABLE|10.0.0.57", "state", "Established")
 
 	var wantVal interface{}
 	if err := json.Unmarshal([]byte(`{"peerType":"e-BGP","state":"Established"}`), &wantVal); err != nil {
@@ -192,7 +192,7 @@ func TestOnceSubscribeStateDBMissingKey(t *testing.T) {
 	ns, _ := sdcfg.GetDbDefaultNamespace()
 	rclient := getRedisClientN(t, 6, ns)
 	defer rclient.Close()
-	rclient.FlushDB()
+	rclient.FlushDB(context.Background())
 
 	got := runOnce(t, s, client.Query{
 		Target:  "STATE_DB",

--- a/gnmi_server/once_subscribe_test.go
+++ b/gnmi_server/once_subscribe_test.go
@@ -1,0 +1,271 @@
+package gnmi
+
+// Tests for gNMI ONCE subscription stream lifecycle.
+//
+// gNMI spec §3.5.1.5.1 requires that the server close the RPC immediately
+// after sending sync_response for a ONCE subscription.  The tests here
+// directly verify that contract by reading from the raw gRPC stream and
+// asserting that io.EOF arrives promptly after the sync_response — without
+// relying on a client-side timeout or test cleanup to cancel the context.
+
+import (
+	"context"
+	"io"
+	"net"
+	"strconv"
+	"testing"
+	"time"
+
+	gnmipb "github.com/openconfig/gnmi/proto/gnmi"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// onceStreamResult holds a single message received from a ONCE subscription stream.
+type onceStreamResult struct {
+	resp *gnmipb.SubscribeResponse
+	err  error
+}
+
+// serverPort extracts the numeric port from a Server whose address is returned
+// by s.Address() (e.g. "localhost:54321").
+func serverPort(t *testing.T, s *Server) int {
+	t.Helper()
+	_, portStr, err := net.SplitHostPort(s.Address())
+	if err != nil {
+		t.Fatalf("cannot parse server address %q: %v", s.Address(), err)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("cannot convert port %q to int: %v", portStr, err)
+	}
+	return port
+}
+
+// runOnceSubscribe opens a raw gRPC Subscribe stream, sends req, and fans all
+// received messages into the returned channel.  The channel is closed when the
+// stream ends (io.EOF or error).
+func runOnceSubscribe(t *testing.T, port int, req *gnmipb.SubscribeRequest) <-chan onceStreamResult {
+	t.Helper()
+	ch := make(chan onceStreamResult, 64)
+
+	conn := createClient(t, port)
+	gnmiClient := gnmipb.NewGNMIClient(conn)
+
+	stream, err := gnmiClient.Subscribe(context.Background())
+	if err != nil {
+		t.Fatalf("Subscribe() stream open failed: %v", err)
+	}
+	if err := stream.Send(req); err != nil {
+		t.Fatalf("Subscribe() Send failed: %v", err)
+	}
+
+	go func() {
+		defer close(ch)
+		defer conn.Close()
+		for {
+			resp, err := stream.Recv()
+			ch <- onceStreamResult{resp, err}
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	return ch
+}
+
+// collectOnce drains ch until io.EOF or a non-nil error, with an overall
+// deadline.  Returns (gotSync, closeErr):
+//   - gotSync  – true if a sync_response was received before the stream ended
+//   - closeErr – nil if the stream ended with io.EOF (status OK),
+//     or the gRPC status error if the server returned a non-OK status,
+//     or context.DeadlineExceeded if the deadline expired before the stream closed.
+func collectOnce(ch <-chan onceStreamResult, timeout time.Duration) (gotSync bool, closeErr error) {
+	deadline := time.After(timeout)
+	for {
+		select {
+		case r, ok := <-ch:
+			if !ok {
+				// channel closed without an explicit error message
+				return gotSync, nil
+			}
+			if r.err == io.EOF {
+				return gotSync, nil // clean close, status OK
+			}
+			if r.err != nil {
+				return gotSync, r.err // server returned a non-OK status
+			}
+			if r.resp.GetSyncResponse() {
+				gotSync = true
+			}
+		case <-deadline:
+			return gotSync, context.DeadlineExceeded
+		}
+	}
+}
+
+// onceReq builds a minimal ONCE SubscribeRequest for the given path.
+func onceReq(path string) *gnmipb.SubscribeRequest {
+	return &gnmipb.SubscribeRequest{
+		Request: &gnmipb.SubscribeRequest_Subscribe{
+			Subscribe: &gnmipb.SubscriptionList{
+				Mode:   gnmipb.SubscriptionList_ONCE,
+				Prefix: strToPath("openconfig:/"),
+				// Empty ACL set — server will send sync_response with no updates.
+				Subscription: []*gnmipb.Subscription{
+					{Path: strToPath(path)},
+				},
+			},
+		},
+	}
+}
+
+// TestOnceSubscribe_StreamClosedAfterSync verifies that the server closes the
+// gRPC stream promptly after sending sync_response for a ONCE subscription.
+//
+// Before the fix the send() loop in client_subscribe.go would block forever on
+// queue.Get() once OnceRun() exited — leaving the stream open indefinitely.
+// This test would time out in that scenario and fail within ~5 seconds instead
+// of waiting for an external timeout.
+func TestOnceSubscribe_StreamClosedAfterSync(t *testing.T) {
+	s := createServer(t, 0)
+	go runServer(t, s)
+	defer s.s.Stop()
+
+	ch := runOnceSubscribe(t, serverPort(t, s), onceReq("/openconfig-acl:acl/acl-sets"))
+
+	// Allow 5 seconds total.  The server should close the stream well within 1s.
+	gotSync, err := collectOnce(ch, 5*time.Second)
+
+	switch {
+	case err == context.DeadlineExceeded && !gotSync:
+		t.Fatal("Timed out waiting for sync_response; server may not have sent it")
+	case err == context.DeadlineExceeded:
+		t.Fatal("sync_response received but stream was not closed within 5s; " +
+			"server likely blocked in send() loop after OnceRun() exited")
+	case err != nil:
+		st, _ := status.FromError(err)
+		t.Fatalf("Stream closed with unexpected status: code=%v msg=%v", st.Code(), st.Message())
+	case !gotSync:
+		t.Fatal("Stream closed without sending sync_response")
+	}
+	// err == nil and gotSync == true → PASS
+}
+
+// TestOnceSubscribe_StatusOK verifies that a successful ONCE subscription
+// causes the server to close the RPC with status OK (not InvalidArgument).
+//
+// Before the fix, Run() always returned grpc.Errorf(codes.InvalidArgument, ...)
+// unconditionally — even when send() returned nil on a clean ONCE completion.
+// The client would see an InvalidArgument status instead of a clean close.
+func TestOnceSubscribe_StatusOK(t *testing.T) {
+	s := createServer(t, 0)
+	go runServer(t, s)
+	defer s.s.Stop()
+
+	ch := runOnceSubscribe(t, serverPort(t, s), onceReq("/openconfig-acl:acl/acl-sets"))
+	_, closeErr := collectOnce(ch, 5*time.Second)
+
+	if closeErr == context.DeadlineExceeded {
+		t.Fatal("Stream did not close within 5s")
+	}
+	if closeErr != nil {
+		st, _ := status.FromError(closeErr)
+		if st.Code() == codes.InvalidArgument {
+			t.Fatalf("Server returned InvalidArgument instead of closing cleanly; "+
+				"Run() likely still unconditionally wrapping nil err: %v", closeErr)
+		}
+		t.Fatalf("Stream closed with unexpected error: %v", closeErr)
+	}
+}
+
+// setOnServer performs a gNMI Set against the given server port.
+// It is a port-aware alternative to the package-level doSet() which hardcodes
+// port 8081 and is only safe to call when that specific server is running.
+func setOnServer(t *testing.T, port int, data ...interface{}) {
+	t.Helper()
+	req := &gnmipb.SetRequest{}
+	for _, v := range data {
+		switch v := v.(type) {
+		case *gnmipb.Path:
+			req.Delete = append(req.Delete, v)
+		case *gnmipb.Update:
+			req.Update = append(req.Update, v)
+		default:
+			t.Fatalf("Unsupported set value: %T %v", v, v)
+		}
+	}
+	client := gnmipb.NewGNMIClient(createClient(t, port))
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if _, err := client.Set(ctx, req); err != nil {
+		t.Fatalf("Set failed: %v", err)
+	}
+}
+
+// TestOnceSubscribe_DataDeliveredBeforeClose verifies that when data exists all
+// update notifications are delivered to the client before the stream is closed.
+//
+// This guards against a regression where send() might exit prematurely (e.g.,
+// on the first sync_response even if more data is enqueued after it).
+func TestOnceSubscribe_DataDeliveredBeforeClose(t *testing.T) {
+	s := createServer(t, 0)
+	go runServer(t, s)
+	defer s.s.Stop()
+
+	prepareDbTranslib(t)
+
+	port := serverPort(t, s)
+	aclPath := "/openconfig-acl:acl/acl-sets"
+	acl1Create := newPbUpdate("/openconfig-acl:acl/acl-sets/acl-set",
+		`{"acl-set": [{"name": "ONCE_TEST", "type": "ACL_IPV4",
+		  "config": {"name": "ONCE_TEST", "type": "ACL_IPV4"}}]}`)
+	defer setOnServer(t, port, strToPath(aclPath))
+	setOnServer(t, port, acl1Create)
+
+	req := &gnmipb.SubscribeRequest{
+		Request: &gnmipb.SubscribeRequest_Subscribe{
+			Subscribe: &gnmipb.SubscriptionList{
+				Mode:   gnmipb.SubscriptionList_ONCE,
+				Prefix: strToPath("openconfig:/"),
+				Subscription: []*gnmipb.Subscription{
+					{Path: strToPath(aclPath + "/acl-set")},
+				},
+			},
+		},
+	}
+
+	ch := runOnceSubscribe(t, port, req)
+
+	var updates int
+	gotSync := false
+	deadline := time.After(5 * time.Second)
+
+loop:
+	for {
+		select {
+		case r, ok := <-ch:
+			if !ok || r.err == io.EOF {
+				break loop
+			}
+			if r.err != nil {
+				t.Fatalf("Recv error: %v", r.err)
+			}
+			if r.resp.GetSyncResponse() {
+				gotSync = true
+			} else if r.resp.GetUpdate() != nil {
+				updates++
+			}
+		case <-deadline:
+			t.Fatal("Stream did not close within 5s")
+		}
+	}
+
+	if !gotSync {
+		t.Error("sync_response not received")
+	}
+	if updates == 0 {
+		t.Error("No update notifications received; expected ACL data before sync_response")
+	}
+}

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -134,6 +134,16 @@ func createClient(t *testing.T, port int) *grpc.ClientConn {
 
 func createServer(t *testing.T, port int64) *Server {
 	t.Helper()
+	if port == 0 {
+		// NewServer requires Port > 0; reserve an OS-assigned port for tests that
+		// want ephemeral binding to avoid fixed-port collisions under CI load.
+		lis, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("failed to reserve ephemeral port: %v", err)
+		}
+		port = int64(lis.Addr().(*net.TCPAddr).Port)
+		lis.Close()
+	}
 	certificate, err := testcert.NewCert()
 	if err != nil {
 		t.Fatalf("could not load server key pair: %s", err)
@@ -146,6 +156,7 @@ func createServer(t *testing.T, port int64) *Server {
 	tlsOpts := []grpc.ServerOption{grpc.Creds(credentials.NewTLS(tlsCfg))}
 	cfg := &Config{
 		Port:                port,
+		BindAddress:         "127.0.0.1",
 		EnableTranslibWrite: true,
 		EnableNativeWrite:   true,
 		Threshold:           100,
@@ -153,7 +164,7 @@ func createServer(t *testing.T, port int64) *Server {
 	}
 	s, err := NewServer(cfg, tlsOpts, nil)
 	if err != nil {
-		t.Errorf("Failed to create gNMI server: %v", err)
+		t.Fatalf("Failed to create gNMI server: %v", err)
 	}
 	return s
 }


### PR DESCRIPTION
## Summary
- Close the Subscribe RPC after sending `sync_response` for ONCE mode (gNMI §3.5.1.5.1)
- Fix successful ONCE completion returning an error when `err` is nil
- Add DB and server ONCE subscribe regression tests; fix redis v9 context and ephemeral test server port

Split from #729 per review feedback. Does not include dialout wildcard or `normalizeOrigin`.

## Test plan
- [ ] `/azp run`
- [ ] `go test ./gnmi_server/... -run OnceSubscribe -count=1`