### PR TITLE
Component Test For Components Model - Transceivers

### DIFF
--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -7583,3 +7583,235 @@ func TestServeUDSErrorDoesNotStopTCP(t *testing.T) {
 		t.Error("Serve() did not return after Stop()")
 	}
 }
+
+func getFreePort(t *testing.T) int64 {
+	t.Helper()
+	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("failed to resolve tcp addr: %v", err)
+	}
+	l, err := net.ListenTCP("tcp", addr)
+	if err != nil {
+		t.Fatalf("failed to listen on free port: %v", err)
+	}
+	defer l.Close()
+	return int64(l.Addr().(*net.TCPAddr).Port)
+}
+
+func TestGnmiGetTranslibPfmCompXcvr(t *testing.T) {
+	// 1. Define all structures locally inside the test function
+	type ComponentState struct {
+		Empty           bool   `json:"empty"`
+		FirmwareVersion string `json:"firmware-version"`
+		HardwareVersion string `json:"hardware-version"`
+		MfgDate         string `json:"mfg-date"`
+		MfgName         string `json:"mfg-name"`
+		Name            string `json:"name"`
+		OperStatus      string `json:"oper-status"`
+		PartNo          string `json:"part-no"`
+		Removable       bool   `json:"removable"`
+		SerialNo        string `json:"serial-no"`
+		Temperature     struct {
+			Instant string `json:"instant"`
+		} `json:"temperature"`
+		Type string `json:"type"`
+	}
+
+	type PhysicalChannel struct {
+		Index  int `json:"index"`
+		Config struct {
+			Index int `json:"index"`
+		} `json:"config"`
+		State struct {
+			Index      int `json:"index"`
+			InputPower struct {
+				Instant string `json:"instant"`
+			} `json:"input-power"`
+			LaserBiasCurrent struct {
+				Instant string `json:"instant"`
+			} `json:"laser-bias-current"`
+			TxLaser bool `json:"tx-laser"`
+		} `json:"state"`
+	}
+
+	type ComponentResp struct {
+		Component []struct {
+			Name   string `json:"name"`
+			Config struct {
+				Name string `json:"name"`
+			} `json:"config"`
+			State       ComponentState `json:"state"`
+			Transceiver struct {
+				PhysicalChannels struct {
+					Channel []PhysicalChannel `json:"channel"`
+				} `json:"physical-channels"`
+			} `json:"openconfig-platform-transceiver:transceiver"`
+		} `json:"openconfig-platform:component"`
+	}
+
+	type StateResp struct {
+		State ComponentState `json:"openconfig-platform:state"`
+	}
+
+	type TempResp struct {
+		Instant string `json:"openconfig-platform:instant"`
+	}
+
+	type PresenceResp struct {
+		Empty bool `json:"openconfig-platform:empty"`
+	}
+
+	// Server/DB setup
+	freePort := getFreePort(t)
+	s := createServer(t, freePort)
+	go runServer(t, s)
+	defer s.Stop()
+	prepareDbTranslib(t)
+	ctx := context.Background()
+	ns, _ := sdcfg.GetDbDefaultNamespace()
+
+	stateDbId, _ := sdcfg.GetDbId("STATE_DB", ns)
+	stateClient := getRedisClientN(t, stateDbId, ns)
+	defer stateClient.Close()
+	if err := stateClient.HSet(ctx, "TRANSCEIVER_INFO|Ethernet0", map[string]interface{}{"name": "Ethernet0"}).Err(); err != nil {
+		t.Fatalf("Failed to HSet TRANSCEIVER_INFO: %v", err)
+	}
+
+	if err := stateClient.HSet(ctx, "TRANSCEIVER_STATUS|Ethernet0", map[string]interface{}{"name": "Ethernet0", "status": true}).Err(); err != nil {
+		t.Fatalf("Failed to HSet TRANSCEIVER_STATUS: %v", err)
+	}
+
+	if err := stateClient.HSet(ctx, "TRANSCEIVER_DOM_SENSOR|Ethernet0", map[string]interface{}{"name": "Ethernet0", "temperature": "101"}).Err(); err != nil {
+		t.Fatalf("Failed to HSet TRANSCEIVER_DOM_SENSOR: %v", err)
+	}
+
+	t.Cleanup(func() {
+		cleanupCtx := context.Background()
+		stateClient.Del(cleanupCtx, "TRANSCEIVER_INFO|Ethernet0")
+		stateClient.Del(cleanupCtx, "TRANSCEIVER_STATUS|Ethernet0")
+		stateClient.Del(cleanupCtx, "TRANSCEIVER_DOM_SENSOR|Ethernet0")
+	})
+
+	targetAddr := fmt.Sprintf("127.0.0.1:%d", s.config.Port)
+	tlsConfig := &tls.Config{InsecureSkipVerify: true}
+	opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
+	conn, err := grpc.Dial(targetAddr, opts...)
+	if err != nil {
+		t.Fatalf("Dialing to %q failed: %v", targetAddr, err)
+	}
+	defer conn.Close()
+	gClient := pb.NewGNMIClient(conn)
+
+	// 2. Prepare Data to match your log output
+	commonState := ComponentState{
+		Empty:           false,
+		FirmwareVersion: "D",
+		HardwareVersion: "D",
+		MfgDate:         "2011-12-13 ",
+		MfgName:         "Amphenol",
+		Name:            "Ethernet0",
+		OperStatus:      "openconfig-platform-types:ACTIVE",
+		PartNo:          "599690001",
+		Removable:       true,
+		SerialNo:        "APF11490011J7E",
+		Type:            "openconfig-platform-types:TRANSCEIVER",
+	}
+	commonState.Temperature.Instant = "101"
+
+	channels := make([]PhysicalChannel, 4)
+	for i := 0; i < 4; i++ {
+		channels[i].Index, channels[i].Config.Index, channels[i].State.Index = i, i, i
+		channels[i].State.InputPower.Instant = "-Inf"
+		channels[i].State.LaserBiasCurrent.Instant = "0"
+		channels[i].State.TxLaser = false
+	}
+
+	// Initialize the 4 specific response objects
+	var compVal ComponentResp
+	compVal.Component = append(compVal.Component, struct {
+		Name   string `json:"name"`
+		Config struct {
+			Name string `json:"name"`
+		} `json:"config"`
+		State       ComponentState `json:"state"`
+		Transceiver struct {
+			PhysicalChannels struct {
+				Channel []PhysicalChannel `json:"channel"`
+			} `json:"physical-channels"`
+		} `json:"openconfig-platform-transceiver:transceiver"`
+	}{
+		Name: "Ethernet0",
+		Config: struct {
+			Name string `json:"name"`
+		}{Name: "Ethernet0"},
+		State: commonState,
+		Transceiver: struct {
+			PhysicalChannels struct {
+				Channel []PhysicalChannel `json:"channel"`
+			} `json:"physical-channels"`
+		}{PhysicalChannels: struct {
+			Channel []PhysicalChannel `json:"channel"`
+		}{Channel: channels}},
+	})
+
+	stateVal := StateResp{State: commonState}
+	tempVal := TempResp{Instant: "101"}
+	presenceVal := PresenceResp{Empty: false}
+
+	// Helper to marshal locally defined structs to []byte for runTestGet
+	marshal := func(v interface{}) []byte {
+		b, _ := json.Marshal(v)
+		return b
+	}
+
+	tds := []struct {
+		desc        string
+		pathTarget  string
+		textPbPath  string
+		wantRetCode codes.Code
+		wantRespVal interface{}
+		valTest     bool
+	}{
+		{
+			desc:        "Get OC Platform Comp Xcvr",
+			pathTarget:  "OC_YANG",
+			textPbPath:  `elem: <name: "openconfig-platform:components" > elem: <name: "component" key:<key:"name" value:"Ethernet0" > >`,
+			wantRetCode: codes.OK,
+			wantRespVal: marshal(compVal),
+			valTest:     true,
+		},
+		{
+			desc:        "Get OC Platform Comp Xcvr State",
+			pathTarget:  "OC_YANG",
+			textPbPath:  `elem: <name: "openconfig-platform:components" > elem: <name: "component" key:<key:"name" value:"Ethernet0" > > elem: <name: "state" >`,
+			wantRetCode: codes.OK,
+			wantRespVal: marshal(stateVal),
+			valTest:     true,
+		},
+		{
+			desc:        "Get OC Platform Comp Xcvr Temperature",
+			pathTarget:  "OC_YANG",
+			textPbPath:  `elem: <name: "openconfig-platform:components" > elem: <name: "component" key:<key:"name" value:"Ethernet0" > > elem: <name: "state" > elem: <name: "temperature" > elem: <name: "instant" >`,
+			wantRetCode: codes.OK,
+			wantRespVal: marshal(tempVal),
+			valTest:     true,
+		},
+		{
+			desc:        "Get OC Platform Comp Xcvr Presence",
+			pathTarget:  "OC_YANG",
+			textPbPath:  `elem: <name: "openconfig-platform:components" > elem: <name: "component" key:<key:"name" value:"Ethernet0" > > elem: <name: "state" > elem: <name: "empty" >`,
+			wantRetCode: codes.OK,
+			wantRespVal: marshal(presenceVal),
+			valTest:     true,
+		},
+	}
+
+	for _, td := range tds {
+		t.Run(td.desc, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			// Your existing runTestGet is called here
+			runTestGet(t, ctx, gClient, td.pathTarget, td.textPbPath, td.wantRetCode, td.wantRespVal, td.valTest)
+		})
+	}
+}

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -7583,3 +7583,164 @@ func TestServeUDSErrorDoesNotStopTCP(t *testing.T) {
 		t.Error("Serve() did not return after Stop()")
 	}
 }
+
+func TestGnmiGetTranslibPfmCompXcvr(t *testing.T) {
+
+	//t.Log("Start server")
+	s := createServer(t, 8081)
+	go runServer(t, s)
+
+	prepareDbTranslib(t)
+	ctx := context.Background()
+	ns, _ := sdcfg.GetDbDefaultNamespace()
+	configClient := getRedisClientN(t, 4, ns) // Force target DB 0
+	defer configClient.Close()
+
+	listFields := map[string]interface{}{
+		"name": "Ethernet0",
+	}
+	listStatusFields := map[string]interface{}{
+		"name":   "Ethernet0",
+		"status": true,
+	}
+
+	// Explicitly write both delimiter schemas into DB 0
+	configClient.HSet(ctx, "TRANSCEIVER_CFG|Ethernet0", listFields)
+	configClient.HSet(ctx, "TRANSCEIVER_INFO|Ethernet0", listFields)
+	configClient.HSet(ctx, "TRANSCEIVER_STATUS|Ethernet0", listStatusFields)
+	configClient.HSet(ctx, "TRANSCEIVER_DOM_SENSOR|Ethernet0", listFields)
+
+	stateClient := getRedisClientN(t, 6, ns) // Force target DB 0
+	defer stateClient.Close()
+
+	// Explicitly write both delimiter schemas into DB 0
+	stateClient.HSet(ctx, "TRANSCEIVER_INFO|Ethernet0", listFields)
+	stateClient.HSet(ctx, "TRANSCEIVER_INFO|Ethernet0", listFields)
+	stateClient.HSet(ctx, "TRANSCEIVER_STATUS|Ethernet0", listStatusFields)
+	stateClient.HSet(ctx, "TRANSCEIVER_DOM_SENSOR|Ethernet0", listFields)
+
+	//t.Log("Start gNMI client")
+	tlsConfig := &tls.Config{InsecureSkipVerify: true}
+	opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
+
+	targetAddr := "127.0.0.1:8081"
+	conn, err := grpc.Dial(targetAddr, opts...)
+	if err != nil {
+		t.Fatalf("Dialing to %q failed: %v", targetAddr, err)
+	}
+	defer conn.Close()
+
+	gClient := pb.NewGNMIClient(conn)
+
+	var emptyRespVal interface{}
+	tds := []struct {
+		desc        string
+		pathTarget  string
+		textPbPath  string
+		timeout     time.Duration
+		wantRetCode codes.Code
+		wantRespVal interface{}
+		valTest     bool
+	}{
+		{
+			desc:       "Get OC Platform Comp Xcvr",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+                        elem: <name: "openconfig-platform:components" > elem: <name: "component" key:<key:"name" value:"Ethernet0" > >
+                `,
+			wantRetCode: codes.OK,
+			wantRespVal: emptyRespVal,
+			valTest:     false,
+		},
+	}
+	for _, td := range tds {
+		t.Run(td.desc, func(t *testing.T) {
+			if td.timeout == 0 {
+				td.timeout = 10 * time.Second
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), td.timeout)
+			defer cancel()
+
+			runTestGet(t, ctx, gClient, td.pathTarget, td.textPbPath, td.wantRetCode, td.wantRespVal, td.valTest)
+		})
+	}
+	s.Stop()
+}
+
+func TestGnmiSetCompTxvr(t *testing.T) {
+	s := createServer(t, 8081)
+	go runServer(t, s)
+
+	prepareDbTranslib(t)
+
+	ctx := context.Background()
+	ns, _ := sdcfg.GetDbDefaultNamespace()
+	configClient := getRedisClientN(t, 4, ns) // Force target DB 0
+	defer configClient.Close()
+
+	listFields := map[string]interface{}{
+		"name": "Ethernet0",
+	}
+	listStatusFields := map[string]interface{}{
+		"name":   "Ethernet0",
+		"status": true,
+	}
+
+	// Explicitly write both delimiter schemas into DB 0
+	configClient.HSet(ctx, "TRANSCEIVER_CFG|Ethernet0", listFields)
+	configClient.HSet(ctx, "TRANSCEIVER_INFO|Ethernet0", listFields)
+	configClient.HSet(ctx, "TRANSCEIVER_STATUS|Ethernet0", listStatusFields)
+	configClient.HSet(ctx, "TRANSCEIVER_DOM_SENSOR|Ethernet0", listFields)
+
+	stateClient := getRedisClientN(t, 6, ns) // Force target DB 0
+	defer stateClient.Close()
+
+	// Explicitly write both delimiter schemas into DB 0
+	stateClient.HSet(ctx, "TRANSCEIVER_INFO|Ethernet0", listFields)
+	stateClient.HSet(ctx, "TRANSCEIVER_INFO|Ethernet0", listFields)
+	stateClient.HSet(ctx, "TRANSCEIVER_STATUS|Ethernet0", listStatusFields)
+	stateClient.HSet(ctx, "TRANSCEIVER_DOM_SENSOR|Ethernet0", listFields)
+
+	//t.Log("Start gNMI client")
+	tlsConfig := &tls.Config{InsecureSkipVerify: true}
+	opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
+
+	targetAddr := fmt.Sprintf("127.0.0.1:%d", s.config.Port)
+	conn, err := grpc.Dial(targetAddr, opts...)
+	if err != nil {
+		t.Fatalf("Dialing to %q failed: %v", targetAddr, err)
+	}
+	defer conn.Close()
+
+	gClient := pb.NewGNMIClient(conn)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	tds := []struct {
+		desc          string
+		pathTarget    string
+		textPbPath    string
+		wantRetCode   codes.Code
+		wantRespVal   interface{}
+		attributeData string
+		operation     op_t
+		valTest       bool
+	}{
+		{
+			desc:          "Plfm xvr delete",
+			pathTarget:    "OC_YANG",
+			textPbPath:    pathToPb("openconfig-platform:components/component[name=Ethernet0]/"),
+			attributeData: "",
+			wantRetCode:   codes.Unknown,
+			operation:     Delete,
+			valTest:       false,
+		},
+	}
+
+	for _, td := range tds {
+		t.Run(td.desc, func(t *testing.T) {
+			runTestSet(t, ctx, gClient, td.pathTarget, td.textPbPath, td.wantRetCode, td.wantRespVal, td.attributeData, td.operation)
+		})
+	}
+	s.Stop()
+}


### PR DESCRIPTION
This PR is created to add component test case for OpenConfig platform components root model transceivers

Note:
Dependency on below sonic-mgmt-common PRs.

Base PR - Support for Components Model Root - https://github.com/sonic-net/sonic-mgmt-common/pull/224
Incremental PR -  Support for Components Model - Transceiver - https://github.com/sonic-net/sonic-mgmt-common/pull/226

**Test Output**
=== RUN   TestGnmiGetTranslibPfmCompXcvr
=== RUN   TestGnmiGetTranslibPfmCompXcvr/Get_OC_Platform_Comp_Xcvr
    server_test.go:3367: [TestGnmiGetTranslibPfmCompXcvr/Get_OC_Platform_Comp_Xcvr] gotVal:
        {
          "openconfig-platform:component": [
            {
              "config": {
                "name": "Ethernet0"
              },
              "name": "Ethernet0",
              "openconfig-platform-transceiver:transceiver": {
                "physical-channels": {
                  "channel": [
                    {
                      "config": {
                        "index": 0
                      },
                      "index": 0,
                      "state": {
                        "index": 0,
                        "input-power": {
                          "instant": "-Inf"
                        },
                        "laser-bias-current": {
                          "instant": "0"
                        },
                        "tx-laser": false
                      }
                    },
                    {
                      "config": {
                        "index": 1
                      },
                      "index": 1,
                      "state": {
                        "index": 1,
                        "input-power": {
                          "instant": "-Inf"
                        },
                        "laser-bias-current": {
                          "instant": "0"
                        },
                        "tx-laser": false
                      }
                    },
                    {
                      "config": {
                        "index": 2
                      },
                      "index": 2,
                      "state": {
                        "index": 2,
                        "input-power": {
                          "instant": "-Inf"
                        },
                        "laser-bias-current": {
                          "instant": "0"
                        },
                        "tx-laser": false
                      }
                    },
                    {
                      "config": {
                        "index": 3
                      },
                      "index": 3,
                      "state": {
                        "index": 3,
                        "input-power": {
                          "instant": "-Inf"
                        },
                        "laser-bias-current": {
                          "instant": "0"
                        },
                        "tx-laser": false
                      }
                    }
                  ]
                }
              },
              "state": {
                "empty": false,
                "firmware-version": "D",
                "hardware-version": "D",
                "mfg-date": "2011-12-13 ",
                "mfg-name": "Amphenol",
                "name": "Ethernet0",
                "oper-status": "openconfig-platform-types:ACTIVE",
                "part-no": "599690001",
                "removable": true,
                "serial-no": "APF11490011J7E",
                "temperature": {
                  "instant": "101"
                },
                "type": "openconfig-platform-types:TRANSCEIVER"
              }
            }
          ]
        }
=== RUN   TestGnmiGetTranslibPfmCompXcvr/Get_OC_Platform_Comp_Xcvr_State
    server_test.go:3367: [TestGnmiGetTranslibPfmCompXcvr/Get_OC_Platform_Comp_Xcvr_State] gotVal:
        {
          "openconfig-platform:state": {
            "empty": false,
            "firmware-version": "D",
            "hardware-version": "D",
            "mfg-date": "2011-12-13 ",
            "mfg-name": "Amphenol",
            "name": "Ethernet0",
            "oper-status": "openconfig-platform-types:ACTIVE",
            "part-no": "599690001",
            "removable": true,
            "serial-no": "APF11490011J7E",
            "temperature": {
              "instant": "101"
            },
            "type": "openconfig-platform-types:TRANSCEIVER"
          }
        }
=== RUN   TestGnmiGetTranslibPfmCompXcvr/Get_OC_Platform_Comp_Xcvr_Temperature
    server_test.go:3367: [TestGnmiGetTranslibPfmCompXcvr/Get_OC_Platform_Comp_Xcvr_Temperature] gotVal:
        {
          "openconfig-platform:instant": "101"
        }
=== RUN   TestGnmiGetTranslibPfmCompXcvr/Get_OC_Platform_Comp_Xcvr_Presence
    server_test.go:3367: [TestGnmiGetTranslibPfmCompXcvr/Get_OC_Platform_Comp_Xcvr_Presence] gotVal:
        {
          "openconfig-platform:empty": false
        }
--- PASS: TestGnmiGetTranslibPfmCompXcvr (1.25s)
    --- PASS: TestGnmiGetTranslibPfmCompXcvr/Get_OC_Platform_Comp_Xcvr (0.04s)
    --- PASS: TestGnmiGetTranslibPfmCompXcvr/Get_OC_Platform_Comp_Xcvr_State (0.02s)
    --- PASS: TestGnmiGetTranslibPfmCompXcvr/Get_OC_Platform_Comp_Xcvr_Temperature (0.02s)
    --- PASS: TestGnmiGetTranslibPfmCompXcvr/Get_OC_Platform_Comp_Xcvr_Presence (0.02s)
PASS