### PR TITLE
dialout: default report_interval to 5000ms, not 5000ns

### DIFF
--- a/dialout/dialout_client/dialout_client.go
+++ b/dialout/dialout_client/dialout_client.go
@@ -597,7 +597,7 @@ func processTelemetryClientConfig(ctx context.Context, redisDb *redis.Client, ke
 			// TODO: start one subscription publish routine for this request
 			// Only start routine when DestGrp2ClientSubMap is not empty, or ...?
 			cs := clientSubscription{
-				interval: 5000, // default to 5000 milliseconds
+				interval: 5000 * time.Millisecond, // default to 5000 milliseconds
 				name:     name,
 				cancel:   cancel,
 			}


### PR DESCRIPTION
#### Why I did it

Fixes #759.

A `TELEMETRY_CLIENT|Subscription_<name>` row that omits the optional `report_interval` field gets a default publish interval of **5 microseconds** instead of the intended **5000 milliseconds**: the fallback assigns the bare literal `5000` to `clientSubscription.interval`, which is a `time.Duration` (nanoseconds), so a `periodic` dial-out subscription publishes in a busy loop. Only the default is broken — explicitly configured values are converted with `* time.Millisecond` and behave correctly.

Measured with identical periodic subscriptions (`path_target COUNTERS_DB`, `paths COUNTERS_PORT_NAME_MAP`) against a live `gNMIDialOut` collector, before this fix:

| `report_interval` in CONFIG_DB | parsed interval | messages received by collector in 3s |
|---|---|---|
| omitted (default) | 5µs | 27,180 (~9,000/s, busy loop) |
| `"5000"` (explicit) | 5s | 1 |

After this fix, both rows behave identically (5s, one message per interval).

#### How I did it

One-token fix: `interval: 5000 * time.Millisecond`, so the omitted-field default behaves identically to `report_interval="5000"`.

#### How to verify it

Run the dialout client with two identical periodic subscriptions — one omitting `report_interval`, one setting `"5000"` explicitly — against a live `gNMIDialOut` collector: before the fix the omitted-field subscription floods the collector (~9,000 msgs/s) while the explicit one publishes every 5s; after the fix both publish every 5s. The end-to-end dial-out test suite proposed in sonic-net/sonic-mgmt#27216 includes a per-stream cadence guard that will catch a regression here once its explicit-`report_interval` workaround is removed.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] 202511
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): #759
Failure type: day-one issue (the default has assigned nanoseconds since the dialout client was introduced)

#### Tested branch

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] 202511
- [x] 202605
- [ ] N/A

#### Test result

Component-level verification, identical procedure per branch: `dialout_client_cli` built from the exact branch source (stock, then with this one-token fix applied), run with `-insecure` against redis + a live `gNMIDialOut` TLS collector; a `periodic` subscription (`path_target COUNTERS_DB`, `paths COUNTERS_PORT_NAME_MAP`) written to `TELEMETRY_CLIENT` with `report_interval` **omitted**, plus a control run with explicit `report_interval="5000"`. The buggy default line is byte-identical on every branch (202505/202511: `dialout_client.go:580`, 202605: `:582`, master: `:600`).

| branch | stock, omitted (3s window) | fixed, omitted (12s window) | fixed, explicit `"5000"` (12s window) |
|---|---|---|---|
| 202505 | 43,142 msgs (~14,000/s busy loop) | 3 msgs (5s cadence) | 3 msgs |
| 202511 | 43,787 msgs (~14,000/s busy loop) | 3 msgs (5s cadence) | 3 msgs |
| 202605 | 42,463 msgs (~14,000/s busy loop) | 3 msgs (5s cadence) | 3 msgs |
| master | 27,180 msgs in 3s (~9,000/s, earlier run) | 5s cadence | 5s cadence |

On every branch the fix makes the omitted-field default behave identically to the explicit `"5000"` control.

#### Description for the changelog

Fix dialout client default report_interval: omitted field now defaults to 5000ms instead of 5000ns (busy loop).

#### Link to config_db schema for YANG module changes

N/A — no YANG/schema change; behavior of an omitted optional field only.

