### PR TITLE
convert stream SAMPLE updates_only flag to suppress_redundant

### DIFF
--- a/gnmi_server/chassis_state_db_test.go
+++ b/gnmi_server/chassis_state_db_test.go
@@ -225,8 +225,7 @@ func TestChassisStateDBSample(t *testing.T) {
 						SubMode:        pb.SubscriptionMode_SAMPLE,
 						SampleInterval: 0,
 					},
-				},
-				false),
+				}),
 			wantNoti: []client.Notification{
 				client.Connected{},
 				client.Update{Path: []string{"CHASSIS_STATE_DB", "DPU_STATE"}, TS: time.Unix(0, 200), Val: dpuStateJson},

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -1362,9 +1362,10 @@ func prepareDbTranslib(t *testing.T) {
 
 // subscriptionQuery represent the input to create an gnmi.Subscription instance.
 type subscriptionQuery struct {
-	Query          []string
-	SubMode        pb.SubscriptionMode
-	SampleInterval uint64
+	Query             []string
+	SubMode           pb.SubscriptionMode
+	SampleInterval    uint64
+	SuppressRedundant bool
 }
 
 func pathToString(q client.Path) string {
@@ -1379,28 +1380,26 @@ func pathToString(q client.Path) string {
 }
 
 // createQuery creates a client.Query with the given args. It assigns query.SubReq.
-func createQuery(subListMode pb.SubscriptionList_Mode, target string, queries []subscriptionQuery, updatesOnly bool) (*client.Query, error) {
+func createQuery(subListMode pb.SubscriptionList_Mode, target string, queries []subscriptionQuery) (*client.Query, error) {
 	s := &pb.SubscribeRequest_Subscribe{
 		Subscribe: &pb.SubscriptionList{
 			Mode:   subListMode,
 			Prefix: &pb.Path{Target: target},
 		},
 	}
-	if updatesOnly {
-		s.Subscribe.UpdatesOnly = true
-	}
 
 	for _, qq := range queries {
 		pp, err := ygot.StringToPath(pathToString(qq.Query), ygot.StructuredPath, ygot.StringSlicePath)
 		if err != nil {
-			return nil, fmt.Errorf("invalid query path %q: %v", qq, err)
+			return nil, fmt.Errorf("invalid query path %q: %v", qq.Query, err)
 		}
 		s.Subscribe.Subscription = append(
 			s.Subscribe.Subscription,
 			&pb.Subscription{
-				Path:           pp,
-				Mode:           qq.SubMode,
-				SampleInterval: qq.SampleInterval,
+				Path:              pp,
+				Mode:              qq.SubMode,
+				SampleInterval:    qq.SampleInterval,
+				SuppressRedundant: qq.SuppressRedundant,
 			})
 	}
 
@@ -1411,8 +1410,8 @@ func createQuery(subListMode pb.SubscriptionList_Mode, target string, queries []
 }
 
 // createQueryOrFail creates a query, in case of a failure it fails the test.
-func createQueryOrFail(t *testing.T, subListMode pb.SubscriptionList_Mode, target string, queries []subscriptionQuery, updatesOnly bool) client.Query {
-	q, err := createQuery(subListMode, target, queries, updatesOnly)
+func createQueryOrFail(t *testing.T, subListMode pb.SubscriptionList_Mode, target string, queries []subscriptionQuery) client.Query {
+	q, err := createQuery(subListMode, target, queries)
 	if err != nil {
 		t.Fatalf("failed to create query: %v", err)
 	}
@@ -1430,8 +1429,7 @@ func createEventsQuery(t *testing.T, paths ...string) client.Query {
 				Query:   paths,
 				SubMode: pb.SubscriptionMode_ON_CHANGE,
 			},
-		},
-		false)
+		})
 }
 
 func createStateDbQueryOnChangeMode(t *testing.T, paths ...string) client.Query {
@@ -1443,8 +1441,7 @@ func createStateDbQueryOnChangeMode(t *testing.T, paths ...string) client.Query 
 				Query:   paths,
 				SubMode: pb.SubscriptionMode_ON_CHANGE,
 			},
-		},
-		false)
+		})
 }
 
 // createCountersDbQueryOnChangeMode creates a query with ON_CHANGE mode.
@@ -1457,8 +1454,7 @@ func createCountersDbQueryOnChangeMode(t *testing.T, paths ...string) client.Que
 				Query:   paths,
 				SubMode: pb.SubscriptionMode_ON_CHANGE,
 			},
-		},
-		false)
+		})
 }
 
 // createRatesTableSetUpdate creates a HSET request on the RATES table.
@@ -1474,18 +1470,24 @@ func createRatesTableSetUpdate(tableKey string, fieldName string, fieldValue str
 }
 
 // createCountersDbQuerySampleMode creates a query with SAMPLE mode.
-func createCountersDbQuerySampleMode(t *testing.T, interval time.Duration, updateOnly bool, paths ...string) client.Query {
+func createCountersDbQuerySampleMode(t *testing.T, interval time.Duration, suppressRedundant bool, paths ...string) client.Query {
 	return createQueryOrFail(t,
 		pb.SubscriptionList_STREAM,
 		"COUNTERS_DB",
 		[]subscriptionQuery{
 			{
-				Query:          paths,
-				SubMode:        pb.SubscriptionMode_SAMPLE,
-				SampleInterval: uint64(interval.Nanoseconds()),
+				Query:             paths,
+				SubMode:           pb.SubscriptionMode_SAMPLE,
+				SampleInterval:    uint64(interval.Nanoseconds()),
+				SuppressRedundant: suppressRedundant,
 			},
-		},
-		updateOnly)
+		})
+}
+
+// withUpdatesOnly sets the SubscriptionList-level updates_only flag on the query.
+func withUpdatesOnly(q client.Query) client.Query {
+	q.SubReq.GetSubscribe().UpdatesOnly = true
+	return q
 }
 
 // createCountersTableSetUpdate creates a HSET request on the COUNTERS table.
@@ -3928,7 +3930,7 @@ func runTestSubscribe(t *testing.T, namespace string) {
 			},
 		},
 		{
-			desc:              "(updates only) sample stream query for table key Ethernet* with new test_field field on Ethernet68",
+			desc:              "(suppress_redundant) sample stream query for table key Ethernet* with new test_field field on Ethernet68",
 			q:                 createCountersDbQuerySampleMode(t, 0, true, "COUNTERS", "Ethernet*"),
 			generateIntervals: true,
 			updates: []tablePathValue{
@@ -3943,6 +3945,27 @@ func runTestSubscribe(t *testing.T, namespace string) {
 				client.Update{Path: []string{"COUNTERS_DB", "COUNTERS", "Ethernet*"}, TS: time.Unix(0, 200), Val: map[string]interface{}{}}, //empty update
 				client.Update{Path: []string{"COUNTERS_DB", "COUNTERS", "Ethernet*"}, TS: time.Unix(0, 200), Val: countersEtherneWildcardJsonUpdate},
 				client.Update{Path: []string{"COUNTERS_DB", "COUNTERS", "Ethernet*"}, TS: time.Unix(0, 200), Val: map[string]interface{}{}}, //empty update
+			},
+		},
+		{
+			// updates_only must not trigger suppression; the full payload is sent
+			// on every interval. (Skip-initial-sync updates_only semantics are not
+			// implemented for this client.)
+			desc:              "(updates_only) sample stream query for table key Ethernet* sends full payload every interval",
+			q:                 withUpdatesOnly(createCountersDbQuerySampleMode(t, 0, false, "COUNTERS", "Ethernet*")),
+			generateIntervals: true,
+			updates: []tablePathValue{
+				createIntervalTickerUpdate(), // no value change but imitate interval ticker
+				createCountersTableSetUpdate("oid:0x1000000000039", "test_field", "test_value"),
+				createIntervalTickerUpdate(),
+			},
+			wantNoti: []client.Notification{
+				client.Connected{},
+				client.Update{Path: []string{"COUNTERS_DB", "COUNTERS", "Ethernet*"}, TS: time.Unix(0, 200), Val: countersEthernetWildcardJson},
+				client.Sync{},
+				client.Update{Path: []string{"COUNTERS_DB", "COUNTERS", "Ethernet*"}, TS: time.Unix(0, 200), Val: countersEthernetWildcardJson}, //full payload, not suppressed
+				client.Update{Path: []string{"COUNTERS_DB", "COUNTERS", "Ethernet*"}, TS: time.Unix(0, 200), Val: mergeStrMaps(countersEthernetWildcardJson, countersEtherneWildcardJsonUpdate)},
+				client.Update{Path: []string{"COUNTERS_DB", "COUNTERS", "Ethernet*"}, TS: time.Unix(0, 200), Val: mergeStrMaps(countersEthernetWildcardJson, countersEtherneWildcardJsonUpdate)}, //full payload again
 			},
 		},
 		/*
@@ -3979,6 +4002,27 @@ func runTestSubscribe(t *testing.T, namespace string) {
 			},
 		},
 		{
+			// Exercises the dbFieldMultiSubscribe path (field across multiple tables)
+			// with suppress_redundant: a change produces an update containing only
+			// the changed leaf, an unchanged interval produces an empty update.
+			// Note: this path re-reads the field from redis on each tick, so a
+			// no-change tick placed before the HSET entry would race with it.
+			desc:              "(suppress_redundant) sample stream query for table field Ethernet*/SAI_PORT_STAT_PFC_7_RX_PKTS with field value update",
+			q:                 createCountersDbQuerySampleMode(t, 0, true, "COUNTERS", "Ethernet*", "SAI_PORT_STAT_PFC_7_RX_PKTS"),
+			generateIntervals: true,
+			updates: []tablePathValue{
+				createCountersTableSetUpdate("oid:0x1000000000039", "SAI_PORT_STAT_PFC_7_RX_PKTS", "4"),
+				createIntervalTickerUpdate(), // no value change but imitate interval ticker
+			},
+			wantNoti: []client.Notification{
+				client.Connected{},
+				client.Update{Path: []string{"COUNTERS_DB", "COUNTERS", "Ethernet*", "SAI_PORT_STAT_PFC_7_RX_PKTS"}, TS: time.Unix(0, 200), Val: countersEthernetWildcardPfcJson},
+				client.Sync{},
+				client.Update{Path: []string{"COUNTERS_DB", "COUNTERS", "Ethernet*", "SAI_PORT_STAT_PFC_7_RX_PKTS"}, TS: time.Unix(0, 200), Val: singlePortPfcJsonUpdate},  //only the changed leaf
+				client.Update{Path: []string{"COUNTERS_DB", "COUNTERS", "Ethernet*", "SAI_PORT_STAT_PFC_7_RX_PKTS"}, TS: time.Unix(0, 200), Val: map[string]interface{}{}}, //empty update
+			},
+		},
+		{
 			desc:              "sample stream query for table key Ethernet*/Pfcwd with field value update",
 			generateIntervals: true,
 			q:                 createCountersDbQuerySampleMode(t, 0, false, "COUNTERS", "Ethernet*", "Pfcwd"),
@@ -3993,7 +4037,7 @@ func runTestSubscribe(t *testing.T, namespace string) {
 			},
 		},
 		{
-			desc:              "(update only) sample stream query for table key Ethernet*/Pfcwd with field value update",
+			desc:              "(suppress_redundant) sample stream query for table key Ethernet*/Pfcwd with field value update",
 			generateIntervals: true,
 			q:                 createCountersDbQuerySampleMode(t, 0, true, "COUNTERS", "Ethernet*", "Pfcwd"),
 			updates: []tablePathValue{

--- a/sonic_data_client/client_test.go
+++ b/sonic_data_client/client_test.go
@@ -505,7 +505,7 @@ func TestSubscribeInternal(t *testing.T) {
 		client.w = &w
 		client.w.Add(1)
 		client.synced.Add(1)
-		client.streamSampleSubscription(&sub, false)
+		client.streamSampleSubscription(&sub)
 	}
 
 	// Test streamSampleSubscription
@@ -525,7 +525,7 @@ func TestSubscribeInternal(t *testing.T) {
 		client.synced.Add(1)
 		client.dbkey = swsscommon.NewSonicDBKey()
 		defer swsscommon.DeleteSonicDBKey(client.dbkey)
-		client.streamSampleSubscription(&sub, false)
+		client.streamSampleSubscription(&sub)
 	}
 
 	// Test dbFieldSubscribe

--- a/sonic_data_client/db_client.go
+++ b/sonic_data_client/db_client.go
@@ -249,7 +249,7 @@ func (c *DbClient) StreamRun(q *queue.PriorityQueue, stop chan struct{}, w *sync
 			if subMode == gnmipb.SubscriptionMode_SAMPLE {
 				c.w.Add(1)      // wait group to indicate the streaming session is complete.
 				c.synced.Add(1) // wait group to indicate whether sync_response is sent.
-				go streamSampleSubscription(c, sub, subscribe.GetUpdatesOnly())
+				go streamSampleSubscription(c, sub)
 			} else if subMode == gnmipb.SubscriptionMode_ON_CHANGE {
 				c.w.Add(1)
 				c.synced.Add(1)
@@ -289,13 +289,13 @@ func streamOnChangeSubscription(c *DbClient, gnmiPath *gnmipb.Path) {
 			go dbFieldSubscribe(c, gnmiPath, true, time.Millisecond*200)
 		}
 	} else {
-		// sample interval and update only parameters are not applicable
+		// sample interval and suppress redundant parameters are not applicable
 		go dbTableKeySubscribe(c, gnmiPath, 0, true)
 	}
 }
 
 // streamSampleSubscription implements Subscription "SAMPLE STREAM" mode
-func streamSampleSubscription(c *DbClient, sub *gnmipb.Subscription, updateOnly bool) {
+func streamSampleSubscription(c *DbClient, sub *gnmipb.Subscription) {
 	samplingInterval, err := validateSampleInterval(sub)
 	if err != nil {
 		enqueueFatalMsg(c, err.Error())
@@ -309,12 +309,12 @@ func streamSampleSubscription(c *DbClient, sub *gnmipb.Subscription, updateOnly 
 	log.V(2).Infof("streamSampleSubscription gnmiPath: %v", gnmiPath)
 	if len(tblPaths) > 0 && tblPaths[0].field != "" {
 		if len(tblPaths) > 1 {
-			dbFieldMultiSubscribe(c, gnmiPath, false, samplingInterval, updateOnly)
+			dbFieldMultiSubscribe(c, gnmiPath, false, samplingInterval, sub.GetSuppressRedundant())
 		} else {
 			dbFieldSubscribe(c, gnmiPath, false, samplingInterval)
 		}
 	} else {
-		dbTableKeySubscribe(c, gnmiPath, samplingInterval, updateOnly)
+		dbTableKeySubscribe(c, gnmiPath, samplingInterval, sub.GetSuppressRedundant())
 	}
 }
 
@@ -1165,9 +1165,9 @@ func putFatalMsg(q *queue.PriorityQueue, msg string) {
 // dbFieldMultiSubscribe would read a field from multiple tables and put to output queue.
 // It handles queries like "COUNTERS/Ethernet*/xyz" where the path translates to a field  in multiple tables.
 // For SAMPLE mode, it would send periodically regardless of change.
-// However, if `updateOnly` is true, the payload would include only the changed fields.
+// However, if `suppressRedundant` is true, the payload would include only the changed fields.
 // For ON_CHANGE mode, it would send only if the value has changed since the last update.
-func dbFieldMultiSubscribe(c *DbClient, gnmiPath *gnmipb.Path, onChange bool, interval time.Duration, updateOnly bool) {
+func dbFieldMultiSubscribe(c *DbClient, gnmiPath *gnmipb.Path, onChange bool, interval time.Duration, suppressRedundant bool) {
 	defer c.w.Done()
 
 	tblPaths := c.pathG2S[gnmiPath]
@@ -1201,7 +1201,7 @@ func dbFieldMultiSubscribe(c *DbClient, gnmiPath *gnmipb.Path, onChange bool, in
 
 			// This value was saved before and it hasn't changed since then
 			_, valueMapped := path2ValueMap[tblPath]
-			if (onChange || updateOnly) && valueMapped && val == path2ValueMap[tblPath] {
+			if (onChange || suppressRedundant) && valueMapped && val == path2ValueMap[tblPath] {
 				continue
 			}
 
@@ -1441,7 +1441,7 @@ func dbSingleTableKeySubscribe(c *DbClient, rsd redisSubData, updateChannel chan
 // dbTableKeySubscribe subscribes to tables using a table keys.
 // Handles queries like "COUNTERS/Ethernet0" or "COUNTERS/Ethernet*"
 // This function handles both ON_CHANGE and SAMPLE modes. "interval" being 0 is interpreted as ON_CHANGE mode.
-func dbTableKeySubscribe(c *DbClient, gnmiPath *gnmipb.Path, interval time.Duration, updateOnly bool) {
+func dbTableKeySubscribe(c *DbClient, gnmiPath *gnmipb.Path, interval time.Duration, suppressRedundant bool) {
 	defer c.w.Done()
 
 	tblPaths := c.pathG2S[gnmiPath]
@@ -1541,7 +1541,7 @@ func dbTableKeySubscribe(c *DbClient, gnmiPath *gnmipb.Path, interval time.Durat
 	signalSync()
 
 	// Clear the payload so that next time it will send only updates
-	if updateOnly {
+	if suppressRedundant {
 		msiAll = make(map[string]interface{})
 	}
 
@@ -1583,7 +1583,7 @@ func dbTableKeySubscribe(c *DbClient, gnmiPath *gnmipb.Path, interval time.Durat
 			}
 
 			// Clear the payload so that next time it will send only updates
-			if updateOnly {
+			if suppressRedundant {
 				msiAll = make(map[string]interface{})
 				log.V(6).Infof("msiAll cleared: %v", len(msiAll))
 			}

--- a/sonic_data_client/mixed_db_client.go
+++ b/sonic_data_client/mixed_db_client.go
@@ -1932,7 +1932,7 @@ func (c *MixedDbClient) StreamRun(q *queue.PriorityQueue, stop chan struct{}, w 
 			if subMode == gnmipb.SubscriptionMode_SAMPLE {
 				c.w.Add(1)      // wait group to indicate the streaming session is complete.
 				c.synced.Add(1) // wait group to indicate whether sync_response is sent.
-				go c.streamSampleSubscription(sub, subscribe.GetUpdatesOnly())
+				go c.streamSampleSubscription(sub)
 			} else if subMode == gnmipb.SubscriptionMode_ON_CHANGE {
 				c.w.Add(1)
 				c.synced.Add(1)
@@ -1975,13 +1975,13 @@ func (c *MixedDbClient) streamOnChangeSubscription(gnmiPath *gnmipb.Path) {
 	if tblPaths[0].field != "" {
 		go c.dbFieldSubscribe(gnmiPath, true, time.Millisecond*200)
 	} else {
-		// sample interval and update only parameters are not applicable
+		// sample interval and suppress redundant parameters are not applicable
 		go c.dbTableKeySubscribe(gnmiPath, 0, true)
 	}
 }
 
 // streamSampleSubscription implements Subscription "SAMPLE STREAM" mode
-func (c *MixedDbClient) streamSampleSubscription(sub *gnmipb.Subscription, updateOnly bool) {
+func (c *MixedDbClient) streamSampleSubscription(sub *gnmipb.Subscription) {
 	samplingInterval, err := validateSampleInterval(sub)
 	if err != nil {
 		putFatalMsg(c.q, err.Error())
@@ -2002,7 +2002,7 @@ func (c *MixedDbClient) streamSampleSubscription(sub *gnmipb.Subscription, updat
 	if tblPaths[0].field != "" {
 		c.dbFieldSubscribe(gnmiPath, false, samplingInterval)
 	} else {
-		c.dbTableKeySubscribe(gnmiPath, samplingInterval, updateOnly)
+		c.dbTableKeySubscribe(gnmiPath, samplingInterval, sub.GetSuppressRedundant())
 	}
 }
 
@@ -2190,7 +2190,7 @@ func (c *MixedDbClient) dbSingleTableKeySubscribe(rsd redisSubData, updateChanne
 // dbTableKeySubscribe subscribes to tables using a table keys.
 // Handles queries like "COUNTERS/Ethernet0" or "COUNTERS/Ethernet*"
 // This function handles both ON_CHANGE and SAMPLE modes. "interval" being 0 is interpreted as ON_CHANGE mode.
-func (c *MixedDbClient) dbTableKeySubscribe(gnmiPath *gnmipb.Path, interval time.Duration, updateOnly bool) {
+func (c *MixedDbClient) dbTableKeySubscribe(gnmiPath *gnmipb.Path, interval time.Duration, suppressRedundant bool) {
 	defer c.w.Done()
 
 	msiAll := make(map[string]interface{})
@@ -2307,7 +2307,7 @@ func (c *MixedDbClient) dbTableKeySubscribe(gnmiPath *gnmipb.Path, interval time
 	signalSync()
 
 	// Clear the payload so that next time it will send only updates
-	if updateOnly {
+	if suppressRedundant {
 		msiAll = make(map[string]interface{})
 	}
 
@@ -2349,7 +2349,7 @@ func (c *MixedDbClient) dbTableKeySubscribe(gnmiPath *gnmipb.Path, interval time
 			}
 
 			// Clear the payload so that next time it will send only updates
-			if updateOnly {
+			if suppressRedundant {
 				msiAll = make(map[string]interface{})
 				log.V(6).Infof("msiAll cleared: %v", len(msiAll))
 			}

--- a/sonic_data_client/sample_suppress_redundant_test.go
+++ b/sonic_data_client/sample_suppress_redundant_test.go
@@ -1,0 +1,275 @@
+package client
+
+// Tests for suppress_redundant handling in SAMPLE-mode stream subscriptions
+// (issue #762). These drive DbClient and MixedDbClient directly against a
+// miniredis instance with a mocked interval ticker.
+
+import (
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Workiva/go-datastructures/queue"
+	"github.com/alicebob/miniredis/v2"
+	gnmipb "github.com/openconfig/gnmi/proto/gnmi"
+	"github.com/redis/go-redis/v9"
+	spb "github.com/sonic-net/sonic-gnmi/proto"
+	"github.com/sonic-net/sonic-gnmi/swsscommon"
+)
+
+const testSampleNs = "sample-test-ns"
+
+// mockIntervalTicker installs a manually driven interval ticker and returns
+// the tick channel and a restore function.
+func mockIntervalTicker() (chan time.Time, func()) {
+	tickCh := make(chan time.Time)
+	NeedMock = true
+	orig := GetIntervalTicker()
+	SetIntervalTicker(func(interval time.Duration) <-chan time.Time {
+		return tickCh
+	})
+	return tickCh, func() {
+		SetIntervalTicker(orig)
+		NeedMock = false
+	}
+}
+
+// getQueueValue reads one spb.Value from the queue with a timeout.
+func getQueueValue(t *testing.T, pq *queue.PriorityQueue) *spb.Value {
+	t.Helper()
+	ch := make(chan *spb.Value, 1)
+	go func() {
+		items, err := pq.Get(1)
+		if err != nil || len(items) == 0 {
+			ch <- nil
+			return
+		}
+		ch <- items[0].(Value).Value
+	}()
+	select {
+	case v := <-ch:
+		if v == nil {
+			t.Fatal("failed to read value from queue")
+		}
+		return v
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for queue value")
+	}
+	return nil
+}
+
+// assertJsonValue asserts the value carries the expected JSON payload.
+func assertJsonValue(t *testing.T, v *spb.Value, want string) {
+	t.Helper()
+	if v.GetSyncResponse() {
+		t.Fatalf("expected data update, got sync_response")
+	}
+	got := v.GetVal().GetJsonIetfVal()
+	var j1, j2 interface{}
+	if err := json.Unmarshal(got, &j1); err != nil {
+		t.Fatalf("invalid JSON in update %q: %v", got, err)
+	}
+	if err := json.Unmarshal([]byte(want), &j2); err != nil {
+		t.Fatalf("invalid JSON in expectation %q: %v", want, err)
+	}
+	g, _ := json.Marshal(j1)
+	w, _ := json.Marshal(j2)
+	if string(g) != string(w) {
+		t.Fatalf("unexpected update payload: got %s, want %s", g, w)
+	}
+}
+
+func assertSyncResponse(t *testing.T, v *spb.Value) {
+	t.Helper()
+	if !v.GetSyncResponse() {
+		t.Fatalf("expected sync_response, got %v", v)
+	}
+}
+
+// TestDbClientSampleSuppressRedundantTableKey covers the DbClient SAMPLE
+// table-key path (dbTableKeySubscribe): with suppress_redundant set, the
+// payload is cleared after every send so an unchanged interval produces an
+// empty update.
+func TestDbClientSampleSuppressRedundantTableKey(t *testing.T) {
+	mr := miniredis.RunT(t)
+	mr.HSet("COUNTERS:oid:0x1", "SAI_PORT_STAT_PFC_7_RX_PKTS", "2")
+
+	defer saveAndResetTarget2RedisDb()()
+	Target2RedisDb[testSampleNs] = map[string]*redis.Client{
+		"COUNTERS_DB": redis.NewClient(&redis.Options{Addr: mr.Addr()}),
+	}
+
+	tickCh, restoreTicker := mockIntervalTicker()
+	defer restoreTicker()
+
+	p := &gnmipb.Path{Elem: []*gnmipb.PathElem{{Name: "COUNTERS"}, {Name: "Ethernet0"}}}
+	c := DbClient{
+		prefix: &gnmipb.Path{Target: "COUNTERS_DB"},
+		pathG2S: map[*gnmipb.Path][]tablePath{
+			p: {{
+				dbNamespace: testSampleNs,
+				dbName:      "COUNTERS_DB",
+				tableName:   "COUNTERS",
+				tableKey:    "oid:0x1",
+				delimitor:   ":",
+			}},
+		},
+	}
+
+	pq := queue.NewPriorityQueue(10, false)
+	stop := make(chan struct{})
+	var w sync.WaitGroup
+	w.Add(1)
+	go c.StreamRun(pq, stop, &w, &gnmipb.SubscriptionList{
+		Mode: gnmipb.SubscriptionList_STREAM,
+		Subscription: []*gnmipb.Subscription{{
+			Path:              p,
+			Mode:              gnmipb.SubscriptionMode_SAMPLE,
+			SampleInterval:    uint64(time.Second),
+			SuppressRedundant: true,
+		}},
+	})
+
+	assertJsonValue(t, getQueueValue(t, pq), `{"SAI_PORT_STAT_PFC_7_RX_PKTS":"2"}`)
+	assertSyncResponse(t, getQueueValue(t, pq))
+
+	// No change: with suppress_redundant the interval produces an empty update.
+	tickCh <- time.Now()
+	assertJsonValue(t, getQueueValue(t, pq), `{}`)
+	tickCh <- time.Now()
+	assertJsonValue(t, getQueueValue(t, pq), `{}`)
+
+	close(stop)
+	w.Wait()
+}
+
+// TestDbClientSampleSuppressRedundantField covers the DbClient SAMPLE
+// field-across-tables path (dbFieldMultiSubscribe): a changed leaf is sent
+// alone, and an unchanged interval produces an empty update.
+func TestDbClientSampleSuppressRedundantField(t *testing.T) {
+	mr := miniredis.RunT(t)
+	mr.HSet("COUNTERS:oid:0x1", "SAI_PORT_STAT_PFC_7_RX_PKTS", "2")
+	mr.HSet("COUNTERS:oid:0x2", "SAI_PORT_STAT_PFC_7_RX_PKTS", "3")
+
+	defer saveAndResetTarget2RedisDb()()
+	Target2RedisDb[testSampleNs] = map[string]*redis.Client{
+		"COUNTERS_DB": redis.NewClient(&redis.Options{Addr: mr.Addr()}),
+	}
+
+	tickCh, restoreTicker := mockIntervalTicker()
+	defer restoreTicker()
+
+	p := &gnmipb.Path{Elem: []*gnmipb.PathElem{
+		{Name: "COUNTERS"}, {Name: "Ethernet*"}, {Name: "SAI_PORT_STAT_PFC_7_RX_PKTS"},
+	}}
+	c := DbClient{
+		prefix: &gnmipb.Path{Target: "COUNTERS_DB"},
+		pathG2S: map[*gnmipb.Path][]tablePath{
+			p: {
+				{
+					dbNamespace:  testSampleNs,
+					dbName:       "COUNTERS_DB",
+					tableName:    "COUNTERS",
+					tableKey:     "oid:0x1",
+					delimitor:    ":",
+					field:        "SAI_PORT_STAT_PFC_7_RX_PKTS",
+					jsonTableKey: "Ethernet0",
+					jsonField:    "SAI_PORT_STAT_PFC_7_RX_PKTS",
+				},
+				{
+					dbNamespace:  testSampleNs,
+					dbName:       "COUNTERS_DB",
+					tableName:    "COUNTERS",
+					tableKey:     "oid:0x2",
+					delimitor:    ":",
+					field:        "SAI_PORT_STAT_PFC_7_RX_PKTS",
+					jsonTableKey: "Ethernet4",
+					jsonField:    "SAI_PORT_STAT_PFC_7_RX_PKTS",
+				},
+			},
+		},
+	}
+
+	pq := queue.NewPriorityQueue(10, false)
+	stop := make(chan struct{})
+	var w sync.WaitGroup
+	w.Add(1)
+	go c.StreamRun(pq, stop, &w, &gnmipb.SubscriptionList{
+		Mode: gnmipb.SubscriptionList_STREAM,
+		Subscription: []*gnmipb.Subscription{{
+			Path:              p,
+			Mode:              gnmipb.SubscriptionMode_SAMPLE,
+			SampleInterval:    uint64(time.Second),
+			SuppressRedundant: true,
+		}},
+	})
+
+	assertJsonValue(t, getQueueValue(t, pq),
+		`{"Ethernet0":{"SAI_PORT_STAT_PFC_7_RX_PKTS":"2"},"Ethernet4":{"SAI_PORT_STAT_PFC_7_RX_PKTS":"3"}}`)
+	assertSyncResponse(t, getQueueValue(t, pq))
+
+	// Change one leaf: only that leaf is reported on the next interval.
+	mr.HSet("COUNTERS:oid:0x1", "SAI_PORT_STAT_PFC_7_RX_PKTS", "7")
+	tickCh <- time.Now()
+	assertJsonValue(t, getQueueValue(t, pq), `{"Ethernet0":{"SAI_PORT_STAT_PFC_7_RX_PKTS":"7"}}`)
+
+	// No change: empty update.
+	tickCh <- time.Now()
+	assertJsonValue(t, getQueueValue(t, pq), `{}`)
+
+	close(stop)
+	w.Wait()
+}
+
+// TestMixedDbClientSampleSuppressRedundant covers the MixedDbClient SAMPLE
+// table path (streamSampleSubscription -> dbTableKeySubscribe) with
+// suppress_redundant set.
+func TestMixedDbClientSampleSuppressRedundant(t *testing.T) {
+	mr := miniredis.RunT(t)
+	mr.HSet("VLAN|Vlan100", "vlanid", "100")
+
+	origRedisDbMap := RedisDbMap
+	RedisDbMap = map[string]*redis.Client{
+		"sample-test:CONFIG_DB": redis.NewClient(&redis.Options{Addr: mr.Addr()}),
+	}
+	defer func() { RedisDbMap = origRedisDbMap }()
+
+	tickCh, restoreTicker := mockIntervalTicker()
+	defer restoreTicker()
+
+	dbkey := swsscommon.NewSonicDBKey()
+	defer swsscommon.DeleteSonicDBKey(dbkey)
+	c := MixedDbClient{
+		prefix:   &gnmipb.Path{Target: "CONFIG_DB"},
+		target:   "CONFIG_DB",
+		encoding: gnmipb.Encoding_JSON_IETF,
+		dbkey:    dbkey,
+		mapkey:   "sample-test",
+	}
+
+	p := &gnmipb.Path{Elem: []*gnmipb.PathElem{{Name: "VLAN"}}}
+	pq := queue.NewPriorityQueue(10, false)
+	stop := make(chan struct{})
+	var w sync.WaitGroup
+	w.Add(1)
+	go c.StreamRun(pq, stop, &w, &gnmipb.SubscriptionList{
+		Mode: gnmipb.SubscriptionList_STREAM,
+		Subscription: []*gnmipb.Subscription{{
+			Path:              p,
+			Mode:              gnmipb.SubscriptionMode_SAMPLE,
+			SampleInterval:    uint64(time.Second),
+			SuppressRedundant: true,
+		}},
+	})
+
+	assertJsonValue(t, getQueueValue(t, pq), `{"Vlan100":{"vlanid":"100"}}`)
+	assertSyncResponse(t, getQueueValue(t, pq))
+
+	// No change: with suppress_redundant the interval produces an empty update.
+	tickCh <- time.Now()
+	assertJsonValue(t, getQueueValue(t, pq), `{}`)
+
+	close(stop)
+	w.Wait()
+}


### PR DESCRIPTION
#### Why I did it

The SAMPLE stream subscription code in `DbClient`/`MixedDbClient` confuses two distinct gNMI flags:

- [`updates_only`](https://github.com/openconfig/reference/blob/master/rpc/gnmi/gnmi-specification.md#3512-the-subscriptionlist-message) (SubscriptionList-level): the target sends only the `sync_response` and then updates as usual, skipping the initial state snapshot.
- [`suppress_redundant`](https://github.com/openconfig/reference/blob/master/rpc/gnmi/gnmi-specification.md#35152-stream-subscriptions) (per-Subscription, SAMPLE mode): the target should only generate updates for leaves whose value changed since the last update.

The code reads `SubscriptionList.updates_only` and uses it to gate "send only changed values on each sample tick" — which is exactly the `suppress_redundant` behavior, keyed off the wrong flag. As a result, clients setting `suppress_redundant` get no suppression, while clients setting `updates_only` get suppression they never asked for.

This supersedes the stale draft #581, rebased onto current master with test coverage added.

#### How I did it

- `sonic_data_client/db_client.go`: `streamSampleSubscription` now reads `sub.GetSuppressRedundant()` instead of receiving `subscribe.GetUpdatesOnly()`; renamed the `updateOnly` parameter of `dbFieldMultiSubscribe`/`dbTableKeySubscribe` to `suppressRedundant` and updated comments.
- `sonic_data_client/mixed_db_client.go`: same conversion for `MixedDbClient.streamSampleSubscription`/`dbTableKeySubscribe`.
- Tests: dropped the `updatesOnly` argument from the `createQuery`/`createQueryOrFail` helpers and moved the flag to a per-subscription `SuppressRedundant` field, so the two existing delta-behavior cases in `runTestSubscribe` now exercise `suppress_redundant` (expected notifications unchanged). Added two new cases: one covering the `dbFieldMultiSubscribe` path (field-across-tables query) with `suppress_redundant=true`, and a regression case asserting `updates_only` no longer triggers suppression (full payload sent every interval).

Notes:
- The translib path (`transl_data_client.go`) already implements both flags correctly and is untouched.
- After this change, `updates_only` is effectively a no-op in the `DbClient`/`MixedDbClient` SAMPLE path (the initial snapshot is still sent). Implementing true skip-initial-sync `updates_only` semantics for these clients is out of scope here.

#### How to verify it

`make check_gotest` — in `gnmi_server`, `TestGnmiSubscribe` / `TestGnmiSubscribeMultiNs` include the converted and newly added cases:

- `(suppress_redundant) sample stream query for table key Ethernet* ...` and `... Ethernet*/Pfcwd ...`: with `suppress_redundant=true`, an interval with no change produces an empty update and a changed field produces a delta-only update.
- `(suppress_redundant) sample stream query for table field Ethernet*/SAI_PORT_STAT_PFC_7_RX_PKTS ...`: same assertions for the field-across-tables path.
- `(updates_only) sample stream query for table key Ethernet* ...`: full payload is sent on every interval, i.e. `updates_only` no longer suppresses.

Additionally, `sonic_data_client/sample_suppress_redundant_test.go` adds package-level tests (miniredis + mocked interval ticker) that drive `DbClient.StreamRun`/`MixedDbClient.StreamRun` in SAMPLE mode with `suppress_redundant=true`, covering the changed lines directly in `sonic_data_client` coverage: table-key and field-across-tables paths for `DbClient`, and the table path for `MixedDbClient`.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605
- [ ] N/A

#### Description for the changelog

Fix SAMPLE stream subscriptions to key changed-values-only updates off the per-subscription suppress_redundant flag instead of the SubscriptionList updates_only flag.

#### Link to config_db schema for YANG module changes

N/A
