### PR TITLE
[202605] Backport gNMI RPC completion logging (#727)

### DIFF
--- a/doc/grpc_telemetry.md
+++ b/doc/grpc_telemetry.md
@@ -3,6 +3,7 @@
    * [Overview of gRPC system data telemetry in SONiC](#overview-of-grpc-system-data-telemetry-in-sonic)
    * [Data available in SONiC](#data-available-in-sonic)
    * [SONiC system telemetry software architecture](#sonic-system-telemetry-software-architecture)
+   * [Get and Set audit records](#get-and-set-audit-records)
    * [gRPC operations for system telemetry in SONiC](#grpc-operations-for-system-telemetry-in-sonic)
       * [Usage of SONiC telemetry server binary](#usage-of-sonic-telemetry-server-binary)
       * [GetRequest/GetResponse](#getrequestgetresponse)
@@ -67,6 +68,39 @@ For data not available in DBs, Target name "OTHERS" is designated for that categ
 # SONiC system telemetry software architecture
 System telemetry in SONiC supports both dial-in mode and dial-out mode. The DB client takes care of retrieving data from SONiC redis database, while non-DB client serves data outside of redis databases. gRPC dial-in server (gNMI server) is described in this document,
 ![SOFTWARE ARCHITECTURE](img/dial_in_out.png)
+
+# Get and Set audit records
+
+One outer gRPC completion interceptor emits one version 2 `RPC_COMPLETION`
+record for each allowed RPC. The unified record contains `v`, `type`, `method`, `peer_type`,
+`peer`, `principal`, `auth_type`, `path`, `code`, `duration_ms`, and
+`suppressed`. `principal`, `auth_type`, and `path` use empty defaults.
+
+The logger uses only data already available at interceptor entry or completion
+and never serializes the complete request or response. `principal` copies the presented
+TLS peer certificate Common Name without chain, SAN, role, authentication, or
+authorization validation. After the deferred completion handler passes the
+rate limit, one `deriveRequestFields` wrapper performs the only peer-context
+existence check, then delegates address/type, presented CN, transport auth
+method, and redacted path-shape extraction. It is named for the request because
+paths are not peer data. `ygot.PathToSchemaPath` formats each logged path as an
+absolute names-only string. Origin, target, `PathElem.Key` maps, and deprecated
+`Element` values are omitted. Request update values and responses are not
+included. Authenticated principal, the existing `TELEMETRY-*` request ID, and
+auth result are deferred until those values are available in the interceptor
+context.
+
+Other unary and streaming methods use the same record. Peer-derived
+`principal` and `auth_type` are populated when available; `path` remains empty
+outside Get/Set. PR #723 method/code rate limiting and suppression summaries
+remain.
+
+Set records are never rate-limited. Get records use the same method/code bucket
+map and `RPC_COMPLETION_SUMMARY` path as other RPCs, with 60 records/hour and burst
+60 instead of PR #723's default one record per 10 seconds. A suppressed Get
+does not reach the glog sink; its common summary reports method, code, and
+suppressed count.
+
 # gRPC operations for system telemetry in SONiC
 As mentioned at the beginning, SONiC gRPC data telemetry is largely based on gNMI protocol,  the GetRquest/GetResponse and SubscribeRequest/SubscribeResponse RPC have been implemented. Since SONiC doesn't have complete YANG data model yet, the DB, TABLE, KEY and Field path hierarchy is used as path to uniquely identify the configuration/state and counter data.
 

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/crypto v0.36.0
 	golang.org/x/net v0.38.0
+	golang.org/x/time v0.14.0
 	google.golang.org/grpc v1.69.2
 	google.golang.org/grpc/security/advancedtls v1.0.0
 	google.golang.org/protobuf v1.36.6

--- a/go.sum
+++ b/go.sum
@@ -2019,6 +2019,8 @@ golang.org/x/time v0.0.0-20220922220347-f3bd1da661af/go.mod h1:tRJNPiyCQ0inRvYxb
 golang.org/x/time v0.1.0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.3.0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.5.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
+golang.org/x/time v0.14.0 h1:MRx4UaLrDotUKUdCIqzPC48t1Y9hANFKIRpNx+Te8PI=
+golang.org/x/time v0.14.0/go.mod h1:eL/Oa2bBBK0TkX57Fyni+NgnyQQN4LitPmob2Hjnqw4=
 golang.org/x/tools v0.0.0-20180525024113-a5b4c53f6e8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190206041539-40960b6deb8e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/pkg/interceptors/rpc_completion_log.go
+++ b/pkg/interceptors/rpc_completion_log.go
@@ -1,0 +1,361 @@
+package interceptors
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"sync"
+	"time"
+
+	gnmipb "github.com/openconfig/gnmi/proto/gnmi"
+	"github.com/openconfig/ygot/ygot"
+	"golang.org/x/time/rate"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	rpcCompletionLogPrefix       = "RPC_COMPLETION"
+	rpcCompletionSummaryPrefix   = "RPC_COMPLETION_SUMMARY"
+	rpcCompletionDefaultInterval = 10 * time.Second
+	gnmiGetMethod                = "/gnmi.gNMI/Get"
+	gnmiSetMethod                = "/gnmi.gNMI/Set"
+)
+
+type scheduleFunc func(time.Duration, func())
+type lineSink func(string) error
+
+type rpcLogKey struct {
+	method string
+	code   codes.Code
+}
+
+type rpcLogLimit struct {
+	limiter    *rate.Limiter
+	suppressed uint64
+	scheduled  bool
+}
+
+type rpcLogPolicy struct {
+	tokenInterval   time.Duration
+	summaryInterval time.Duration
+	burst           int
+	unlimited       bool
+}
+
+var defaultRPCLogPolicy = rpcLogPolicy{
+	tokenInterval:   rpcCompletionDefaultInterval,
+	summaryInterval: rpcCompletionDefaultInterval,
+	burst:           1,
+}
+
+var rpcLogPolicies = map[string]rpcLogPolicy{
+	gnmiGetMethod: {
+		tokenInterval:   time.Minute,
+		summaryInterval: time.Hour,
+		burst:           60,
+	},
+	gnmiSetMethod: {
+		unlimited: true,
+	},
+}
+
+type rpcCompletionRecord struct {
+	Version    int      `json:"v"`
+	RPCType    string   `json:"type"`
+	Method     string   `json:"method"`
+	PeerType   string   `json:"peer_type"`
+	Peer       string   `json:"peer"`
+	Principal  string   `json:"principal"`
+	AuthType   string   `json:"auth_type"`
+	Path       []string `json:"path"`
+	Code       string   `json:"code"`
+	DurationMS int64    `json:"duration_ms"`
+	Suppressed uint64   `json:"suppressed"`
+}
+
+type rpcCompletionSummary struct {
+	Version    int    `json:"v"`
+	Method     string `json:"method"`
+	Code       string `json:"code"`
+	Suppressed uint64 `json:"suppressed"`
+}
+
+type requestFields struct {
+	peerType  string
+	address   string
+	principal string
+	authType  string
+	paths     []string
+}
+
+// rpcCompletionLogger owns the server RPC completion lifecycle and rate policy.
+type rpcCompletionLogger struct {
+	sink     lineSink
+	now      func() time.Time
+	schedule scheduleFunc
+
+	mu     sync.Mutex
+	limits map[rpcLogKey]*rpcLogLimit
+}
+
+func newRPCCompletionLogger(sink lineSink) *rpcCompletionLogger {
+	return newRPCCompletionLoggerWithClockAndScheduler(sink, time.Now, func(delay time.Duration, f func()) {
+		time.AfterFunc(delay, f)
+	})
+}
+
+func newRPCCompletionLoggerWithClockAndScheduler(
+	sink lineSink,
+	now func() time.Time,
+	schedule scheduleFunc,
+) *rpcCompletionLogger {
+	logger := &rpcCompletionLogger{
+		sink:     sink,
+		now:      now,
+		schedule: schedule,
+		limits:   make(map[rpcLogKey]*rpcLogLimit),
+	}
+	return logger
+}
+
+func (l *rpcCompletionLogger) UnaryInterceptor() grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (response interface{}, err error) {
+		started := l.now()
+		defer l.log(ctx, req, "unary", info.FullMethod, started, &err)
+		return handler(ctx, req)
+	}
+}
+
+func (l *rpcCompletionLogger) StreamInterceptor() grpc.StreamServerInterceptor {
+	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) (err error) {
+		started := l.now()
+		defer l.log(stream.Context(), nil, "stream", info.FullMethod, started, &err)
+		return handler(srv, stream)
+	}
+}
+
+func (l *rpcCompletionLogger) log(
+	ctx context.Context,
+	req interface{},
+	rpcType string,
+	method string,
+	started time.Time,
+	rpcErr *error,
+) {
+	if panicValue := recover(); panicValue != nil {
+		panic(panicValue)
+	}
+
+	finished := l.now()
+	code := grpcCode(*rpcErr)
+	suppressed, allowed := l.allow(method, code, finished)
+	if !allowed {
+		return
+	}
+
+	fields := deriveRequestFields(ctx, req)
+	record := rpcCompletionRecord{
+		Version:    2,
+		RPCType:    rpcType,
+		Method:     method,
+		PeerType:   fields.peerType,
+		Peer:       fields.address,
+		Principal:  fields.principal,
+		AuthType:   fields.authType,
+		Path:       fields.paths,
+		Code:       code.String(),
+		DurationMS: finished.Sub(started).Milliseconds(),
+		Suppressed: suppressed,
+	}
+
+	if data, err := json.Marshal(record); err == nil {
+		func() {
+			defer func() { _ = recover() }()
+			_ = l.sink(rpcCompletionLogPrefix + " " + string(data))
+		}()
+	}
+}
+
+func (l *rpcCompletionLogger) allow(method string, code codes.Code, now time.Time) (uint64, bool) {
+	policy := rpcLogPolicyForMethod(method)
+	if policy.unlimited {
+		return 0, true
+	}
+
+	l.mu.Lock()
+	key := rpcLogKey{method: method, code: code}
+	limit, ok := l.limits[key]
+	if !ok {
+		limit = &rpcLogLimit{
+			limiter: rate.NewLimiter(rate.Every(policy.tokenInterval), policy.burst),
+		}
+		l.limits[key] = limit
+	}
+	if !limit.limiter.AllowN(now, 1) {
+		limit.suppressed++
+		shouldSchedule := markSummaryScheduled(limit)
+		l.mu.Unlock()
+		if shouldSchedule {
+			l.scheduleSummary(key)
+		}
+		return 0, false
+	}
+	suppressed := limit.suppressed
+	limit.suppressed = 0
+	l.mu.Unlock()
+	return suppressed, true
+}
+
+func markSummaryScheduled(limit *rpcLogLimit) bool {
+	if limit.scheduled {
+		return false
+	}
+	limit.scheduled = true
+	return true
+}
+
+func (l *rpcCompletionLogger) scheduleSummary(key rpcLogKey) {
+	l.schedule(rpcLogPolicyForMethod(key.method).summaryInterval, func() { l.writeSummary(key) })
+}
+
+func rpcLogPolicyForMethod(method string) rpcLogPolicy {
+	if policy, ok := rpcLogPolicies[method]; ok {
+		return policy
+	}
+	return defaultRPCLogPolicy
+}
+
+func (l *rpcCompletionLogger) writeSummary(key rpcLogKey) {
+	l.mu.Lock()
+	limit := l.limits[key]
+	limit.scheduled = false
+	if limit.suppressed == 0 {
+		l.mu.Unlock()
+		return
+	}
+	if !limit.limiter.AllowN(l.now(), 1) {
+		shouldSchedule := markSummaryScheduled(limit)
+		l.mu.Unlock()
+		if shouldSchedule {
+			l.scheduleSummary(key)
+		}
+		return
+	}
+	suppressed := limit.suppressed
+	limit.suppressed = 0
+	l.mu.Unlock()
+
+	summary := rpcCompletionSummary{
+		Version:    1,
+		Method:     key.method,
+		Code:       key.code.String(),
+		Suppressed: suppressed,
+	}
+	if data, err := json.Marshal(summary); err == nil {
+		func() {
+			defer func() { _ = recover() }()
+			_ = l.sink(rpcCompletionSummaryPrefix + " " + string(data))
+		}()
+	}
+}
+
+func grpcCode(err error) codes.Code {
+	if err == nil {
+		return codes.OK
+	}
+	if rpcStatus, ok := status.FromError(err); ok {
+		return rpcStatus.Code()
+	}
+	return status.FromContextError(err).Code()
+}
+
+func deriveRequestFields(ctx context.Context, req interface{}) requestFields {
+	fields := requestFields{
+		peerType: "unknown",
+		paths:    requestPaths(req),
+	}
+	requestPeer, ok := peer.FromContext(ctx)
+	if !ok {
+		return fields
+	}
+
+	fields.peerType, fields.address = peerAddress(requestPeer)
+	fields.principal = presentedCertificateCommonName(requestPeer)
+	fields.authType = peerAuthType(requestPeer)
+	return fields
+}
+
+func peerAddress(requestPeer *peer.Peer) (string, string) {
+	peerType := "unknown"
+	peerAddress := ""
+	if requestPeer.Addr != nil {
+		peerAddress = requestPeer.Addr.String()
+		switch network := requestPeer.Addr.Network(); {
+		case strings.HasPrefix(network, "tcp"):
+			peerType = "tcp"
+		case strings.HasPrefix(network, "unix"):
+			peerType = "unix"
+		}
+	}
+	return peerType, peerAddress
+}
+
+func requestPaths(req interface{}) []string {
+	paths := []string{}
+	switch request := req.(type) {
+	case *gnmipb.GetRequest:
+		for _, path := range request.GetPath() {
+			paths = append(paths, formatRequestPath(path))
+		}
+	case *gnmipb.SetRequest:
+		for _, path := range request.GetDelete() {
+			paths = append(paths, formatRequestPath(path))
+		}
+		for _, update := range request.GetReplace() {
+			paths = append(paths, formatRequestPath(update.GetPath()))
+		}
+		for _, update := range request.GetUpdate() {
+			paths = append(paths, formatRequestPath(update.GetPath()))
+		}
+	}
+	return paths
+}
+
+func formatRequestPath(path *gnmipb.Path) string {
+	if path == nil {
+		return "<invalid>"
+	}
+
+	schemaPath := &gnmipb.Path{Elem: make([]*gnmipb.PathElem, 0, len(path.GetElem()))}
+	for _, elem := range path.GetElem() {
+		if elem == nil {
+			return "<invalid>"
+		}
+		schemaPath.Elem = append(schemaPath.Elem, &gnmipb.PathElem{Name: elem.GetName()})
+	}
+
+	formatted, err := ygot.PathToSchemaPath(schemaPath)
+	if err != nil {
+		return "<invalid>"
+	}
+	return formatted
+}
+
+func presentedCertificateCommonName(requestPeer *peer.Peer) string {
+	tlsInfo, ok := requestPeer.AuthInfo.(credentials.TLSInfo)
+	if !ok || len(tlsInfo.State.PeerCertificates) == 0 {
+		return ""
+	}
+	return tlsInfo.State.PeerCertificates[0].Subject.CommonName
+}
+
+func peerAuthType(requestPeer *peer.Peer) string {
+	if requestPeer.AuthInfo == nil {
+		return ""
+	}
+	return requestPeer.AuthInfo.AuthType()
+}

--- a/pkg/interceptors/rpc_completion_log_test.go
+++ b/pkg/interceptors/rpc_completion_log_test.go
@@ -1,0 +1,717 @@
+package interceptors
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"fmt"
+	"net"
+	"reflect"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	gnmipb "github.com/openconfig/gnmi/proto/gnmi"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/status"
+)
+
+type accessLogServerStream struct {
+	ctx context.Context
+}
+
+type completionTestAddr struct {
+	network string
+	address string
+}
+
+func (a completionTestAddr) Network() string { return a.network }
+func (a completionTestAddr) String() string  { return a.address }
+
+type completionCapture struct {
+	mu        sync.Mutex
+	lines     []string
+	delays    []time.Duration
+	callbacks []func()
+}
+
+func (c *completionCapture) sink(line string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.lines = append(c.lines, line)
+	return nil
+}
+
+func (c *completionCapture) schedule(delay time.Duration, callback func()) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.delays = append(c.delays, delay)
+	c.callbacks = append(c.callbacks, callback)
+}
+
+func (c *completionCapture) snapshot() ([]string, []time.Duration, []func()) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]string(nil), c.lines...),
+		append([]time.Duration(nil), c.delays...),
+		append([]func(){}, c.callbacks...)
+}
+
+func (s *accessLogServerStream) SetHeader(metadata.MD) error  { return nil }
+func (s *accessLogServerStream) SendHeader(metadata.MD) error { return nil }
+func (s *accessLogServerStream) SetTrailer(metadata.MD)       {}
+func (s *accessLogServerStream) Context() context.Context     { return s.ctx }
+func (s *accessLogServerStream) SendMsg(interface{}) error    { return nil }
+func (s *accessLogServerStream) RecvMsg(interface{}) error    { return nil }
+
+func captureAccessLog(t *testing.T) (lineSink, func() rpcCompletionRecord) {
+	t.Helper()
+
+	var lines []string
+	sink := func(line string) error {
+		lines = append(lines, line)
+		return nil
+	}
+	record := func() rpcCompletionRecord {
+		t.Helper()
+		if len(lines) != 1 {
+			t.Fatalf("got %d log lines, want 1: %v", len(lines), lines)
+		}
+		return parseAccessLog(t, lines[0])
+	}
+	return sink, record
+}
+
+func parseAccessLog(t *testing.T, line string) rpcCompletionRecord {
+	t.Helper()
+
+	const prefix = "RPC_COMPLETION "
+	if !strings.HasPrefix(line, prefix) {
+		t.Fatalf("log line %q does not start with %q", line, prefix)
+	}
+
+	payload := []byte(strings.TrimPrefix(line, prefix))
+	var fields map[string]interface{}
+	if err := json.Unmarshal(payload, &fields); err != nil {
+		t.Fatalf("log line is not valid JSON: %v", err)
+	}
+	gotFields := make([]string, 0, len(fields))
+	for field := range fields {
+		gotFields = append(gotFields, field)
+	}
+	slices.Sort(gotFields)
+	wantFields := []string{"auth_type", "code", "duration_ms", "method", "path", "peer", "peer_type", "principal", "suppressed", "type", "v"}
+	if !reflect.DeepEqual(gotFields, wantFields) {
+		t.Fatalf("log record fields = %v, want %v", gotFields, wantFields)
+	}
+
+	var got rpcCompletionRecord
+	if err := json.Unmarshal(payload, &got); err != nil {
+		t.Fatalf("cannot decode access log: %v", err)
+	}
+	if got.Version != 2 {
+		t.Fatalf("access log version = %d, want 2", got.Version)
+	}
+	if got.Principal != "" || got.AuthType != "" || len(got.Path) != 0 {
+		t.Fatalf("access defaults = principal %q, auth_type %q, path %v; want empty",
+			got.Principal, got.AuthType, got.Path)
+	}
+	return got
+}
+
+func parseAccessLogSummary(t *testing.T, line string) rpcCompletionSummary {
+	t.Helper()
+
+	const prefix = "RPC_COMPLETION_SUMMARY "
+	if !strings.HasPrefix(line, prefix) {
+		t.Fatalf("log line %q does not start with %q", line, prefix)
+	}
+	payload := []byte(strings.TrimPrefix(line, prefix))
+	var fields map[string]interface{}
+	if err := json.Unmarshal(payload, &fields); err != nil {
+		t.Fatalf("log summary is not valid JSON: %v", err)
+	}
+	gotFields := make([]string, 0, len(fields))
+	for field := range fields {
+		gotFields = append(gotFields, field)
+	}
+	slices.Sort(gotFields)
+	wantFields := []string{"code", "method", "suppressed", "v"}
+	if !reflect.DeepEqual(gotFields, wantFields) {
+		t.Fatalf("log summary fields = %v, want %v", gotFields, wantFields)
+	}
+
+	var got rpcCompletionSummary
+	if err := json.Unmarshal(payload, &got); err != nil {
+		t.Fatalf("cannot decode access log summary: %v", err)
+	}
+	return got
+}
+
+func TestRPCLoggerEndToEnd(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("net.Listen() failed: %v", err)
+	}
+	defer listener.Close()
+
+	logs := make(chan string, 1)
+	logger := newRPCCompletionLogger(func(line string) error {
+		logs <- line
+		return nil
+	})
+	server := grpc.NewServer(
+		grpc.UnaryInterceptor(logger.UnaryInterceptor()),
+		grpc.StreamInterceptor(logger.StreamInterceptor()),
+	)
+	healthServer := health.NewServer()
+	healthServer.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)
+	healthpb.RegisterHealthServer(server, healthServer)
+	go func() {
+		if serveErr := server.Serve(listener); serveErr != nil {
+			select {
+			case logs <- fmt.Sprintf("serve error: %v", serveErr):
+			default:
+			}
+		}
+	}()
+	t.Cleanup(server.Stop)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	conn, err := grpc.DialContext(ctx, listener.Addr().String(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithBlock(),
+	)
+	if err != nil {
+		t.Fatalf("grpc.DialContext() failed: %v", err)
+	}
+	defer conn.Close()
+
+	response, err := healthpb.NewHealthClient(conn).Check(ctx, &healthpb.HealthCheckRequest{})
+	if err != nil {
+		t.Fatalf("Health.Check() failed: %v", err)
+	}
+	if response.Status != healthpb.HealthCheckResponse_SERVING {
+		t.Fatalf("Health.Check() status = %v, want SERVING", response.Status)
+	}
+
+	select {
+	case line := <-logs:
+		got := parseAccessLog(t, line)
+		if got.RPCType != "unary" || got.Method != "/grpc.health.v1.Health/Check" ||
+			got.PeerType != "tcp" || got.Code != codes.OK.String() {
+			t.Fatalf("access log = %+v, want successful TCP Health.Check", got)
+		}
+		if got.DurationMS < 0 {
+			t.Fatalf("duration_ms = %d, want non-negative", got.DurationMS)
+		}
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for RPC access log")
+	}
+}
+
+func TestRPCLoggerRateLimitsEachMethodAndCode(t *testing.T) {
+	now := time.Date(2026, time.July, 27, 0, 0, 0, 0, time.UTC)
+	var lines []string
+	logger := newRPCCompletionLoggerWithClockAndScheduler(func(line string) error {
+		lines = append(lines, line)
+		return nil
+	}, func() time.Time { return now }, func(time.Duration, func()) {})
+	interceptor := logger.UnaryInterceptor()
+
+	call := func(method string, wantErr error) {
+		t.Helper()
+		_, err := interceptor(context.Background(), nil,
+			&grpc.UnaryServerInfo{FullMethod: method},
+			func(context.Context, interface{}) (interface{}, error) { return nil, wantErr })
+		if err != wantErr {
+			t.Fatalf("UnaryInterceptor() error = %v, want %v", err, wantErr)
+		}
+	}
+
+	call("/test.Service/Get", nil)
+	call("/test.Service/Get", nil)
+	call("/test.Service/Get", nil)
+	if len(lines) != 1 {
+		t.Fatalf("same-key calls produced %d log lines, want 1: %v", len(lines), lines)
+	}
+
+	permissionDenied := status.Error(codes.PermissionDenied, "not allowed")
+	call("/test.Service/Get", permissionDenied)
+	call("/test.Service/Set", nil)
+	if len(lines) != 3 {
+		t.Fatalf("distinct-key calls produced %d log lines, want 3: %v", len(lines), lines)
+	}
+
+	now = now.Add(10 * time.Second)
+	call("/test.Service/Get", nil)
+	if len(lines) != 4 {
+		t.Fatalf("call after interval produced %d log lines, want 4: %v", len(lines), lines)
+	}
+	got := parseAccessLog(t, lines[3])
+	if got.Method != "/test.Service/Get" || got.Code != codes.OK.String() ||
+		got.Suppressed != 2 {
+		t.Fatalf("access log = %+v, want Get/OK with 2 suppressed calls", got)
+	}
+}
+
+func TestRPCLoggerReportsSuppressionAfterTrafficStops(t *testing.T) {
+	now := time.Date(2026, time.July, 27, 0, 0, 0, 0, time.UTC)
+	var lines []string
+	var scheduled func()
+	logger := newRPCCompletionLoggerWithClockAndScheduler(func(line string) error {
+		lines = append(lines, line)
+		return nil
+	}, func() time.Time { return now }, func(delay time.Duration, f func()) {
+		if delay != 10*time.Second {
+			t.Fatalf("summary delay = %v, want 10s", delay)
+		}
+		scheduled = f
+	})
+	interceptor := logger.UnaryInterceptor()
+	call := func() {
+		_, _ = interceptor(context.Background(), nil,
+			&grpc.UnaryServerInfo{FullMethod: "/test.Service/Get"},
+			func(context.Context, interface{}) (interface{}, error) { return nil, nil })
+	}
+
+	call()
+	call()
+	call()
+	if scheduled == nil {
+		t.Fatal("suppression summary was not scheduled")
+	}
+	now = now.Add(10 * time.Second)
+	scheduled()
+
+	if len(lines) != 2 {
+		t.Fatalf("got %d log lines, want access and summary: %v", len(lines), lines)
+	}
+	got := parseAccessLogSummary(t, lines[1])
+	if got.Version != 1 || got.Method != "/test.Service/Get" ||
+		got.Code != codes.OK.String() || got.Suppressed != 2 {
+		t.Fatalf("access log summary = %+v, want Get/OK with 2 suppressed calls", got)
+	}
+	call()
+	if len(lines) != 2 {
+		t.Fatalf("call after summary produced %d log lines, want shared rate limit", len(lines))
+	}
+}
+
+func TestRPCLoggerRetriesSummaryWhenAccessRecordWinsInterval(t *testing.T) {
+	now := time.Date(2026, time.July, 27, 0, 0, 0, 0, time.UTC)
+	var lines []string
+	var scheduled []func()
+	logger := newRPCCompletionLoggerWithClockAndScheduler(func(line string) error {
+		lines = append(lines, line)
+		return nil
+	}, func() time.Time { return now }, func(delay time.Duration, f func()) {
+		if delay != 10*time.Second {
+			t.Fatalf("summary delay = %v, want 10s", delay)
+		}
+		scheduled = append(scheduled, f)
+	})
+	interceptor := logger.UnaryInterceptor()
+	call := func() {
+		_, _ = interceptor(context.Background(), nil,
+			&grpc.UnaryServerInfo{FullMethod: "/test.Service/Get"},
+			func(context.Context, interface{}) (interface{}, error) { return nil, nil })
+	}
+
+	call()
+	call()
+	now = now.Add(10 * time.Second)
+	call()
+	call()
+	scheduled[0]()
+	if len(scheduled) != 2 {
+		t.Fatalf("scheduled callbacks = %d, want summary retry", len(scheduled))
+	}
+	if len(lines) != 2 {
+		t.Fatalf("got %d log lines before retry, want 2: %v", len(lines), lines)
+	}
+
+	now = now.Add(10 * time.Second)
+	scheduled[1]()
+	if len(lines) != 3 {
+		t.Fatalf("got %d log lines after retry, want 3: %v", len(lines), lines)
+	}
+	if got := parseAccessLogSummary(t, lines[2]); got.Suppressed != 1 {
+		t.Fatalf("suppressed = %d, want 1 since last access record", got.Suppressed)
+	}
+}
+
+func TestRPCLoggerRateLimitIsConcurrent(t *testing.T) {
+	now := time.Date(2026, time.July, 27, 0, 0, 0, 0, time.UTC)
+	var lines []string
+	var linesMu sync.Mutex
+	logger := newRPCCompletionLoggerWithClockAndScheduler(func(line string) error {
+		linesMu.Lock()
+		defer linesMu.Unlock()
+		lines = append(lines, line)
+		return nil
+	}, func() time.Time { return now }, func(time.Duration, func()) {})
+	interceptor := logger.UnaryInterceptor()
+
+	const calls = 100
+	var wg sync.WaitGroup
+	wg.Add(calls)
+	for range calls {
+		go func() {
+			defer wg.Done()
+			_, _ = interceptor(context.Background(), nil,
+				&grpc.UnaryServerInfo{FullMethod: "/test.Service/Get"},
+				func(context.Context, interface{}) (interface{}, error) { return nil, nil })
+		}()
+	}
+	wg.Wait()
+
+	if len(lines) != 1 {
+		t.Fatalf("concurrent calls produced %d log lines, want 1", len(lines))
+	}
+	now = now.Add(10 * time.Second)
+	_, _ = interceptor(context.Background(), nil,
+		&grpc.UnaryServerInfo{FullMethod: "/test.Service/Get"},
+		func(context.Context, interface{}) (interface{}, error) { return nil, nil })
+	if got := parseAccessLog(t, lines[1]); got.Suppressed != calls-1 {
+		t.Fatalf("suppressed = %d, want %d", got.Suppressed, calls-1)
+	}
+}
+
+func TestRPCLoggerSchedulerMayRunSynchronously(t *testing.T) {
+	now := time.Date(2026, time.July, 27, 0, 0, 0, 0, time.UTC)
+	var lines []string
+	scheduleCalls := 0
+	logger := newRPCCompletionLoggerWithClockAndScheduler(func(line string) error {
+		lines = append(lines, line)
+		return nil
+	}, func() time.Time { return now }, func(delay time.Duration, f func()) {
+		scheduleCalls++
+		now = now.Add(delay)
+		f()
+	})
+	interceptor := logger.UnaryInterceptor()
+
+	for range 2 {
+		_, _ = interceptor(context.Background(), nil,
+			&grpc.UnaryServerInfo{FullMethod: "/test.Service/Get"},
+			func(context.Context, interface{}) (interface{}, error) { return nil, nil })
+	}
+
+	if scheduleCalls != 1 || len(lines) != 2 {
+		t.Fatalf("synchronous scheduler = %d calls, %d lines; want 1 call and access+summary", scheduleCalls, len(lines))
+	}
+	if got := parseAccessLogSummary(t, lines[1]); got.Suppressed != 1 {
+		t.Fatalf("suppressed = %d, want 1", got.Suppressed)
+	}
+}
+
+func TestRPCLoggerUnaryError(t *testing.T) {
+	sink, capturedRecord := captureAccessLog(t)
+	logger := newRPCCompletionLogger(sink)
+	info := &grpc.UnaryServerInfo{FullMethod: "/test.Service/Set"}
+	wantErr := status.Error(codes.PermissionDenied, "not allowed")
+
+	response, err := logger.UnaryInterceptor()(context.Background(), "secret request", info,
+		func(context.Context, interface{}) (interface{}, error) {
+			return nil, wantErr
+		})
+	if err != wantErr {
+		t.Fatalf("UnaryInterceptor() error = %v, want original error %v", err, wantErr)
+	}
+	if response != nil {
+		t.Fatalf("UnaryInterceptor() response = %v, want nil", response)
+	}
+
+	got := capturedRecord()
+	if got.Code != codes.PermissionDenied.String() {
+		t.Fatalf("access log code = %q, want %q", got.Code, codes.PermissionDenied)
+	}
+}
+
+func TestRPCLoggerUnaryContextErrorUsesGRPCCode(t *testing.T) {
+	sink, capturedRecord := captureAccessLog(t)
+	logger := newRPCCompletionLogger(sink)
+
+	_, err := logger.UnaryInterceptor()(context.Background(), nil,
+		&grpc.UnaryServerInfo{FullMethod: "/test.Service/Get"},
+		func(context.Context, interface{}) (interface{}, error) {
+			return nil, context.DeadlineExceeded
+		})
+	if err != context.DeadlineExceeded {
+		t.Fatalf("UnaryInterceptor() error = %v, want original context error", err)
+	}
+	if got := capturedRecord(); got.Code != codes.DeadlineExceeded.String() {
+		t.Fatalf("access log code = %q, want %q", got.Code, codes.DeadlineExceeded)
+	}
+}
+
+func TestRPCLoggerStreamError(t *testing.T) {
+	sink, capturedRecord := captureAccessLog(t)
+	logger := newRPCCompletionLogger(sink)
+	ctx := peer.NewContext(context.Background(), &peer.Peer{
+		Addr: &net.UnixAddr{Name: "/var/run/gnmi/gnmi.sock", Net: "unix"},
+	})
+	stream := &accessLogServerStream{ctx: ctx}
+	info := &grpc.StreamServerInfo{FullMethod: "/gnmi.gNMI/Subscribe"}
+	wantErr := status.Error(codes.Canceled, "client closed stream")
+
+	err := logger.StreamInterceptor()(nil, stream, info,
+		func(interface{}, grpc.ServerStream) error {
+			return wantErr
+		})
+	if err != wantErr {
+		t.Fatalf("StreamInterceptor() error = %v, want original error %v", err, wantErr)
+	}
+
+	got := capturedRecord()
+	want := rpcCompletionRecord{
+		Version:  2,
+		RPCType:  "stream",
+		Method:   "/gnmi.gNMI/Subscribe",
+		PeerType: "unix",
+		Peer:     "/var/run/gnmi/gnmi.sock",
+		Code:     codes.Canceled.String(),
+	}
+	if got.Version != want.Version || got.RPCType != want.RPCType || got.Method != want.Method ||
+		got.PeerType != want.PeerType || got.Peer != want.Peer || got.Code != want.Code {
+		t.Fatalf("access log = %+v, want %+v", got, want)
+	}
+}
+
+func TestRPCLoggerDoesNotPropagateLoggingPanic(t *testing.T) {
+	logger := newRPCCompletionLogger(func(string) error { panic("log sink failure") })
+
+	response, err := logger.UnaryInterceptor()(context.Background(), nil,
+		&grpc.UnaryServerInfo{FullMethod: "/test.Service/Get"},
+		func(context.Context, interface{}) (interface{}, error) { return "response", nil })
+	if err != nil || response != "response" {
+		t.Fatalf("UnaryInterceptor() = %v, %v; want response, nil", response, err)
+	}
+}
+
+func TestRPCLoggerRecordsInnerShortCircuit(t *testing.T) {
+	sink, capturedRecord := captureAccessLog(t)
+	logger := newRPCCompletionLogger(sink)
+	calls := []string{}
+	shortCircuit := &mockInterceptor{name: "short-circuit", calls: &calls, shouldReplace: true}
+	chain := NewChain(logger, shortCircuit)
+
+	response, err := chain.UnaryInterceptor()(context.Background(), nil,
+		&grpc.UnaryServerInfo{FullMethod: "/gnoi.os.OS/Activate"},
+		func(context.Context, interface{}) (interface{}, error) {
+			t.Fatal("handler called after inner interceptor short-circuited")
+			return nil, nil
+		})
+	if err != nil {
+		t.Fatalf("UnaryInterceptor() returned error: %v", err)
+	}
+	if response != "short-circuit response" {
+		t.Fatalf("UnaryInterceptor() response = %v, want short-circuit response", response)
+	}
+	if got := capturedRecord(); got.Method != "/gnoi.os.OS/Activate" || got.Code != codes.OK.String() {
+		t.Fatalf("access log = %+v, want short-circuited RPC with OK status", got)
+	}
+}
+
+func TestDeriveRequestFields(t *testing.T) {
+	getPath := &gnmipb.Path{Elem: []*gnmipb.PathElem{{Name: "get"}}}
+	ctx := peer.NewContext(context.Background(), &peer.Peer{
+		Addr: &net.TCPAddr{IP: net.ParseIP("10.0.0.1"), Port: 1234},
+		AuthInfo: credentials.TLSInfo{
+			State: tls.ConnectionState{
+				PeerCertificates: []*x509.Certificate{{
+					Subject: pkix.Name{CommonName: "client-cn"},
+				}},
+			},
+		},
+	})
+
+	got := deriveRequestFields(ctx, &gnmipb.GetRequest{Path: []*gnmipb.Path{getPath}})
+	if got.peerType != "tcp" || got.address != "10.0.0.1:1234" ||
+		got.principal != "client-cn" || got.authType != "tls" ||
+		!reflect.DeepEqual(got.paths, []string{"/get"}) {
+		t.Fatalf("deriveRequestFields() = %+v", got)
+	}
+
+	empty := deriveRequestFields(context.Background(), nil)
+	if empty.peerType != "unknown" || empty.address != "" ||
+		empty.principal != "" || empty.authType != "" || len(empty.paths) != 0 {
+		t.Fatalf("deriveRequestFields() defaults = %+v", empty)
+	}
+}
+
+func TestRPCLoggerRedactsPathKeysWithoutMutatingRequest(t *testing.T) {
+	newPath := func(name, secret string) *gnmipb.Path {
+		return &gnmipb.Path{
+			Element: []string{"legacy-" + secret},
+			Origin:  "openconfig",
+			Target:  "CONFIG_DB",
+			Elem: []*gnmipb.PathElem{{
+				Name: name,
+				Key:  map[string]string{"name": secret},
+			}},
+		}
+	}
+
+	getPath := newPath("interface", "Ethernet0")
+	deletePath := newPath("delete", "delete-secret")
+	replacePath := newPath("replace", "replace-secret")
+	updatePath := newPath("update", "update-secret")
+	tests := []struct {
+		name        string
+		method      string
+		req         interface{}
+		sourcePaths []*gnmipb.Path
+	}{
+		{
+			name:        "Get",
+			method:      gnmiGetMethod,
+			req:         &gnmipb.GetRequest{Path: []*gnmipb.Path{getPath}},
+			sourcePaths: []*gnmipb.Path{getPath},
+		},
+		{
+			name:   "Set",
+			method: gnmiSetMethod,
+			req: &gnmipb.SetRequest{
+				Delete:  []*gnmipb.Path{deletePath},
+				Replace: []*gnmipb.Update{{Path: replacePath}},
+				Update:  []*gnmipb.Update{{Path: updatePath}},
+			},
+			sourcePaths: []*gnmipb.Path{deletePath, replacePath, updatePath},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var line string
+			logger := newRPCCompletionLogger(func(got string) error {
+				line = got
+				return nil
+			})
+			_, err := logger.UnaryInterceptor()(context.Background(), test.req,
+				&grpc.UnaryServerInfo{FullMethod: test.method},
+				func(context.Context, interface{}) (interface{}, error) { return nil, nil })
+			if err != nil {
+				t.Fatalf("UnaryInterceptor() failed: %v", err)
+			}
+
+			var record rpcCompletionRecord
+			payload := strings.TrimPrefix(line, rpcCompletionLogPrefix+" ")
+			if err := json.Unmarshal([]byte(payload), &record); err != nil {
+				t.Fatalf("cannot decode completion record: %v", err)
+			}
+			if len(record.Path) != len(test.sourcePaths) {
+				t.Fatalf("logged paths = %v, want %d paths", record.Path, len(test.sourcePaths))
+			}
+			for i, loggedPath := range record.Path {
+				sourcePath := test.sourcePaths[i]
+				wantPath := "/" + sourcePath.GetElem()[0].GetName()
+				if loggedPath != wantPath {
+					t.Fatalf("logged path[%d] = %q, want %q", i, loggedPath, wantPath)
+				}
+				if got := sourcePath.GetElem()[0].GetKey()["name"]; got == "" {
+					t.Fatalf("source path[%d] key was mutated", i)
+				}
+				if strings.Contains(line, sourcePath.GetElem()[0].GetKey()["name"]) ||
+					strings.Contains(line, sourcePath.GetElement()[0]) {
+					t.Fatalf("completion record leaked path key: %s", line)
+				}
+			}
+		})
+	}
+}
+
+func TestFormatRequestPathFormatsSONiCPath(t *testing.T) {
+	path := &gnmipb.Path{Elem: []*gnmipb.PathElem{
+		{Name: "PORT"},
+		{Name: "Ethernet0"},
+		{Name: "admin_status"},
+	}}
+	if got := formatRequestPath(path); got != "/PORT/Ethernet0/admin_status" {
+		t.Fatalf("formatRequestPath() = %q, want /PORT/Ethernet0/admin_status", got)
+	}
+}
+
+func TestFormatRequestPathMarksInvalidPaths(t *testing.T) {
+	for _, path := range []*gnmipb.Path{
+		nil,
+		{Elem: []*gnmipb.PathElem{nil}},
+		{Elem: []*gnmipb.PathElem{{}}},
+	} {
+		if got := formatRequestPath(path); got != "<invalid>" {
+			t.Fatalf("formatRequestPath() = %q, want <invalid>", got)
+		}
+	}
+}
+
+func TestGNMIGetPolicyAndSummary(t *testing.T) {
+	now := time.Date(2026, time.August, 5, 0, 0, 0, 0, time.UTC)
+	capture := &completionCapture{}
+	logger := newRPCCompletionLoggerWithClockAndScheduler(
+		capture.sink,
+		func() time.Time { return now },
+		capture.schedule,
+	)
+	interceptor := logger.UnaryInterceptor()
+	policy := rpcLogPolicyForMethod(gnmiGetMethod)
+
+	const calls = 100
+	for range calls {
+		_, _ = interceptor(context.Background(), nil,
+			&grpc.UnaryServerInfo{FullMethod: gnmiGetMethod},
+			func(context.Context, interface{}) (interface{}, error) { return nil, nil })
+	}
+
+	lines, delays, callbacks := capture.snapshot()
+	if len(lines) != policy.burst ||
+		!reflect.DeepEqual(delays, []time.Duration{policy.summaryInterval}) ||
+		len(callbacks) != 1 {
+		t.Fatalf("Get policy output = lines %d delays %v callbacks %d",
+			len(lines), delays, len(callbacks))
+	}
+
+	now = now.Add(policy.summaryInterval)
+	callbacks[0]()
+	lines, _, _ = capture.snapshot()
+	if len(lines) != policy.burst+1 {
+		t.Fatalf("Get lines after summary = %d, want %d", len(lines), policy.burst+1)
+	}
+	summary := parseAccessLogSummary(t, lines[len(lines)-1])
+	if summary.Method != gnmiGetMethod || summary.Code != codes.OK.String() ||
+		summary.Suppressed != uint64(calls-policy.burst) {
+		t.Fatalf("Get summary = %+v", summary)
+	}
+}
+
+func TestGNMISetPolicyIsUnlimited(t *testing.T) {
+	capture := &completionCapture{}
+	logger := newRPCCompletionLoggerWithClockAndScheduler(
+		capture.sink, time.Now, capture.schedule)
+	interceptor := logger.UnaryInterceptor()
+
+	const calls = 100
+	for range calls {
+		_, _ = interceptor(context.Background(), nil,
+			&grpc.UnaryServerInfo{FullMethod: gnmiSetMethod},
+			func(context.Context, interface{}) (interface{}, error) { return nil, nil })
+	}
+
+	lines, delays, callbacks := capture.snapshot()
+	if len(lines) != calls || len(delays) != 0 || len(callbacks) != 0 {
+		t.Fatalf("Set policy output = lines %d delays %v callbacks %d",
+			len(lines), delays, len(callbacks))
+	}
+}

--- a/pkg/interceptors/setup.go
+++ b/pkg/interceptors/setup.go
@@ -1,6 +1,7 @@
 package interceptors
 
 import (
+	log "github.com/golang/glog"
 	"github.com/sonic-net/sonic-gnmi/pkg/interceptors/dpuproxy"
 	"google.golang.org/grpc"
 )
@@ -12,7 +13,7 @@ type ServerChain struct {
 }
 
 // NewServerChain creates a complete interceptor chain for the gNMI server.
-// Currently includes DPU proxy interceptor with Redis-based DPU resolution.
+// It includes RPC completion logging and DPU proxying with Redis-based DPU resolution.
 // Returns the chain and a cleanup function that must be called during shutdown.
 func NewServerChain() (*ServerChain, error) {
 	// Create Redis clients for DPU info resolution from both StateDB and ConfigDB
@@ -27,8 +28,13 @@ func NewServerChain() (*ServerChain, error) {
 	dpuProxy := dpuproxy.NewDPUProxy(dpuResolver)
 	dpuproxy.SetDefaultProxy(dpuProxy)
 
-	// Create interceptor chain with DPU proxy
-	chain := NewChain(dpuProxy)
+	sink := lineSink(func(line string) error {
+		log.Infof("%s", line)
+		return nil
+	})
+
+	// Keep completion logging outside the DPU proxy so it records forwarded and rejected RPCs.
+	chain := NewChain(newRPCCompletionLogger(sink), dpuProxy)
 
 	// Create cleanup function to close Redis clients
 	cleanup := func() error {

--- a/pkg/interceptors/setup_test.go
+++ b/pkg/interceptors/setup_test.go
@@ -26,12 +26,35 @@ func TestNewServerChain(t *testing.T) {
 	}
 }
 
+func TestNewServerChainStartsWithCompletionLogger(t *testing.T) {
+	serverChain, err := NewServerChain()
+	if err != nil {
+		t.Fatalf("NewServerChain() failed: %v", err)
+	}
+	defer func() {
+		if closeErr := serverChain.Close(); closeErr != nil {
+			t.Errorf("Failed to close server chain: %v", closeErr)
+		}
+	}()
+
+	if len(serverChain.chain.interceptors) < 2 {
+		t.Fatalf("server chain has %d interceptors, want completion logger and DPU proxy", len(serverChain.chain.interceptors))
+	}
+	if _, ok := serverChain.chain.interceptors[0].(*rpcCompletionLogger); !ok {
+		t.Fatalf("first server interceptor is %T, want *rpcCompletionLogger", serverChain.chain.interceptors[0])
+	}
+}
+
 func TestServerChain_GetServerOptions(t *testing.T) {
 	chain, err := NewServerChain()
 	if err != nil {
 		t.Fatalf("NewServerChain() failed: %v", err)
 	}
-	defer chain.Close()
+	defer func() {
+		if closeErr := chain.Close(); closeErr != nil {
+			t.Errorf("Failed to close server chain: %v", closeErr)
+		}
+	}()
 
 	opts := chain.GetServerOptions()
 	if len(opts) == 0 {


### PR DESCRIPTION
#### Why I did it

Backport the structured gNMI RPC completion logging from #727 so the 202605 release emits the same privacy-preserving `RPC_COMPLETION` records as master.

#### How I did it

Cherry-picked the merged #727 commit (`f43f967a59fe20d2ad38c6d7be06e381336e1065`) onto `202605` as one backport commit. `git range-diff` reports the backport patch as identical to the merged change.

The backport keeps the outer unary/stream completion interceptor, names-only gNMI paths, method/code rate buckets, Set unlimited policy, TLS transport identity fields, and sink/panic behavior from #727.

#### How to verify it

Local validation:

- `go test -mod=mod -race ./pkg/interceptors`: pass
- `go vet -mod=mod ./pkg/interceptors`: pass
- Built the Debian package against the 202605 dependency set.
- [PR checks](https://github.com/sonic-net/sonic-gnmi/pull/750/checks)
- [CodeQL Go analysis](https://github.com/sonic-net/sonic-gnmi/actions/runs/31543402400/job/93950616823): pass
- [Semgrep](https://github.com/sonic-net/sonic-gnmi/actions/runs/31543402636/job/93950617385): pass

Physical testbed validation:

- Validated on a physical Broadcom T0 testbed running a 202605 release image.
- Runtime-stacked the backport package inside the `gnmi` container.
- `gnmi/test_gnmi_countersdb.py::test_gnmi_output`: pass
- `gnmi/test_gnmi_configdb.py::test_gnmi_configdb_incremental_01`: pass
- Observed successful version 2 Get and Set records with TLS principal, canonical names-only paths, final `OK` code, and duration.
- Restored the test environment after validation and confirmed the relevant services were healthy.

Sanitized reproduction outline (lab identifiers are placeholders):

```bash
set -euo pipefail

TESTBED="<physical-t0-testbed>"
DUT="<dut-inventory-host>"
INVENTORY="<inventory-file>"
TESTBED_FILE="<single-testbed-file>"
DEB="<build-output>/sonic-gnmi_0.1_amd64.deb"

# Confirm the release image before overlaying the package.
IMAGE_VERSION=$(ansible -i "$INVENTORY" "$DUT" -m shell \
  -a "show version | sed -n 's/^SONiC Software Version: //p'" -o)
echo "$IMAGE_VERSION"
# The validated run reported: SONiC.20260510.10

# Runtime-only overlay inside the gnmi container.
ansible -i "$INVENTORY" "$DUT" -b -m copy \
  -a "src=$DEB dest=/tmp/sonic-gnmi-pr750.deb mode=0644"
ansible -i "$INVENTORY" "$DUT" -b -m shell -a '
  docker cp /tmp/sonic-gnmi-pr750.deb gnmi:/root/sonic-gnmi-pr750.deb
  docker exec gnmi dpkg -i --force-overwrite /root/sonic-gnmi-pr750.deb
  docker exec gnmi supervisorctl restart gnmi-native
  docker exec gnmi supervisorctl status gnmi-native
'

cd tests
pkill() { :; } # Do not interrupt unrelated jobs in the shared test runner.
export -f pkill

COMMON_ARGS=(
  -u -n "$TESTBED" -i "$INVENTORY" -f "$TESTBED_FILE" -t any
  -e "--skip_sanity --skip_pre_sanity --disable_loganalyzer --ignore-conditional-mark"
  -l info -k debug -q 1
)

./run_tests.sh "${COMMON_ARGS[@]}" \
  -c gnmi/test_gnmi_countersdb.py::test_gnmi_output \
  -p logs/pr750-202605-get

./run_tests.sh "${COMMON_ARGS[@]}" \
  -c gnmi/test_gnmi_configdb.py::test_gnmi_configdb_incremental_01 \
  -p logs/pr750-202605-set

# Inspect the temporary server log produced by the sonic-mgmt fixture.
ansible -i "$INVENTORY" "$DUT" -b -m shell -a \
  "docker exec gnmi grep -E 'RPC_COMPLETION .*\"method\":\"/gnmi.gNMI/(Get|Set)\"' /root/gnmi.log"

# Remove the runtime overlay by recreating gnmi from the image, restore services,
# and verify health before releasing the testbed.
ansible -i "$INVENTORY" "$DUT" -b -m shell -a '
  systemctl stop gnmi
  docker rm -f gnmi >/dev/null 2>&1 || true
  systemctl start gnmi
  systemctl reset-failed telemetry || true
  systemctl restart telemetry
  systemctl is-active gnmi
  systemctl is-active telemetry
  docker exec gnmi supervisorctl status gnmi-native
'
```

Sanitized JUnit summary:

```text
gnmi.test_gnmi_countersdb::test_gnmi_output
tests=1 errors=0 failures=0 skipped=0

gnmi.test_gnmi_configdb::test_gnmi_configdb_incremental_01
tests=1 errors=0 failures=0 skipped=0
```

Sanitized runtime evidence:

```text
RPC_COMPLETION {"v":2,"type":"unary","method":"/gnmi.gNMI/Get","peer_type":"tcp","peer":"<redacted>","principal":"test.client.gnmi.sonic","auth_type":"tls","path":["/COUNTERS_DB/localhost/COUNTERS/<redacted>"],"code":"OK","suppressed":0}
RPC_COMPLETION {"v":2,"type":"unary","method":"/gnmi.gNMI/Set","peer_type":"tcp","peer":"<redacted>","principal":"test.client.gnmi.sonic","auth_type":"tls","path":["/CONFIG_DB/localhost/PORT/<redacted>/admin_status"],"code":"OK","suppressed":0}
```

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202605

Tracking issue/work item for backport/cherry-pick request: #727
Failure type: other - release observability and audit parity

#### Tested branch

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202605
- [ ] N/A

#### Test result

- 202605: physical Broadcom T0 Get/Set tests passed as detailed above.

#### Description for the changelog

Backport structured gNMI RPC completion logging to the 202605 release.

#### Link to config_db schema for YANG module changes

N/A
