### PR TITLE
ci: enforce provider boundaries in pure build mode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/go-redis/redismock/v9 v9.2.0
 	github.com/godbus/dbus/v5 v5.1.0
 	github.com/gogo/protobuf v1.3.2
-	github.com/golang/glog v1.2.4
+	github.com/golang/glog v1.2.5
 	github.com/golang/mock v1.7.0-rc.1 // no stable v1.7.0; forced by cloud.google.com/go/spanner transitive dep
 	github.com/golang/protobuf v1.5.4
 	github.com/google/gnxi v0.0.0-20181220173256-89f51f0ce1e2
@@ -68,6 +68,7 @@ require (
 	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/text v0.39.0 // indirect
+	golang.org/x/time v0.11.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478 // indirect
 	inet.af/netaddr v0.0.0-20230525184311-b8eac61e914a // indirect

--- a/go.sum
+++ b/go.sum
@@ -4028,6 +4028,7 @@ golang.org/x/time v0.7.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
 golang.org/x/time v0.8.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
 golang.org/x/time v0.9.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
 golang.org/x/time v0.10.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
+golang.org/x/time v0.11.0 h1:/bpjEDfN9tkoN/ryeYHnv5hcMlc8ncjMcM4XBk5NWV0=
 golang.org/x/time v0.11.0/go.mod h1:CDIdPxbZBQxdj6cxyCIdrNogrJKMJ7pr37NYpMcMDSg=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180525024113-a5b4c53f6e8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/pure.mk
+++ b/pure.mk
@@ -7,6 +7,10 @@
 # Go configuration
 GO ?= go
 GOROOT ?= $(shell $(GO) env GOROOT)
+PURE_CGO_ENABLED ?= 0
+RACE_CGO_ENABLED ?= 1
+PURE_TAG ?= pure
+PURE_GO_FLAGS := -tags=$(PURE_TAG)
 
 # Discover every package under the canonical pure roots. This makes purity a
 # path-based invariant instead of an allowlist that can omit new packages.
@@ -64,17 +68,17 @@ vet:
 	@echo "Running go vet on pure packages..."
 	@set -e; for pkg in $(PACKAGES); do \
 		echo "Vetting $$pkg..."; \
-		(cd $$pkg && $(GO) vet .); \
+		(cd $$pkg && CGO_ENABLED=$(PURE_CGO_ENABLED) $(GO) vet $(PURE_GO_FLAGS) .); \
 	done
 
 # Test - run all tests with coverage
 .PHONY: test
-test:
+test: build-test
 	@echo "Running tests for pure packages..."
 	@set -e; for pkg in $(PACKAGES); do \
 		echo ""; \
 		echo "=== Testing $$pkg ==="; \
-		(cd $$pkg && $(GO) test -gcflags="all=-N -l" -v -race -coverprofile=coverage.out -covermode=atomic .); \
+		(cd $$pkg && CGO_ENABLED=$(RACE_CGO_ENABLED) $(GO) test $(PURE_GO_FLAGS) -gcflags="all=-N -l" -v -race -coverprofile=coverage.out -covermode=atomic .); \
 		if [ -f $$pkg/coverage.out ]; then \
 			echo "Coverage for $$pkg:"; \
 			(cd $$pkg && $(GO) tool cover -func=coverage.out); \
@@ -83,12 +87,12 @@ test:
 
 # Generate coverage files for Azure pipeline integration
 .PHONY: azure-coverage
-azure-coverage:
+azure-coverage: build-test
 	@echo "Generating coverage files for Azure pipeline..."
 	@set -e; for pkg in $(PACKAGES); do \
 		echo "Testing $$pkg..."; \
 		pkgname=$$(echo $$pkg | tr '/' '-'); \
-		$(GO) test -gcflags="all=-N -l" -race -coverprofile=coverage-pure-$$pkgname.txt -covermode=atomic -v ./$$pkg; \
+		CGO_ENABLED=$(RACE_CGO_ENABLED) $(GO) test $(PURE_GO_FLAGS) -gcflags="all=-N -l" -race -coverprofile=coverage-pure-$$pkgname.txt -covermode=atomic -v ./$$pkg; \
 	done
 	@echo "Coverage files generated for Azure pipeline"
 
@@ -134,10 +138,11 @@ coverage-xml: test
 # Build test - ensure the package builds
 .PHONY: build-test
 build-test:
-	@echo "Testing build of pure packages..."
+	@echo "Testing build of pure packages and tests..."
 	@set -e; for pkg in $(PACKAGES); do \
 		echo "Building $$pkg..."; \
-		(cd $$pkg && $(GO) build -v .); \
+		(cd $$pkg && CGO_ENABLED=$(PURE_CGO_ENABLED) $(GO) build $(PURE_GO_FLAGS) -v .); \
+		(cd $$pkg && CGO_ENABLED=$(PURE_CGO_ENABLED) $(GO) test $(PURE_GO_FLAGS) -c -o /dev/null .); \
 	done
 
 # Lint check using basic go tools
@@ -151,7 +156,7 @@ bench:
 	@echo "Running benchmarks for pure packages..."
 	@set -e; for pkg in $(PACKAGES); do \
 		echo "Benchmarking $$pkg..."; \
-		(cd $$pkg && $(GO) test -bench=. -benchmem .); \
+		(cd $$pkg && CGO_ENABLED=$(PURE_CGO_ENABLED) $(GO) test $(PURE_GO_FLAGS) -bench=. -benchmem .); \
 	done
 
 # Module verification
@@ -173,14 +178,32 @@ security:
 	@set -e; if command -v gosec >/dev/null 2>&1; then \
 		for pkg in $(PACKAGES); do \
 			echo "Scanning $$pkg..."; \
-			(cd $$pkg && gosec .); \
+			(cd $$pkg && gosec -tags=$(PURE_TAG) .); \
 		done; \
 	else \
 		echo "gosec not available, skipping security scan"; \
 		echo "Install with: go install github.com/securecodewarrior/gosec/v2/cmd/gosec@latest"; \
 	fi
 
-# List vanilla packages
+# Keep pure build constraints under internal/adaptors rather than business logic.
+.PHONY: check-tags
+check-tags:
+	@echo "Checking pure build-tag placement..."
+	@set -e; \
+	files=$$(find $(PURE_ROOTS) -type f -name '*.go' -exec grep -l '^//go:build .*pure' {} + 2>/dev/null || true); \
+	for file in $$files; do \
+		case "$$file" in \
+			internal/adaptors/*/provider_*.go) \
+				relative=$${file#internal/adaptors/}; \
+				case "$$relative" in */*/*) ;; *) continue ;; esac; \
+				;; \
+		esac; \
+		echo "Pure build tag is outside a direct internal adaptor provider: $$file"; \
+		exit 1; \
+	done
+	@echo "Pure build-tag placement is clean."
+
+# List pure packages
 .PHONY: list-packages
 list-packages:
 	@echo "Pure packages:"
@@ -196,7 +219,7 @@ list-packages:
 
 # Full CI pipeline
 .PHONY: ci
-ci: clean lint build-test test
+ci: clean check-tags lint build-test test
 	@echo ""
 	@echo "============================================="
 	@echo "✅ Pure CI completed successfully!"
@@ -219,7 +242,7 @@ ci: clean lint build-test test
 # Note: The Azure pipeline now calls gotestsum directly with set -euo pipefail
 # This target is kept for local testing convenience
 .PHONY: junit-xml
-junit-xml: clean
+junit-xml: clean check-tags build-test
 	@echo "Installing gotestsum for JUnit XML generation..."
 	@if ! command -v gotestsum >/dev/null 2>&1; then \
 		$(GO) install gotest.tools/gotestsum@v1.12.3; \
@@ -234,9 +257,9 @@ junit-xml: clean
 	@echo "Running pure package tests with JUnit XML output..."
 	@mkdir -p test-results
 	@export PATH=$(PATH):$(shell $(GO) env GOPATH)/bin && \
-	gotestsum --junitfile test-results/junit-pure.xml \
+	CGO_ENABLED=$(RACE_CGO_ENABLED) gotestsum --junitfile test-results/junit-pure.xml \
 		--format testname \
-		-- -gcflags="all=-N -l" -v -race \
+		-- $(PURE_GO_FLAGS) -gcflags="all=-N -l" -v -race \
 		-coverprofile=test-results/coverage-pure.txt \
 		-covermode=atomic \
 		$(addprefix ./,$(PACKAGES))
@@ -262,7 +285,7 @@ junit-xml: clean
 
 # Quick check for development
 .PHONY: quick
-quick: fmt-check vet build-test
+quick: check-tags fmt-check vet build-test
 	@echo "Quick validation complete for pure packages"
 
 # Help target
@@ -288,6 +311,7 @@ help:
 	@echo "  build-test       - Test package builds"
 	@echo "  bench            - Run benchmarks"
 	@echo "  security         - Run security scan (requires gosec)"
+	@echo "  check-tags       - Restrict pure tags to internal adaptors"
 	@echo "  mod-verify       - Verify go modules"
 	@echo "  list-packages    - List pure packages"
 	@echo "  clean            - Clean build artifacts"


### PR DESCRIPTION
## Summary

- add the `pure` build tag to the existing pure-package path
- compile packages and tests with `CGO_ENABLED=0` before race tests
- restrict pure build tags to direct internal adapter provider files
- declare direct dependencies exposed by current mechanical package discovery

## Validation at commit `21bf9058`

- `make -f pure.mk ci` passes for 17 packages
- `go mod tidy -diff` reports no changes
- AMD64, ARM64, memory, pure, static, CodeQL, and Semgrep checks passed
- integration passed all 1,279 tests in builds 1201604, 1201690, and 1202463
- each run then failed during coverage-tool installation on the shared `/tmp/go` permission boundary

## Blocker

- blocked by sonic-net/sonic-gnmi#767
- PR 767 removes the shared Go cache boundary and passed full upstream CI build 1202340
- after PR 767 merges, this branch will rebase onto current master and rerun unchanged

## Relationship

- first delivery commit from non-mergeable umbrella draft #764
- the database-config adapter follows only after this PR is green and merged

Tracking: Azure DevOps Task [39387055](https://msazure.visualstudio.com/One/_workitems/edit/39387055).