### PR TITLE
Component test for Components Model - Eeprom

### DIFF
--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -486,6 +486,409 @@ func TestGnmiGetInterfaceCountersVPath(t *testing.T) {
 	}
 }
 
+func TestGnmiGetPlatformSysEepromComponents(t *testing.T) {
+	// 1. Start gNMI server
+	s := createServer(t, 8081)
+	go runServer(t, s)
+
+	prepareDbTranslib(t)
+	ns, _ := sdcfg.GetDbDefaultNamespace()
+	ctx := context.Background()
+
+	// Use StateDB (DB No 6 in SONiC)
+	stateClient := getRedisClientN(t, 6, ns)
+	defer stateClient.Close()
+
+	// CONFIG_DB (DB 4)
+	configClient := getRedisClientN(t, 4, ns)
+	defer configClient.Close()
+
+	// 2. Prepare Mock Data in Redis (EEPROM_INFO Table)
+
+	// Product Name (0x21)
+	prodNameFields := map[string]interface{}{
+		"Name":  "Product Name",
+		"Value": "Test-Product-100",
+	}
+	stateClient.HSet(ctx, "EEPROM_INFO|0x21", prodNameFields)
+	configClient.HSet(ctx, "EEPROM_INFO|0x21", prodNameFields)
+
+	// Part Number (0x22)
+	partNoFields := map[string]interface{}{
+		"Name":  "Part Number",
+		"Value": "PN-12345",
+	}
+	stateClient.HSet(ctx, "EEPROM_INFO|0x22", partNoFields)
+	configClient.HSet(ctx, "EEPROM_INFO|0x22", partNoFields)
+
+	// Serial Number (0x23)
+	serialNoFields := map[string]interface{}{
+		"Name":  "Serial Number",
+		"Value": "SN-987654321",
+	}
+	stateClient.HSet(ctx, "EEPROM_INFO|0x23", serialNoFields)
+	configClient.HSet(ctx, "EEPROM_INFO|0x23", serialNoFields)
+
+	// Base MAC Address (0x24)
+	baseMacFields := map[string]interface{}{
+		"Name":  "Base MAC Address",
+		"Value": "00:11:22:33:44:55",
+	}
+	stateClient.HSet(ctx, "EEPROM_INFO|0x24", baseMacFields)
+	configClient.HSet(ctx, "EEPROM_INFO|0x24", baseMacFields)
+
+	// Manufacture Date (0x25)
+	mfgDateFields := map[string]interface{}{
+		"Name":  "Manufacture Date",
+		"Value": "2026-01-01",
+	}
+	stateClient.HSet(ctx, "EEPROM_INFO|0x25", mfgDateFields)
+	configClient.HSet(ctx, "EEPROM_INFO|0x25", mfgDateFields)
+
+	// Device Version (0x26)
+	devVerFields := map[string]interface{}{
+		"Name":  "Device Version",
+		"Value": "v1.2.3",
+	}
+	stateClient.HSet(ctx, "EEPROM_INFO|0x26", devVerFields)
+	configClient.HSet(ctx, "EEPROM_INFO|0x26", devVerFields)
+
+	// Label Revision (0x27)
+	labelRevFields := map[string]interface{}{
+		"Name":  "Label Revision",
+		"Value": "Rev-A",
+	}
+	stateClient.HSet(ctx, "EEPROM_INFO|0x27", labelRevFields)
+	configClient.HSet(ctx, "EEPROM_INFO|0x27", labelRevFields)
+
+	// Platform Name (0x28)
+	platformNameFields := map[string]interface{}{
+		"Name":  "Platform Name",
+		"Value": "x86_64-test_platform-r0",
+	}
+	stateClient.HSet(ctx, "EEPROM_INFO|0x28", platformNameFields)
+	configClient.HSet(ctx, "EEPROM_INFO|0x28", platformNameFields)
+
+	// ONIE Version (0x29)
+	onieVerFields := map[string]interface{}{
+		"Name":  "ONIE Version",
+		"Value": "2023.11",
+	}
+	stateClient.HSet(ctx, "EEPROM_INFO|0x29", onieVerFields)
+	configClient.HSet(ctx, "EEPROM_INFO|0x29", onieVerFields)
+
+	// MAC Addresses (0x2A)
+	macAddrCountFields := map[string]interface{}{
+		"Name":  "MAC Addresses",
+		"Value": "4",
+	}
+	stateClient.HSet(ctx, "EEPROM_INFO|0x2A", macAddrCountFields)
+	configClient.HSet(ctx, "EEPROM_INFO|0x2A", macAddrCountFields)
+
+	// Manufacturer (0x2B)
+	mfgNameFields := map[string]interface{}{
+		"Name":  "Manufacturer",
+		"Value": "Test-Manufacturer",
+	}
+	stateClient.HSet(ctx, "EEPROM_INFO|0x2B", mfgNameFields)
+	configClient.HSet(ctx, "EEPROM_INFO|0x2B", mfgNameFields)
+
+	// Manufacture Country (0x2C)
+	countryFields := map[string]interface{}{
+		"Name":  "Manufacture Country",
+		"Value": "USA",
+	}
+	stateClient.HSet(ctx, "EEPROM_INFO|0x2C", countryFields)
+	configClient.HSet(ctx, "EEPROM_INFO|0x2C", countryFields)
+
+	// Vendor Name (0x2D)
+	vendorNameFields := map[string]interface{}{
+		"Name":  "Vendor Name",
+		"Value": "Test-Vendor",
+	}
+	stateClient.HSet(ctx, "EEPROM_INFO|0x2D", vendorNameFields)
+	configClient.HSet(ctx, "EEPROM_INFO|0x2D", vendorNameFields)
+
+	// Diag Version (0x2E)
+	diagVerFields := map[string]interface{}{
+		"Name":  "Diag Version",
+		"Value": "Diag-1.0",
+	}
+	stateClient.HSet(ctx, "EEPROM_INFO|0x2E", diagVerFields)
+	configClient.HSet(ctx, "EEPROM_INFO|0x2E", diagVerFields)
+
+	// Service Tag (0x2F)
+	serviceTagFields := map[string]interface{}{
+		"Name":  "Service Tag",
+		"Value": "ST-123456",
+	}
+	stateClient.HSet(ctx, "EEPROM_INFO|0x2F", serviceTagFields)
+	configClient.HSet(ctx, "EEPROM_INFO|0x2F", serviceTagFields)
+
+	// Card Type (0x30)
+	cardTypeFields := map[string]interface{}{
+		"Name":  "Card Type",
+		"Value": "Type-A",
+	}
+	stateClient.HSet(ctx, "EEPROM_INFO|0x30", cardTypeFields)
+	configClient.HSet(ctx, "EEPROM_INFO|0x30", cardTypeFields)
+
+	// Model Name (0x31)
+	modelNameFields := map[string]interface{}{
+		"Name":  "Model Name",
+		"Value": "Model-X",
+	}
+	stateClient.HSet(ctx, "EEPROM_INFO|0x31", modelNameFields)
+	configClient.HSet(ctx, "EEPROM_INFO|0x31", modelNameFields)
+
+	// Hardware Version (0x32)
+	hwVerFields := map[string]interface{}{
+		"Name":  "Hardware Version",
+		"Value": "HW-v1.0",
+	}
+	stateClient.HSet(ctx, "EEPROM_INFO|0x32", hwVerFields)
+	configClient.HSet(ctx, "EEPROM_INFO|0x32", hwVerFields)
+
+	// Software Version (0x33)
+	swVerFields := map[string]interface{}{
+		"Name":  "Software Version",
+		"Value": "SW-v2.0",
+	}
+	stateClient.HSet(ctx, "EEPROM_INFO|0x33", swVerFields)
+	configClient.HSet(ctx, "EEPROM_INFO|0x33", swVerFields)
+
+	// Magic Number (0x00)
+	magicNumFields := map[string]interface{}{
+		"Name":  "Magic Number",
+		"Value": "255",
+	}
+	stateClient.HSet(ctx, "EEPROM_INFO|0x00", magicNumFields)
+	configClient.HSet(ctx, "EEPROM_INFO|0x00", magicNumFields)
+
+	// Vendor Extension (0xFD)
+	vendorExtFields := map[string]interface{}{
+		"Name":  "Vendor Extension",
+		"Value": "Ext-Data",
+	}
+	stateClient.HSet(ctx, "EEPROM_INFO|0xFD", vendorExtFields)
+	configClient.HSet(ctx, "EEPROM_INFO|0xFD", vendorExtFields)
+
+	// 3. Setup gNMI Client
+	tlsConfig := &tls.Config{InsecureSkipVerify: true}
+	opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
+	targetAddr := "127.0.0.1:8081"
+	conn, err := grpc.Dial(targetAddr, opts...)
+	if err != nil {
+		t.Fatalf("Dialing to %q failed: %v", targetAddr, err)
+	}
+	defer conn.Close()
+	gClient := pb.NewGNMIClient(conn)
+
+	// 4. Define Test Scenarios
+	tds := []struct {
+		desc        string
+		pathTarget  string
+		textPbPath  string
+		timeout     time.Duration
+		wantRetCode codes.Code
+		wantRespVal interface{}
+		valTest     bool
+	}{
+		// --- Top-Level List ---
+		{
+			desc:       "Get All Platform Components (Top-level ListAll)",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+                elem: <name: "openconfig-platform:components" >
+            `,
+			wantRetCode: codes.OK,
+			valTest:     false,
+		},
+		// --- Individual State Leaves ---
+		{
+			desc:       "Get System Eeprom State Name",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+                elem: <name: "openconfig-platform:components" >
+                elem: <name: "component" key:<key:"name" value:"eeprom" > >
+                elem: <name: "state" >
+                elem: <name: "name" >
+            `,
+			wantRetCode: codes.OK,
+			valTest:     false,
+		},
+		{
+			desc:       "Get System Eeprom State Location",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+                elem: <name: "openconfig-platform:components" >
+                elem: <name: "component" key:<key:"name" value:"eeprom" > >
+                elem: <name: "state" >
+                elem: <name: "location" >
+            `,
+			wantRetCode: codes.OK,
+			valTest:     false,
+		},
+		{
+			desc:       "Get System Eeprom State Empty",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+                elem: <name: "openconfig-platform:components" >
+                elem: <name: "component" key:<key:"name" value:"eeprom" > >
+                elem: <name: "state" >
+                elem: <name: "empty" >
+            `,
+			wantRetCode: codes.OK,
+			valTest:     false,
+		},
+		{
+			desc:       "Get System Eeprom State Removable",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+                elem: <name: "openconfig-platform:components" >
+                elem: <name: "component" key:<key:"name" value:"eeprom" > >
+                elem: <name: "state" >
+                elem: <name: "removable" >
+            `,
+			wantRetCode: codes.OK,
+			valTest:     false,
+		},
+		{
+			desc:       "Get System Eeprom State Oper Status",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+                elem: <name: "openconfig-platform:components" >
+                elem: <name: "component" key:<key:"name" value:"eeprom" > >
+                elem: <name: "state" >
+                elem: <name: "oper-status" >
+            `,
+			wantRetCode: codes.OK,
+			valTest:     false,
+		},
+		{
+			desc:       "Get System Eeprom State ID (Product Name)",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+                elem: <name: "openconfig-platform:components" >
+                elem: <name: "component" key:<key:"name" value:"eeprom" > >
+                elem: <name: "state" >
+                elem: <name: "id" >
+            `,
+			wantRetCode: codes.OK,
+			valTest:     false,
+		},
+		{
+			desc:       "Get System Eeprom State Part Number",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+                elem: <name: "openconfig-platform:components" >
+                elem: <name: "component" key:<key:"name" value:"eeprom" > >
+                elem: <name: "state" >
+                elem: <name: "part-no" >
+            `,
+			wantRetCode: codes.OK,
+			valTest:     false,
+		},
+		{
+			desc:       "Get System Eeprom State Serial Number",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+                elem: <name: "openconfig-platform:components" >
+                elem: <name: "component" key:<key:"name" value:"eeprom" > >
+                elem: <name: "state" >
+                elem: <name: "serial-no" >
+            `,
+			wantRetCode: codes.OK,
+			valTest:     false,
+		},
+		{
+			desc:       "Get System Eeprom State Mfg Date",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+                elem: <name: "openconfig-platform:components" >
+                elem: <name: "component" key:<key:"name" value:"eeprom" > >
+                elem: <name: "state" >
+                elem: <name: "mfg-date" >
+            `,
+			wantRetCode: codes.OK,
+			valTest:     false,
+		},
+		{
+			desc:       "Get System Eeprom State Hardware Version",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+                elem: <name: "openconfig-platform:components" >
+                elem: <name: "component" key:<key:"name" value:"eeprom" > >
+                elem: <name: "state" >
+                elem: <name: "hardware-version" >
+            `,
+			wantRetCode: codes.OK,
+			valTest:     false,
+		},
+		{
+			desc:       "Get System Eeprom State Description",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+                elem: <name: "openconfig-platform:components" >
+                elem: <name: "component" key:<key:"name" value:"eeprom" > >
+                elem: <name: "state" >
+                elem: <name: "description" >
+            `,
+			wantRetCode: codes.OK,
+			valTest:     false,
+		},
+		{
+			desc:       "Get System Eeprom State Mfg Name",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+                elem: <name: "openconfig-platform:components" >
+                elem: <name: "component" key:<key:"name" value:"eeprom" > >
+                elem: <name: "state" >
+                elem: <name: "mfg-name" >
+            `,
+			wantRetCode: codes.OK,
+			valTest:     false,
+		},
+		{
+			desc:       "Get System Eeprom State Software Version",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+                elem: <name: "openconfig-platform:components" >
+                elem: <name: "component" key:<key:"name" value:"eeprom" > >
+                elem: <name: "state" >
+                elem: <name: "software-version" >
+            `,
+			wantRetCode: codes.OK,
+			valTest:     false,
+		},
+		{
+			desc:       "Get Non-Existent Platform Component (Expect NotFound)",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+                elem: <name: "openconfig-platform:components" >
+                elem: <name: "component" key:<key:"name" value:"non_existent_comp" > >
+                elem: <name: "state" >
+            `,
+			wantRetCode: codes.NotFound,
+			valTest:     false,
+		},
+	}
+
+	// 5. Run Tests
+	for _, td := range tds {
+		t.Run(td.desc, func(t *testing.T) {
+			if td.timeout == 0 {
+				td.timeout = 10 * time.Second
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), td.timeout)
+			defer cancel()
+
+			runTestGet(t, ctx, gClient, td.pathTarget, td.textPbPath, td.wantRetCode, td.wantRespVal, td.valTest)
+		})
+	}
+	s.Stop()
+}
+
 // runTestGet requests a path from the server by Get grpc call, and compares if
 // the return code and response value are expected.
 func runTestGet(t *testing.T, ctx context.Context, gClient pb.GNMIClient, pathTarget string,

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -486,6 +486,291 @@ func TestGnmiGetInterfaceCountersVPath(t *testing.T) {
 	}
 }
 
+func TestGnmiGetPlatformSysEepromComponents(t *testing.T) {
+	// 1. Start gNMI server
+	freePort := getFreePort(t)
+	s := createServer(t, freePort)
+	go runServer(t, s)
+
+	prepareDbTranslib(t)
+
+	// 2. Setup gNMI Client
+	targetAddr := fmt.Sprintf("127.0.0.1:%d", s.config.Port)
+	tlsConfig := &tls.Config{InsecureSkipVerify: true}
+	opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
+	conn, err := grpc.Dial(targetAddr, opts...)
+	if err != nil {
+		t.Fatalf("Dialing to %q failed: %v", targetAddr, err)
+	}
+	defer conn.Close()
+	gClient := pb.NewGNMIClient(conn)
+
+	type EepromState struct {
+		Description     string `json:"description"`
+		Empty           bool   `json:"empty"`
+		HardwareVersion string `json:"hardware-version"`
+		ID              string `json:"id"`
+		Location        string `json:"location"`
+		MfgDate         string `json:"mfg-date"`
+		MfgName         string `json:"mfg-name"`
+		Name            string `json:"name"`
+		OperStatus      string `json:"oper-status"`
+		PartNo          string `json:"part-no"`
+		Removable       bool   `json:"removable"`
+		SerialNo        string `json:"serial-no"`
+		SoftwareVersion string `json:"software-version"`
+	}
+
+	type EepromResp struct {
+		State EepromState `json:"openconfig-platform:state"`
+	}
+
+	var eepromVal EepromResp
+	eepromVal.State = EepromState{
+		Description:     "x86_64-dell_z9100_c2538-r0",
+		Empty:           false,
+		HardwareVersion: "HW-v1.0",
+		ID:              "Z9100ON",
+		Location:        "Slot 1",
+		MfgDate:         "2026-01-01",
+		MfgName:         "Test-Manufacturer",
+		Name:            "System Eeprom",
+		OperStatus:      "openconfig-platform-types:ACTIVE",
+		PartNo:          "PN-12345",
+		Removable:       false,
+		SerialNo:        "SN-987654321",
+		SoftwareVersion: "SW-v2.0",
+	}
+
+	// 2. CONVERT TO JSON BYTES (This prevents the panic)
+	eepromBytes, err := json.Marshal(eepromVal)
+	if err != nil {
+		t.Fatalf("Failed to marshal eepromVal: %v", err)
+	}
+
+	// 3. Define Test Scenarios
+	var emptyRespVal interface{}
+	tds := []struct {
+		desc        string
+		pathTarget  string
+		textPbPath  string
+		timeout     time.Duration
+		wantRetCode codes.Code
+		wantRespVal interface{}
+		valTest     bool
+	}{
+		// EEPROM Data
+		{
+			desc:       "Get System Eeprom State Container",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+				elem: <name: "openconfig-platform:components" >
+				elem: <name: "component" key:<key:"name" value:"System Eeprom" > >
+				elem: <name: "state" >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: eepromBytes,
+			valTest:     true,
+		},
+		// --- Individual State Leaves ---
+		{
+			desc:       "Get System Eeprom State Name",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+				elem: <name: "openconfig-platform:components" >
+				elem: <name: "component" key:<key:"name" value:"System Eeprom" > >
+				elem: <name: "state" >
+				elem: <name: "name" >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: emptyRespVal,
+			valTest:     true,
+		},
+		{
+			desc:       "Get System Eeprom State Location",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+				elem: <name: "openconfig-platform:components" >
+				elem: <name: "component" key:<key:"name" value:"System Eeprom" > >
+				elem: <name: "state" >
+				elem: <name: "location" >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: emptyRespVal,
+			valTest:     true,
+		},
+		{
+			desc:       "Get System Eeprom State Empty",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+				elem: <name: "openconfig-platform:components" >
+				elem: <name: "component" key:<key:"name" value:"System Eeprom" > >
+				elem: <name: "state" >
+				elem: <name: "empty" >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: emptyRespVal,
+			valTest:     true,
+		},
+		{
+			desc:       "Get System Eeprom State Removable",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+				elem: <name: "openconfig-platform:components" >
+				elem: <name: "component" key:<key:"name" value:"System Eeprom" > >
+				elem: <name: "state" >
+				elem: <name: "removable" >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: emptyRespVal,
+			valTest:     true,
+		},
+		{
+			desc:       "Get System Eeprom State Oper Status",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+				elem: <name: "openconfig-platform:components" >
+				elem: <name: "component" key:<key:"name" value:"System Eeprom" > >
+				elem: <name: "state" >
+				elem: <name: "oper-status" >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: emptyRespVal,
+			valTest:     true,
+		},
+		{
+			desc:       "Get System Eeprom State ID (Product Name)",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+				elem: <name: "openconfig-platform:components" >
+				elem: <name: "component" key:<key:"name" value:"System Eeprom" > >
+				elem: <name: "state" >
+				elem: <name: "id" >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: emptyRespVal,
+			valTest:     true,
+		},
+		{
+			desc:       "Get System Eeprom State Part Number",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+				elem: <name: "openconfig-platform:components" >
+				elem: <name: "component" key:<key:"name" value:"System Eeprom" > >
+				elem: <name: "state" >
+				elem: <name: "part-no" >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: emptyRespVal,
+			valTest:     true,
+		},
+		{
+			desc:       "Get System Eeprom State Serial Number",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+				elem: <name: "openconfig-platform:components" >
+				elem: <name: "component" key:<key:"name" value:"System Eeprom" > >
+				elem: <name: "state" >
+				elem: <name: "serial-no" >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: emptyRespVal,
+			valTest:     true,
+		},
+		{
+			desc:       "Get System Eeprom State Mfg Date",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+				elem: <name: "openconfig-platform:components" >
+				elem: <name: "component" key:<key:"name" value:"System Eeprom" > >
+				elem: <name: "state" >
+				elem: <name: "mfg-date" >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: emptyRespVal,
+			valTest:     true,
+		},
+		{
+			desc:       "Get System Eeprom State Hardware Version",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+				elem: <name: "openconfig-platform:components" >
+				elem: <name: "component" key:<key:"name" value:"System Eeprom" > >
+				elem: <name: "state" >
+				elem: <name: "hardware-version" >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: emptyRespVal,
+			valTest:     true,
+		},
+		{
+			desc:       "Get System Eeprom State Description",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+				elem: <name: "openconfig-platform:components" >
+				elem: <name: "component" key:<key:"name" value:"System Eeprom" > >
+				elem: <name: "state" >
+				elem: <name: "description" >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: emptyRespVal,
+			valTest:     true,
+		},
+		{
+			desc:       "Get System Eeprom State Mfg Name",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+				elem: <name: "openconfig-platform:components" >
+				elem: <name: "component" key:<key:"name" value:"System Eeprom" > >
+				elem: <name: "state" >
+				elem: <name: "mfg-name" >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: emptyRespVal,
+			valTest:     true,
+		},
+		{
+			desc:       "Get System Eeprom State Software Version",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+				elem: <name: "openconfig-platform:components" >
+				elem: <name: "component" key:<key:"name" value:"System Eeprom" > >
+				elem: <name: "state" >
+				elem: <name: "software-version" >
+			`,
+			wantRetCode: codes.OK,
+			wantRespVal: emptyRespVal,
+			valTest:     true,
+		},
+		{
+			desc:       "Get Non-Existent Platform Component (Expect NotFound)",
+			pathTarget: "OC_YANG",
+			textPbPath: `
+				elem: <name: "openconfig-platform:components" >
+				elem: <name: "component" key:<key:"name" value:"non_existent_comp" > >
+				elem: <name: "state" >
+			`,
+			wantRetCode: codes.NotFound,
+			wantRespVal: emptyRespVal,
+			valTest:     true,
+		},
+	}
+
+	// 5. Run Tests
+	for _, td := range tds {
+		t.Run(td.desc, func(t *testing.T) {
+			if td.timeout == 0 {
+				td.timeout = 10 * time.Second
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), td.timeout)
+			defer cancel()
+
+			runTestGet(t, ctx, gClient, td.pathTarget, td.textPbPath, td.wantRetCode, td.wantRespVal, td.valTest)
+		})
+	}
+	s.Stop()
+}
+
 // runTestGet requests a path from the server by Get grpc call, and compares if
 // the return code and response value are expected.
 func runTestGet(t *testing.T, ctx context.Context, gClient pb.GNMIClient, pathTarget string,


### PR DESCRIPTION
This PR is created to add a component test case for Open Config platform components Eeprom Model.

### **Base PR :**  
**System EEPROM Support:**
[sonic-mgmt-common/pull/236](https://github.com/sonic-net/sonic-mgmt-common/pull/236)

### **Test logs:**
=== RUN   TestGnmiGetPlatformSysEepromComponents
=== RUN   TestGnmiGetPlatformSysEepromComponents/Get_System_Eeprom_State_Container
    server_test.go:4930: [TestGnmiGetPlatformSysEepromComponents/Get_System_Eeprom_State_Container] gotVal:
        {
          "openconfig-platform:state": {
            "description": "x86_64-dell_z9100_c2538-r0",
            "empty": false,
            "hardware-version": "HW-v1.0",
            "id": "Z9100ON",
            "location": "Slot 1",
            "mfg-date": "2026-01-01",
            "mfg-name": "Test-Manufacturer",
            "name": "System Eeprom",
            "oper-status": "openconfig-platform-types:ACTIVE",
            "part-no": "PN-12345",
            "removable": false,
            "serial-no": "SN-987654321",
            "software-version": "SW-v2.0"
          }
        }
=== RUN   TestGnmiGetPlatformSysEepromComponents/Get_System_Eeprom_State_Name
    server_test.go:4930: [TestGnmiGetPlatformSysEepromComponents/Get_System_Eeprom_State_Name] gotVal:
        {
          "openconfig-platform:name": "System Eeprom"
        }
=== RUN   TestGnmiGetPlatformSysEepromComponents/Get_System_Eeprom_State_Location
    server_test.go:4930: [TestGnmiGetPlatformSysEepromComponents/Get_System_Eeprom_State_Location] gotVal:
        {
          "openconfig-platform:location": "Slot 1"
        }
=== RUN   TestGnmiGetPlatformSysEepromComponents/Get_System_Eeprom_State_Empty
    server_test.go:4930: [TestGnmiGetPlatformSysEepromComponents/Get_System_Eeprom_State_Empty] gotVal:
        {
          "openconfig-platform:empty": false
        }
=== RUN   TestGnmiGetPlatformSysEepromComponents/Get_System_Eeprom_State_Removable
    server_test.go:4930: [TestGnmiGetPlatformSysEepromComponents/Get_System_Eeprom_State_Removable] gotVal:
        {
          "openconfig-platform:removable": false
        }
=== RUN   TestGnmiGetPlatformSysEepromComponents/Get_System_Eeprom_State_Oper_Status
    server_test.go:4930: [TestGnmiGetPlatformSysEepromComponents/Get_System_Eeprom_State_Oper_Status] gotVal:
        {
          "openconfig-platform:oper-status": "openconfig-platform-types:ACTIVE"
        }
=== RUN   TestGnmiGetPlatformSysEepromComponents/Get_System_Eeprom_State_ID_(Product_Name)
    server_test.go:4930: [TestGnmiGetPlatformSysEepromComponents/Get_System_Eeprom_State_ID_(Product_Name)] gotVal:
        {
          "openconfig-platform:id": "Z9100ON"
        }
=== RUN   TestGnmiGetPlatformSysEepromComponents/Get_System_Eeprom_State_Part_Number
    server_test.go:4930: [TestGnmiGetPlatformSysEepromComponents/Get_System_Eeprom_State_Part_Number] gotVal:
        {
          "openconfig-platform:part-no": "PN-12345"
        }
=== RUN   TestGnmiGetPlatformSysEepromComponents/Get_System_Eeprom_State_Serial_Number
    server_test.go:4930: [TestGnmiGetPlatformSysEepromComponents/Get_System_Eeprom_State_Serial_Number] gotVal:
        {
          "openconfig-platform:serial-no": "SN-987654321"
        }
=== RUN   TestGnmiGetPlatformSysEepromComponents/Get_System_Eeprom_State_Mfg_Date
    server_test.go:4930: [TestGnmiGetPlatformSysEepromComponents/Get_System_Eeprom_State_Mfg_Date] gotVal:
        {
          "openconfig-platform:mfg-date": "2026-01-01"
        }
=== RUN   TestGnmiGetPlatformSysEepromComponents/Get_System_Eeprom_State_Hardware_Version
    server_test.go:4930: [TestGnmiGetPlatformSysEepromComponents/Get_System_Eeprom_State_Hardware_Version] gotVal:
        {
          "openconfig-platform:hardware-version": "A00"
        }
=== RUN   TestGnmiGetPlatformSysEepromComponents/Get_System_Eeprom_State_Description
    server_test.go:4930: [TestGnmiGetPlatformSysEepromComponents/Get_System_Eeprom_State_Description] gotVal:
        {
          "openconfig-platform:description": "x86_64-dell_z9100_c2538-r0"
        }
=== RUN   TestGnmiGetPlatformSysEepromComponents/Get_System_Eeprom_State_Mfg_Name
    server_test.go:4930: [TestGnmiGetPlatformSysEepromComponents/Get_System_Eeprom_State_Mfg_Name] gotVal:
        {
          "openconfig-platform:mfg-name": "Test-Manufacturer"
        }
=== RUN   TestGnmiGetPlatformSysEepromComponents/Get_System_Eeprom_State_Software_Version
    server_test.go:4930: [TestGnmiGetPlatformSysEepromComponents/Get_System_Eeprom_State_Software_Version] gotVal:
        {
          "openconfig-platform:software-version": "SW-v2.0"
        }
=== RUN   TestGnmiGetPlatformSysEepromComponents/Get_Non-Existent_Platform_Component_(Expect_NotFound)
    server_test.go:4930: [TestGnmiGetPlatformSysEepromComponents/Get_Non-Existent_Platform_Component_(Expect_NotFound)] gotVal:
        null
--- PASS: TestGnmiGetPlatformSysEepromComponents (2.14s)
    --- PASS: TestGnmiGetPlatformSysEepromComponents/Get_System_Eeprom_State_Container (0.05s)
    --- PASS: TestGnmiGetPlatformSysEepromComponents/Get_System_Eeprom_State_Name (0.03s)
    --- PASS: TestGnmiGetPlatformSysEepromComponents/Get_System_Eeprom_State_Location (0.03s)
    --- PASS: TestGnmiGetPlatformSysEepromComponents/Get_System_Eeprom_State_Empty (0.03s)
    --- PASS: TestGnmiGetPlatformSysEepromComponents/Get_System_Eeprom_State_Removable (0.03s)
    --- PASS: TestGnmiGetPlatformSysEepromComponents/Get_System_Eeprom_State_Oper_Status (0.03s)
    --- PASS: TestGnmiGetPlatformSysEepromComponents/Get_System_Eeprom_State_ID_(Product_Name) (0.03s)
    --- PASS: TestGnmiGetPlatformSysEepromComponents/Get_System_Eeprom_State_Part_Number (0.03s)
    --- PASS: TestGnmiGetPlatformSysEepromComponents/Get_System_Eeprom_State_Serial_Number (0.03s)
    --- PASS: TestGnmiGetPlatformSysEepromComponents/Get_System_Eeprom_State_Mfg_Date (0.03s)
    --- PASS: TestGnmiGetPlatformSysEepromComponents/Get_System_Eeprom_State_Hardware_Version (0.03s)
    --- PASS: TestGnmiGetPlatformSysEepromComponents/Get_System_Eeprom_State_Description (0.03s)
    --- PASS: TestGnmiGetPlatformSysEepromComponents/Get_System_Eeprom_State_Mfg_Name (0.03s)
    --- PASS: TestGnmiGetPlatformSysEepromComponents/Get_System_Eeprom_State_Software_Version (0.03s)
    --- PASS: TestGnmiGetPlatformSysEepromComponents/Get_Non-Existent_Platform_Component_(Expect_NotFound) (0.01s)
PASS
