### PR TITLE
[202511] Prevent Redis updates from starving gNMI SAMPLE intervals

### DIFF
--- a/sonic_data_client/db_client.go
+++ b/sonic_data_client/db_client.go
@@ -1533,14 +1533,11 @@ func dbTableKeySubscribe(c *DbClient, gnmiPath *gnmipb.Path, interval time.Durat
 	// Listen on updates from tables.
 	// Depending on the interval, send the updates every interval or on change only.
 	intervalTicker := make(<-chan time.Time)
+	if interval > 0 {
+		intervalTicker = GetIntervalTicker()(interval)
+	}
+
 	for {
-
-		// The interval ticker ticks only when the interval is non-zero.
-		// Otherwise (e.g. on-change mode) it would never tick.
-		if interval > 0 {
-			intervalTicker = GetIntervalTicker()(interval)
-		}
-
 		select {
 		case updatedTable := <-updateChannel:
 			log.V(6).Infof("update received: %v", updatedTable)
@@ -1569,6 +1566,9 @@ func dbTableKeySubscribe(c *DbClient, gnmiPath *gnmipb.Path, interval time.Durat
 				msiAll = make(map[string]interface{})
 				log.V(6).Infof("msiAll cleared: %v", len(msiAll))
 			}
+
+			// Recreate the ticker for the next interval
+			intervalTicker = GetIntervalTicker()(interval)
 
 		case <-c.channel:
 			log.V(1).Infof("Stopping dbTableKeySubscribe routine for %v ", c.pathG2S)

--- a/sonic_data_client/mixed_db_client.go
+++ b/sonic_data_client/mixed_db_client.go
@@ -2117,13 +2117,10 @@ func (c *MixedDbClient) dbTableKeySubscribe(gnmiPath *gnmipb.Path, interval time
 	// Listen on updates from tables.
 	// Depending on the interval, send the updates every interval or on change only.
 	intervalTicker := make(<-chan time.Time)
+	if interval > 0 {
+		intervalTicker = GetIntervalTicker()(interval)
+	}
 	for {
-
-		// The interval ticker ticks only when the interval is non-zero.
-		// Otherwise (e.g. on-change mode) it would never tick.
-		if interval > 0 {
-			intervalTicker = GetIntervalTicker()(interval)
-		}
 
 		select {
 		case updatedTable := <-updateChannel:
@@ -2153,7 +2150,7 @@ func (c *MixedDbClient) dbTableKeySubscribe(gnmiPath *gnmipb.Path, interval time
 				msiAll = make(map[string]interface{})
 				log.V(6).Infof("msiAll cleared: %v", len(msiAll))
 			}
-
+			intervalTicker = GetIntervalTicker()(interval)
 		case <-c.channel:
 			log.V(1).Infof("Stopping dbTableKeySubscribe routine for %v ", c.pathG2S)
 			return


### PR DESCRIPTION
#### Why I did it

The 202511 gNMI server recreates the SAMPLE interval ticker whenever Redis publishes an update. Frequent updates can continually reset the ticker, preventing periodic SAMPLE responses until the client deadline expires.

This backports the fix from #541 to the 202511 release branch.

#### How I did it

Create the interval ticker before entering each subscription loop. Recreate it only after an interval tick is consumed, rather than after every Redis update.

#### How to verify it

Validated on a Cisco-8102-C64 physical testbed running `SONiC.20251110.46` with:

`gnmi/test_gnmi.py::test_gnmi_subscribe_sample`

- Before the fix: STATE_DB received 2 of 6 expected responses and ended with `DEADLINE_EXCEEDED`.
- With this backport: STATE_DB and COUNTERS_DB each received all 6 expected responses, including five periodic samples.
- Negative control: rebuilding after reverting this commit reproduced 2 of 6 responses and `DEADLINE_EXCEEDED`.

#### Which release branch to backport (provide reason below if selected)

- [x] 202511

The defect is present in the current 202511 sonic-gnmi branch and in `SONiC.20251110.46`.

#### Description for the changelog

Prevent Redis update churn from starving gNMI SAMPLE interval responses.

#### Link to config_db schema for YANG module changes

N/A

#### A picture of a cute animal (not mandatory but encouraged)

N/A
