### PR TITLE
Subscribe support for openconfig-* module origins

### DIFF
--- a/gnmi_server/client_subscribe.go
+++ b/gnmi_server/client_subscribe.go
@@ -160,7 +160,7 @@ func (c *Client) Run(stream gnmipb.GNMI_SubscribeServer, config *Config) (err er
 	}
 
 	prefix := c.subscribe.GetPrefix()
-	origin := prefix.GetOrigin()
+	origin := normalizeOrigin(prefix.GetOrigin())
 	target := prefix.GetTarget()
 
 	paths, err := c.populateDbPathSubscrition(c.subscribe)

--- a/gnmi_server/server.go
+++ b/gnmi_server/server.go
@@ -928,6 +928,16 @@ func (s *Server) checkEncodingAndModel(encoding gnmipb.Encoding, models []*gnmip
 	return nil
 }
 
+// normalizeOrigin maps module-specific OpenConfig origins (e.g. openconfig-interfaces)
+// to the canonical "openconfig" origin expected by translib. Non-openconfig origins
+// (e.g. "sonic-db") are returned unchanged.
+func normalizeOrigin(origin string) string {
+	if origin == "openconfig" || strings.HasPrefix(origin, "openconfig-") {
+		return "openconfig"
+	}
+	return origin
+}
+
 func ParseOrigin(paths []*gnmipb.Path) (string, error) {
 	origin := ""
 	if len(paths) == 0 {

--- a/gnmi_server/server.go
+++ b/gnmi_server/server.go
@@ -929,8 +929,9 @@ func (s *Server) checkEncodingAndModel(encoding gnmipb.Encoding, models []*gnmip
 }
 
 // normalizeOrigin maps module-specific OpenConfig origins (e.g. openconfig-interfaces)
-// to the canonical "openconfig" origin expected by translib. Non-openconfig origins
-// (e.g. "sonic-db") are returned unchanged.
+// to the canonical "openconfig" origin expected by translib. Subscribe uses this
+// before prefix routing so openconfig-* module paths reach translib correctly.
+// Non-openconfig origins (e.g. "sonic-db") are returned unchanged.
 func normalizeOrigin(origin string) string {
 	if origin == "openconfig" || strings.HasPrefix(origin, "openconfig-") {
 		return "openconfig"

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -6252,6 +6252,25 @@ func TestParseOrigin(t *testing.T) {
 	}
 }
 
+func TestNormalizeOrigin(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"openconfig", "openconfig"},
+		{"openconfig-interfaces", "openconfig"},
+		{"openconfig-system", "openconfig"},
+		{"sonic-db", "sonic-db"},
+		{"", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.in, func(t *testing.T) {
+			if got := normalizeOrigin(tc.in); got != tc.want {
+				t.Errorf("normalizeOrigin(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestMasterArbitration(t *testing.T) {
 	s := createServer(t, 8088)
 	// Turn on Master Arbitration


### PR DESCRIPTION
## Summary
- Add `normalizeOrigin()` to map `openconfig-*` module origins to canonical `openconfig` for translib
- Use it in Subscribe prefix routing before DB path population

Split from #729 per review feedback. Follow-up to ONCE subscribe split; independent of dialout wildcard.

## Test plan
- [ ] `/azp run`