### PR TITLE
build: separate Go caches from project tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,9 @@ GOROOT ?= $(shell $(GO) env GOROOT)
 HOST_GOOS = $(shell $(GO) env GOHOSTOS)
 HOST_GOARCH = $(shell $(GO) env GOHOSTARCH)
 HOST_GO_ENV = GOOS=$(HOST_GOOS) GOARCH=$(HOST_GOARCH)
-SUDO_GO := sudo -E env -u GOPATH -u GOMODCACHE -u GOCACHE -u GOCACHEPROG -u GOENV \
-	-u GOTMPDIR -u XDG_CACHE_HOME -u XDG_CONFIG_HOME HOME=/root
+GO_BIN_DIR = $(dir $(shell command -v $(GO)))
+SUDO_GO := sudo -H env -i HOME=/root USER=root LOGNAME=root \
+	PATH=$(GO_BIN_DIR):/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 FORMAT_CHECK = $(BUILD_DIR)/.formatcheck
 FORMAT_LOG = $(BUILD_DIR)/go_format.log
 # Find all .go files excluding vendor, build, and patches files

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,3 @@
-ifeq ($(GOPATH),)
-export GOPATH=/tmp/go
-endif
-export PATH := $(PATH):$(GOPATH)/bin
-
 INSTALL := /usr/bin/install
 DBDIR := /var/run/redis/sonic-db/
 GO ?= /usr/local/go/bin/go
@@ -10,6 +5,7 @@ TOPDIR := $(abspath .)
 MGMT_COMMON_DIR := $(TOPDIR)/../sonic-mgmt-common
 BUILD_BASE := build
 BUILD_DIR := build/bin
+TOOLS_BIN_DIR := $(BUILD_BASE)/tools/bin
 BUILD_GNOI_YANG_DIR := $(BUILD_BASE)/gnoi_yang
 BUILD_GNOI_YANG_PROTO_DIR := $(BUILD_GNOI_YANG_DIR)/proto
 BUILD_GNOI_YANG_SERVER_DIR := $(BUILD_GNOI_YANG_DIR)/server
@@ -19,6 +15,11 @@ TOOLS_DIR        := $(TOPDIR)/tools
 PYANG_PLUGIN_DIR := $(TOOLS_DIR)/pyang_plugins
 PYANG  ?= pyang
 GOROOT ?= $(shell $(GO) env GOROOT)
+HOST_GOOS = $(shell $(GO) env GOHOSTOS)
+HOST_GOARCH = $(shell $(GO) env GOHOSTARCH)
+HOST_GO_ENV = GOOS=$(HOST_GOOS) GOARCH=$(HOST_GOARCH)
+SUDO_GO := sudo -E env -u GOPATH -u GOMODCACHE -u GOCACHE -u GOCACHEPROG -u GOENV \
+	-u GOTMPDIR -u XDG_CACHE_HOME -u XDG_CONFIG_HOME HOME=/root
 FORMAT_CHECK = $(BUILD_DIR)/.formatcheck
 FORMAT_LOG = $(BUILD_DIR)/go_format.log
 # Find all .go files excluding vendor, build, and patches files
@@ -34,6 +35,12 @@ export CGO_LDFLAGS := -lswsscommon -lhiredis
 export CGO_CXXFLAGS := -I/usr/include/swss -w -Wall -fpermissive
 export MEMCHECK_CGO_LDFLAGS := $(CGO_LDFLAGS) -fsanitize=address
 export MEMCHECK_CGO_CXXFLAGS := $(CGO_CXXFLAGS) -fsanitize=leak
+
+GOTESTSUM := $(abspath $(TOOLS_BIN_DIR)/gotestsum-v1.13.0)
+GOCOV := $(abspath $(TOOLS_BIN_DIR)/gocov-v1.1.0)
+GOCOV_XML := $(abspath $(TOOLS_BIN_DIR)/gocov-xml-v1.2.0)
+PROTOC_GEN_GO := $(abspath $(TOOLS_BIN_DIR)/protoc-gen-go-v1.5.4)
+PROTOC_GEN_GOFAST := $(abspath $(TOOLS_BIN_DIR)/protoc-gen-gofast-v1.3.2)
 
 ifeq ($(ENABLE_TRANSLIB_WRITE),y)
 BLD_TAGS := gnmi_translib_write
@@ -77,7 +84,9 @@ $(GO_DEPS): go.mod $(PATCHES) swsscommon_wrap $(GNOI_YANG)
 	 fi
 	$(GO) mod vendor
 	$(GO) mod download github.com/google/gnxi@v0.0.0-20181220173256-89f51f0ce1e2
-	cp -r $(GOPATH)/pkg/mod/github.com/google/gnxi@v0.0.0-20181220173256-89f51f0ce1e2/* vendor/github.com/google/gnxi/
+	gnxi_dir=$$($(GO) list -mod=mod -m -f '{{.Dir}}' github.com/google/gnxi@v0.0.0-20181220173256-89f51f0ce1e2) && \
+		cp -r "$$gnxi_dir"/* vendor/github.com/google/gnxi/ && \
+		chmod -R u+w vendor/github.com/google/gnxi
 
 # x/crypto/ssh/terminal imports x/term in v0.24.0+; gnmi_cli uses ssh/terminal
 # but go mod vendor omits both because the unpatched code doesn't import them.
@@ -86,23 +95,23 @@ $(GO_DEPS): go.mod $(PATCHES) swsscommon_wrap $(GNOI_YANG)
 # cmd packages that are not imported by any package in this module).
 	$(GO) mod download golang.org/x/term@v0.43.0
 	mkdir -p vendor/golang.org/x/crypto/ssh/terminal vendor/golang.org/x/term
-	cp $(GOPATH)/pkg/mod/golang.org/x/crypto@v0.52.0/ssh/terminal/terminal.go \
-		vendor/golang.org/x/crypto/ssh/terminal/
-	rsync -r --chmod=u+w --exclude=testdata --exclude='*_test.go' \
-		$(GOPATH)/pkg/mod/golang.org/x/term@v0.43.0/ vendor/golang.org/x/term/
+	crypto_dir=$$($(GO) list -mod=mod -m -f '{{.Dir}}' golang.org/x/crypto@v0.52.0) && \
+		cp "$$crypto_dir"/ssh/terminal/terminal.go vendor/golang.org/x/crypto/ssh/terminal/
+	term_dir=$$($(GO) list -mod=mod -m -f '{{.Dir}}' golang.org/x/term@v0.43.0) && \
+		rsync -r --chmod=u+w --exclude=testdata --exclude='*_test.go' \
+		"$$term_dir"/ vendor/golang.org/x/term/
 	python3 -c 'import re, sys; txt=open("vendor/modules.txt").read(); pkg="golang.org/x/term\n"; m=re.search(r"^(# golang\.org/x/term [^\n]+\n## explicit[^\n]*\n)", txt, re.MULTILINE) if pkg not in txt else None; sys.exit("ERROR: golang.org/x/term block not found in vendor/modules.txt") if pkg not in txt and not m else None; open("vendor/modules.txt","w").write(txt[:m.end()]+pkg+txt[m.end():]) if m else None'
 	$(GO) mod download github.com/openconfig/gnmi@v0.0.0-20200617225440-d2b4e6a45802
 	mkdir -p vendor/github.com/openconfig/gnmi/cmd/gnmi_cli \
 		vendor/github.com/openconfig/gnmi/cli \
 		vendor/github.com/openconfig/gnmi/client/flags
-	cp $(GOPATH)/pkg/mod/github.com/openconfig/gnmi@v0.0.0-20200617225440-d2b4e6a45802/cmd/gnmi_cli/gnmi_cli.go \
-		vendor/github.com/openconfig/gnmi/cmd/gnmi_cli/
-	cp $(GOPATH)/pkg/mod/github.com/openconfig/gnmi@v0.0.0-20200617225440-d2b4e6a45802/cli/cli.go \
-		vendor/github.com/openconfig/gnmi/cli/
-	cp $(GOPATH)/pkg/mod/github.com/openconfig/gnmi@v0.0.0-20200617225440-d2b4e6a45802/client/flags/intmap.go \
-		$(GOPATH)/pkg/mod/github.com/openconfig/gnmi@v0.0.0-20200617225440-d2b4e6a45802/client/flags/stringlist.go \
-		$(GOPATH)/pkg/mod/github.com/openconfig/gnmi@v0.0.0-20200617225440-d2b4e6a45802/client/flags/stringmap.go \
-		vendor/github.com/openconfig/gnmi/client/flags/
+	gnmi_dir=$$($(GO) list -mod=mod -m -f '{{.Dir}}' github.com/openconfig/gnmi@v0.0.0-20200617225440-d2b4e6a45802) && \
+		cp "$$gnmi_dir"/cmd/gnmi_cli/gnmi_cli.go vendor/github.com/openconfig/gnmi/cmd/gnmi_cli/ && \
+		cp "$$gnmi_dir"/cli/cli.go vendor/github.com/openconfig/gnmi/cli/ && \
+		cp "$$gnmi_dir"/client/flags/intmap.go \
+			"$$gnmi_dir"/client/flags/stringlist.go \
+			"$$gnmi_dir"/client/flags/stringmap.go \
+			vendor/github.com/openconfig/gnmi/client/flags/
 
 # Apply patch from sonic-mgmt-common, ignore glog.patch because glog version changed
 	sed -i 's/patch -d $${DEST_DIR}\/github.com\/golang\/glog/\#patch -d $${DEST_DIR}\/github.com\/golang\/glog/g' $(MGMT_COMMON_DIR)/patches/apply.sh
@@ -181,7 +190,6 @@ swsscommon_wrap:
 
 .SECONDEXPANSION:
 
-PROTOC_PATH := $(PATH):$(GOBIN)
 PROTOC_OPTS := -I$(CURDIR)/vendor -I/usr/local/include -I/usr/include
 PROTOC_OPTS_WITHOUT_VENDOR := -I/usr/local/include -I/usr/include
 
@@ -216,23 +224,40 @@ $(BUILD_GNOI_YANG_PROTO_DIR)/.proto_sonic_done: $(SONIC_YANGS)
 	@echo "+++++ Generation of protobuf files for SONiC Yang modules completed +++++"
 	touch $@
 
-$(GNOI_YANG): $(BUILD_GNOI_YANG_PROTO_DIR)/.proto_api_done $(BUILD_GNOI_YANG_PROTO_DIR)/.proto_sonic_done
+$(GNOI_YANG): $(BUILD_GNOI_YANG_PROTO_DIR)/.proto_api_done $(BUILD_GNOI_YANG_PROTO_DIR)/.proto_sonic_done | $(PROTOC_GEN_GOFAST)
 	@echo "+++++ Compiling PROTOBUF files; +++++"
 	# Remove the toolchain directive added by newer Go versions
 	sed -i '/^toolchain/d' go.mod
-	$(GO) install github.com/gogo/protobuf/protoc-gen-gofast
 	@mkdir -p $(@D)
-	$(foreach file, $(wildcard $(BUILD_GNOI_YANG_PROTO_DIR)/*/*.proto), PATH=$(PROTOC_PATH) protoc -I$(@D) $(PROTOC_OPTS_WITHOUT_VENDOR) --gofast_out=plugins=grpc,Mgoogle/protobuf/struct.proto=github.com/gogo/protobuf/types:$(BUILD_GNOI_YANG_PROTO_DIR) $(file);)
+	$(foreach file, $(wildcard $(BUILD_GNOI_YANG_PROTO_DIR)/*/*.proto), protoc -I$(@D) $(PROTOC_OPTS_WITHOUT_VENDOR) --plugin=protoc-gen-gofast=$(PROTOC_GEN_GOFAST) --gofast_out=plugins=grpc,Mgoogle/protobuf/struct.proto=github.com/gogo/protobuf/types:$(BUILD_GNOI_YANG_PROTO_DIR) $(file);)
 	@echo "+++++ PROTOBUF completion completed; +++++"
 	touch $@
 
-$(PROTO_GO_BINDINGS): $$(patsubst %.pb.go,%.proto,$$@) | $(GOBIN)/protoc-gen-go
-	PATH=$(PROTOC_PATH) protoc -I$(@D) $(PROTOC_OPTS) --go_out=plugins=grpc:$(@D) $<
+$(PROTO_GO_BINDINGS): $$(patsubst %.pb.go,%.proto,$$@) | $(PROTOC_GEN_GO)
+	protoc -I$(@D) $(PROTOC_OPTS) --plugin=protoc-gen-go=$(PROTOC_GEN_GO) --go_out=plugins=grpc:$(@D) $<
 
-$(GOBIN)/protoc-gen-go:
-	cd $$(mktemp -d) && \
-	$(GO) mod init protoc && \
-	$(GO) install github.com/golang/protobuf/protoc-gen-go
+$(TOOLS_BIN_DIR):
+	mkdir -p $@
+
+$(PROTOC_GEN_GOFAST): | $(TOOLS_BIN_DIR)
+	$(HOST_GO_ENV) GOBIN=$(abspath $(TOOLS_BIN_DIR)) $(GO) install github.com/gogo/protobuf/protoc-gen-gofast@v1.3.2
+	mv $(TOOLS_BIN_DIR)/protoc-gen-gofast $@
+
+$(PROTOC_GEN_GO): | $(TOOLS_BIN_DIR)
+	$(HOST_GO_ENV) GOBIN=$(abspath $(TOOLS_BIN_DIR)) $(GO) install github.com/golang/protobuf/protoc-gen-go@v1.5.4
+	mv $(TOOLS_BIN_DIR)/protoc-gen-go $@
+
+$(GOTESTSUM): | $(TOOLS_BIN_DIR)
+	$(HOST_GO_ENV) GOBIN=$(abspath $(TOOLS_BIN_DIR)) $(GO) install gotest.tools/gotestsum@v1.13.0
+	mv $(TOOLS_BIN_DIR)/gotestsum $@
+
+$(GOCOV): | $(TOOLS_BIN_DIR)
+	$(HOST_GO_ENV) GOBIN=$(abspath $(TOOLS_BIN_DIR)) $(GO) install github.com/axw/gocov/gocov@v1.1.0
+	mv $(TOOLS_BIN_DIR)/gocov $@
+
+$(GOCOV_XML): | $(TOOLS_BIN_DIR)
+	$(HOST_GO_ENV) GOBIN=$(abspath $(TOOLS_BIN_DIR)) $(GO) install github.com/AlekSi/gocov-xml@v1.2.0
+	mv $(TOOLS_BIN_DIR)/gocov-xml $@
 
 
 DBCONFG = $(DBDIR)/database_config.json
@@ -247,34 +272,24 @@ $(ENVFILE):
 	mkdir -p $(@D)
 	tools/test/env.sh | grep -v DB_CONFIG_PATH | tee $@
 
-check_gotest: $(DBCONFG) $(ENVFILE)
-	sudo CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" $(GO) test -race $(TEST_FLAGS) -coverprofile=coverage-telemetry.txt -covermode=atomic -mod=vendor -v github.com/sonic-net/sonic-gnmi/telemetry
-	sudo CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" $(GO) test -race $(TEST_FLAGS) -coverprofile=coverage-config.txt -covermode=atomic -v github.com/sonic-net/sonic-gnmi/sonic_db_config
-	sudo CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" $(TESTENV) $(GO) test -race -timeout 40m $(TEST_FLAGS) -coverprofile=coverage-gnmi.txt -covermode=atomic -mod=vendor $(BLD_FLAGS) -v github.com/sonic-net/sonic-gnmi/gnmi_server -coverpkg ../...
-	sudo CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" $(TESTENV) $(GO) test -race -timeout 40m $(TEST_FLAGS) -coverprofile=coverage-pathz_authorizer.txt -covermode=atomic -mod=vendor $(BLD_FLAGS) -v github.com/sonic-net/sonic-gnmi/pathz_authorizer -coverpkg ../...
+check_gotest: $(DBCONFG) $(ENVFILE) $(GOCOV) $(GOCOV_XML)
+	$(SUDO_GO) CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" $(GO) test -race $(TEST_FLAGS) -coverprofile=coverage-telemetry.txt -covermode=atomic -mod=vendor -v github.com/sonic-net/sonic-gnmi/telemetry
+	$(SUDO_GO) CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" $(GO) test -race $(TEST_FLAGS) -coverprofile=coverage-config.txt -covermode=atomic -v github.com/sonic-net/sonic-gnmi/sonic_db_config
+	$(SUDO_GO) CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" $(TESTENV) $(GO) test -race -timeout 40m $(TEST_FLAGS) -coverprofile=coverage-gnmi.txt -covermode=atomic -mod=vendor $(BLD_FLAGS) -v github.com/sonic-net/sonic-gnmi/gnmi_server -coverpkg ../...
+	$(SUDO_GO) CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" $(TESTENV) $(GO) test -race -timeout 40m $(TEST_FLAGS) -coverprofile=coverage-pathz_authorizer.txt -covermode=atomic -mod=vendor $(BLD_FLAGS) -v github.com/sonic-net/sonic-gnmi/pathz_authorizer -coverpkg ../...
 ifneq ($(ENABLE_DIALOUT_VALUE),0)
-	sudo CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" $(TESTENV) $(GO) test $(TEST_FLAGS) -coverprofile=coverage-dialout.txt -covermode=atomic -mod=vendor $(BLD_FLAGS) -v github.com/sonic-net/sonic-gnmi/dialout/dialout_client
+	$(SUDO_GO) CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" $(TESTENV) $(GO) test $(TEST_FLAGS) -coverprofile=coverage-dialout.txt -covermode=atomic -mod=vendor $(BLD_FLAGS) -v github.com/sonic-net/sonic-gnmi/dialout/dialout_client
 endif
-	sudo CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" $(GO) test -race $(TEST_FLAGS) -coverprofile=coverage-data.txt -covermode=atomic -mod=vendor -v github.com/sonic-net/sonic-gnmi/sonic_data_client
-	sudo CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" $(GO) test -race $(TEST_FLAGS) -coverprofile=coverage-dbus.txt -covermode=atomic -mod=vendor -v github.com/sonic-net/sonic-gnmi/sonic_service_client
-	sudo CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" $(TESTENV) $(GO) test -race $(TEST_FLAGS) -coverprofile=coverage-translutils.txt -covermode=atomic -mod=vendor -v github.com/sonic-net/sonic-gnmi/transl_utils
-	sudo CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" $(TESTENV) $(GO) test -race $(TEST_FLAGS) -coverprofile=coverage-gnoi-client-system.txt -covermode=atomic -mod=vendor -v github.com/sonic-net/sonic-gnmi/gnoi_client/system
-
-	# Install required coverage tools
-	$(GO) install github.com/axw/gocov/gocov@v1.1.0
-	$(GO) install github.com/AlekSi/gocov-xml@latest
-	@GO_MOD_VER=$$(sed -n 's/^go //p' go.mod) && \
-	 GO_CUR_VER=$$($(GO) env GOVERSION | sed 's/go//') && \
-	 if printf '%s\n' "$$GO_MOD_VER" "$$GO_CUR_VER" | sort -V | head -1 | grep -qx "$$GO_MOD_VER"; then \
-	   $(GO) mod tidy; \
-	 fi
-	$(GO) mod vendor
+	$(SUDO_GO) CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" $(GO) test -race $(TEST_FLAGS) -coverprofile=coverage-data.txt -covermode=atomic -mod=vendor -v github.com/sonic-net/sonic-gnmi/sonic_data_client
+	$(SUDO_GO) CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" $(GO) test -race $(TEST_FLAGS) -coverprofile=coverage-dbus.txt -covermode=atomic -mod=vendor -v github.com/sonic-net/sonic-gnmi/sonic_service_client
+	$(SUDO_GO) CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" $(TESTENV) $(GO) test -race $(TEST_FLAGS) -coverprofile=coverage-translutils.txt -covermode=atomic -mod=vendor -v github.com/sonic-net/sonic-gnmi/transl_utils
+	$(SUDO_GO) CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" $(TESTENV) $(GO) test -race $(TEST_FLAGS) -coverprofile=coverage-gnoi-client-system.txt -covermode=atomic -mod=vendor -v github.com/sonic-net/sonic-gnmi/gnoi_client/system
 
 	# Filter out "mocks" and generated "proto" files from the coverage reports
 	for file in coverage-*.txt; do grep -v -e "/mocks/" -e "proto/" $$file > $$file.filtered; done
 
 	# Convert and generate the final coverage.xml file
-	gocov convert coverage-*.txt.filtered | gocov-xml -source $(shell pwd) > coverage.xml
+	$(GOCOV) convert coverage-*.txt.filtered | $(GOCOV_XML) -source $(shell pwd) > coverage.xml
 
 	# Cleanup temporary files
 	rm -rf coverage-*.txt coverage-*.txt.filtered
@@ -309,18 +324,16 @@ MEMLEAK_STANDARD_PKGS := \
 # MEMLEAK_TEST_PATTERN := ^TestGNMINative
 
 check_memleak: $(DBCONFG) $(ENVFILE)
-	sudo CGO_LDFLAGS="$(MEMCHECK_CGO_LDFLAGS)" CGO_CXXFLAGS="$(MEMCHECK_CGO_CXXFLAGS)" $(GO) test -mod=vendor $(TEST_FLAGS) $(MEMCHECK_FLAGS) -v $(MEMLEAK_STANDARD_PKGS)
+	$(SUDO_GO) CGO_LDFLAGS="$(MEMCHECK_CGO_LDFLAGS)" CGO_CXXFLAGS="$(MEMCHECK_CGO_CXXFLAGS)" $(GO) test -mod=vendor $(TEST_FLAGS) $(MEMCHECK_FLAGS) -v $(MEMLEAK_STANDARD_PKGS)
 	# sudo CGO_LDFLAGS="$(MEMCHECK_CGO_LDFLAGS)" CGO_CXXFLAGS="$(MEMCHECK_CGO_CXXFLAGS)" $(GO) test -mod=vendor $(MEMCHECK_FLAGS) -v $(MEMLEAK_GNMI_SERVER_PKG) -run="$(MEMLEAK_TEST_PATTERN)"
 
 # JUnit XML output for memory leak tests in Azure Pipelines
 .PHONY: check_memleak_junit
-check_memleak_junit: $(DBCONFG) $(ENVFILE)
-	@echo "Installing gotestsum for memory leak JUnit XML generation..."
-	sudo $(GO) install gotest.tools/gotestsum@v1.13.0
+check_memleak_junit: $(DBCONFG) $(ENVFILE) $(GOTESTSUM)
 	@echo "Running memory leak tests with JUnit XML output..."
 	@mkdir -p test-results
-	CGO_LDFLAGS="$(MEMCHECK_CGO_LDFLAGS)" CGO_CXXFLAGS="$(MEMCHECK_CGO_CXXFLAGS)" \
-		sudo -E $(shell sudo $(GO) env GOPATH)/bin/gotestsum --junitfile test-results/junit-memleak-standard.xml \
+	$(SUDO_GO) CGO_LDFLAGS="$(MEMCHECK_CGO_LDFLAGS)" CGO_CXXFLAGS="$(MEMCHECK_CGO_CXXFLAGS)" \
+		$(GOTESTSUM) --junitfile test-results/junit-memleak-standard.xml \
 		--format testname \
 		-- -mod=vendor $(MEMCHECK_FLAGS) -v $(MEMLEAK_STANDARD_PKGS)
 	@echo ""
@@ -340,9 +353,7 @@ check_memleak_junit: $(DBCONFG) $(ENVFILE)
 
 # JUnit XML output for integration tests in Azure Pipelines
 .PHONY: check_gotest_junit
-check_gotest_junit: $(DBCONFG) $(ENVFILE)
-	@echo "Installing gotestsum for integration test JUnit XML generation..."
-	sudo $(GO) install gotest.tools/gotestsum@v1.13.0
+check_gotest_junit: $(DBCONFG) $(ENVFILE) $(GOTESTSUM) $(GOCOV) $(GOCOV_XML)
 	@echo "Running integration tests with JUnit XML output..."
 	@mkdir -p test-results
 	
@@ -353,8 +364,8 @@ check_gotest_junit: $(DBCONFG) $(ENVFILE)
 	# Run basic packages (no special environment needed)
 	@if [ -n "$(INTEGRATION_BASIC_PKGS)" ]; then \
 		echo "Running basic integration tests..."; \
-		CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" \
-			sudo -E $(shell sudo $(GO) env GOPATH)/bin/gotestsum --junitfile test-results/junit-integration-basic.xml \
+		$(SUDO_GO) CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" \
+			$(GOTESTSUM) --junitfile test-results/junit-integration-basic.xml \
 			--format testname \
 			-- -race -timeout 40m $(TEST_FLAGS) -coverprofile=test-results/coverage-integration-basic.txt \
 			-covermode=atomic -mod=vendor -v $(INTEGRATION_BASIC_PKGS); \
@@ -363,11 +374,11 @@ check_gotest_junit: $(DBCONFG) $(ENVFILE)
 	# Run packages needing special environment
 	@if [ -n "$(INTEGRATION_ENV_PKGS)" ]; then \
 		echo "Pre-checking env packages compile..."; \
-		CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" $(TESTENV) \
-			sudo -E $(GO) test -run=^$$ -mod=vendor $(BLD_FLAGS) $(INTEGRATION_ENV_PKGS) 2>&1 || true; \
+		$(SUDO_GO) CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" $(TESTENV) \
+			$(GO) test -run=^$$ -mod=vendor $(BLD_FLAGS) $(INTEGRATION_ENV_PKGS) 2>&1 || true; \
 		echo "Running environment-dependent integration tests..."; \
-		CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" $(TESTENV) \
-			sudo -E $(shell sudo $(GO) env GOPATH)/bin/gotestsum --junitfile test-results/junit-integration-env.xml \
+		$(SUDO_GO) CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" $(TESTENV) \
+			$(GOTESTSUM) --junitfile test-results/junit-integration-env.xml \
 			--format testname \
 			-- -race -timeout 40m $(TEST_FLAGS) -coverprofile=test-results/coverage-integration-env.txt \
 			-covermode=atomic -mod=vendor $(BLD_FLAGS) -v $(INTEGRATION_ENV_PKGS); \
@@ -377,24 +388,13 @@ check_gotest_junit: $(DBCONFG) $(ENVFILE)
 ifneq ($(ENABLE_DIALOUT_VALUE),0)
 	@if [ -n "$(INTEGRATION_DIALOUT_PKG)" ]; then \
 		echo "Running dialout integration tests..."; \
-		CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" $(TESTENV) \
-			sudo -E $(shell sudo $(GO) env GOPATH)/bin/gotestsum --junitfile test-results/junit-integration-dialout.xml \
+		$(SUDO_GO) CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" $(TESTENV) \
+			$(GOTESTSUM) --junitfile test-results/junit-integration-dialout.xml \
 			--format testname \
 			-- $(TEST_FLAGS) -coverprofile=test-results/coverage-integration-dialout.txt \
 			-covermode=atomic -mod=vendor $(BLD_FLAGS) -v $(INTEGRATION_DIALOUT_PKG); \
 	fi
 endif
-
-	# Generate Cobertura XML coverage report for Azure Pipelines
-	@echo "Installing coverage tools..."
-	$(GO) install github.com/axw/gocov/gocov@v1.1.0
-	$(GO) install github.com/AlekSi/gocov-xml@latest
-	@GO_MOD_VER=$$(sed -n 's/^go //p' go.mod) && \
-	 GO_CUR_VER=$$($(GO) env GOVERSION | sed 's/go//') && \
-	 if printf '%s\n' "$$GO_MOD_VER" "$$GO_CUR_VER" | sort -V | head -1 | grep -qx "$$GO_MOD_VER"; then \
-	   $(GO) mod tidy; \
-	 fi
-	$(GO) mod vendor
 
 	@echo "Generating coverage.xml..."
 	@for file in test-results/coverage-*.txt; do \
@@ -402,7 +402,7 @@ endif
 			grep -v -e "/mocks/" -e "proto/" "$$file" > "$$file.filtered" 2>/dev/null || true; \
 		fi; \
 	done
-	gocov convert test-results/coverage-*.txt.filtered | gocov-xml -source $(shell pwd) > coverage.xml
+	$(GOCOV) convert test-results/coverage-*.txt.filtered | $(GOCOV_XML) -source $(shell pwd) > coverage.xml
 	@rm -f test-results/coverage-*.txt.filtered
 
 	@echo ""
@@ -484,5 +484,3 @@ diff-cover: coverage.xml test-results/coverage-pure.xml
 		--compare-branch $(TARGET_BRANCH) \
 		--src-roots . \
 		--fail-under $(DIFF_COVER_THRESHOLD)
-
-

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -121,7 +121,7 @@ stages:
 
     - bash: |
         set -euo pipefail
-        export PATH=$PATH:/usr/local/go/bin:$(go env GOPATH)/bin
+        export PATH=$PATH:/usr/local/go/bin
         cd sonic-gnmi
         go mod tidy
         make -f pure.mk junit-xml

--- a/pure.mk
+++ b/pure.mk
@@ -7,6 +7,33 @@
 # Go configuration
 GO ?= go
 GOROOT ?= $(shell $(GO) env GOROOT)
+HOST_GOOS = $(shell $(GO) env GOHOSTOS)
+HOST_GOARCH = $(shell $(GO) env GOHOSTARCH)
+HOST_GO_ENV = GOOS=$(HOST_GOOS) GOARCH=$(HOST_GOARCH)
+TOOLS_BIN_DIR := $(abspath build/tools/bin)
+GOTESTSUM := $(TOOLS_BIN_DIR)/gotestsum-v1.12.3
+GOCOV := $(TOOLS_BIN_DIR)/gocov-v1.1.0
+GOCOV_XML := $(TOOLS_BIN_DIR)/gocov-xml-v1.1.0
+GOSEC := $(TOOLS_BIN_DIR)/gosec-v2.28.0
+
+$(TOOLS_BIN_DIR):
+	@mkdir -p $@
+
+$(GOTESTSUM): | $(TOOLS_BIN_DIR)
+	@$(HOST_GO_ENV) GOBIN=$(TOOLS_BIN_DIR) $(GO) install gotest.tools/gotestsum@v1.12.3
+	@mv $(TOOLS_BIN_DIR)/gotestsum $@
+
+$(GOCOV): | $(TOOLS_BIN_DIR)
+	@$(HOST_GO_ENV) GOBIN=$(TOOLS_BIN_DIR) $(GO) install github.com/axw/gocov/gocov@v1.1.0
+	@mv $(TOOLS_BIN_DIR)/gocov $@
+
+$(GOCOV_XML): | $(TOOLS_BIN_DIR)
+	@$(HOST_GO_ENV) GOBIN=$(TOOLS_BIN_DIR) $(GO) install github.com/AlekSi/gocov-xml@v1.1.0
+	@mv $(TOOLS_BIN_DIR)/gocov-xml $@
+
+$(GOSEC): | $(TOOLS_BIN_DIR)
+	@$(HOST_GO_ENV) GOBIN=$(TOOLS_BIN_DIR) $(GO) install github.com/securego/gosec/v2/cmd/gosec@v2.28.0
+	@mv $(TOOLS_BIN_DIR)/gosec $@
 
 # Discover every package under the canonical pure roots. This makes purity a
 # path-based invariant instead of an allowlist that can omit new packages.
@@ -106,29 +133,23 @@ test-coverage: test
 
 # Generate XML coverage report for Azure pipelines
 .PHONY: coverage-xml
-coverage-xml: test
+coverage-xml: test $(GOCOV) $(GOCOV_XML)
 	@echo "Generating XML coverage report for Azure..."
-	@set -e; if command -v gocov >/dev/null 2>&1 && command -v gocov-xml >/dev/null 2>&1; then \
-		echo "Converting coverage to XML format..."; \
-		rm -f coverage-*.out; \
-		for pkg in $(PACKAGES); do \
-			if [ -f $$pkg/coverage.out ]; then \
-				pkgname=$$(echo $$pkg | tr '/' '-'); \
-				cp $$pkg/coverage.out coverage-$$pkgname.out; \
-			fi; \
-		done; \
-		if ls coverage-*.out >/dev/null 2>&1; then \
-			trap 'rm -f coverage-*.out coverage-pure.json' EXIT; \
-			gocov convert coverage-*.out > coverage-pure.json; \
-			gocov-xml -source $(shell pwd) < coverage-pure.json > coverage.xml; \
-			echo "XML coverage report generated: coverage.xml"; \
-		else \
-			echo "No coverage files found"; \
+	@set -e; echo "Converting coverage to XML format..."; \
+	 rm -f coverage-*.out; \
+	 for pkg in $(PACKAGES); do \
+		if [ -f $$pkg/coverage.out ]; then \
+			pkgname=$$(echo $$pkg | tr '/' '-'); \
+			cp $$pkg/coverage.out coverage-$$pkgname.out; \
 		fi; \
-	else \
-		echo "Warning: gocov and gocov-xml not available"; \
-		echo "Install with: go install github.com/axw/gocov/gocov@latest"; \
-		echo "              go install github.com/AlekSi/gocov-xml@latest"; \
+	 done; \
+	 if ls coverage-*.out >/dev/null 2>&1; then \
+		trap 'rm -f coverage-*.out coverage-pure.json' EXIT; \
+		$(GOCOV) convert coverage-*.out > coverage-pure.json; \
+		$(GOCOV_XML) -source $(shell pwd) < coverage-pure.json > coverage.xml; \
+		echo "XML coverage report generated: coverage.xml"; \
+	 else \
+		echo "No coverage files found"; \
 	fi
 
 # Build test - ensure the package builds
@@ -166,19 +187,14 @@ mod-verify:
 		echo "Go modules are clean"; \
 	fi
 
-# Security scan using gosec if available
+# Security scan using the pinned gosec tool
 .PHONY: security
-security:
+security: $(GOSEC)
 	@echo "Running security scan on pure packages..."
-	@set -e; if command -v gosec >/dev/null 2>&1; then \
-		for pkg in $(PACKAGES); do \
-			echo "Scanning $$pkg..."; \
-			(cd $$pkg && gosec .); \
-		done; \
-	else \
-		echo "gosec not available, skipping security scan"; \
-		echo "Install with: go install github.com/securecodewarrior/gosec/v2/cmd/gosec@latest"; \
-	fi
+	@set -e; for pkg in $(PACKAGES); do \
+		echo "Scanning $$pkg..."; \
+		(cd $$pkg && $(GOSEC) .); \
+	done
 
 # List vanilla packages
 .PHONY: list-packages
@@ -220,30 +236,18 @@ ci: clean lint build-test test
 # This target is kept for local testing convenience
 .PHONY: junit-xml
 junit-xml: clean
-	@echo "Installing gotestsum for JUnit XML generation..."
-	@if ! command -v gotestsum >/dev/null 2>&1; then \
-		$(GO) install gotest.tools/gotestsum@v1.12.3; \
-	fi
-	@echo "Installing gocov tools for coverage conversion..."
-	@if ! command -v gocov >/dev/null 2>&1; then \
-		$(GO) install github.com/axw/gocov/gocov@v1.1.0; \
-	fi
-	@if ! command -v gocov-xml >/dev/null 2>&1; then \
-		$(GO) install github.com/AlekSi/gocov-xml@v1.1.0; \
-	fi
+	@$(MAKE) -f pure.mk $(GOTESTSUM) $(GOCOV) $(GOCOV_XML)
 	@echo "Running pure package tests with JUnit XML output..."
 	@mkdir -p test-results
-	@export PATH=$(PATH):$(shell $(GO) env GOPATH)/bin && \
-	gotestsum --junitfile test-results/junit-pure.xml \
+	@$(GOTESTSUM) --junitfile test-results/junit-pure.xml \
 		--format testname \
 		-- -gcflags="all=-N -l" -v -race \
 		-coverprofile=test-results/coverage-pure.txt \
 		-covermode=atomic \
 		$(addprefix ./,$(PACKAGES))
 	@echo "Converting coverage to Cobertura XML format..."
-	@export PATH=$(PATH):$(shell $(GO) env GOPATH)/bin && \
-	if [ -f test-results/coverage-pure.txt ]; then \
-		gocov convert test-results/coverage-pure.txt | gocov-xml -source $(shell pwd) > test-results/coverage-pure.xml; \
+	@if [ -f test-results/coverage-pure.txt ]; then \
+		$(GOCOV) convert test-results/coverage-pure.txt | $(GOCOV_XML) -source $(shell pwd) > test-results/coverage-pure.xml; \
 		echo "Coverage XML generated: test-results/coverage-pure.xml"; \
 	fi
 	@echo ""
@@ -287,7 +291,7 @@ help:
 	@echo "  lint             - Run linting checks"
 	@echo "  build-test       - Test package builds"
 	@echo "  bench            - Run benchmarks"
-	@echo "  security         - Run security scan (requires gosec)"
+	@echo "  security         - Run security scan"
 	@echo "  mod-verify       - Verify go modules"
 	@echo "  list-packages    - List pure packages"
 	@echo "  clean            - Clean build artifacts"


### PR DESCRIPTION
## Why

`GOPATH=/tmp/go` makes privileged and unprivileged Go commands share module and checksum cache state. Root-owned cache files can then block later unprivileged commands after tests pass.

Go caches are user state, not repository artifacts. Repository tools also need stable locations that do not depend on ambient `PATH` state.

## What changes

- The Makefile does not assign `GOPATH`.
- Direct module source lookups use `go list` instead of `GOPATH/pkg/mod`.
- Versioned build and test tools use `build/tools/bin` and exact invocation paths.
- Cross-builds compile host tools for the host architecture.
- Existing Go commands that use `sudo` run in an explicit root environment with root default caches.

## Long-term direction

- Users own their Go caches.
- Product binaries stay in `build/bin`.
- Repository tools stay in `build/tools/bin`.
- Tests eventually run without `sudo` and use project-local fixtures.
- Cleanup eventually removes repository artifacts only.
- Debian packaging eventually consumes an explicit product manifest.

## Scope

This PR changes cache and tool ownership only. It does not change product binaries, packaging, fixtures, `sudo` usage, or cleanup behavior.

The `sonic-mgmt-common` patch helper remains unchanged. It still assumes its default `$GOPATH/pkg/mod` module-cache path.

## Validation

- [Azure Pipelines run 1205748](https://dev.azure.com/mssonic/be1b070f-be15-4154-aade-b1d3bfb17054/_build/results?buildId=1205748) passed all `sonic-gnmi` checks for commit `afb6db7`.
- `make -f pure.mk junit-xml` passed 853 tests and generated Cobertura XML.
- Cross-target tool installation produced an `amd64` host executable.
- Environment checks confirmed that privileged Go commands use the explicit root environment and root cache paths.

Tracking: Azure DevOps Task [39393252](https://msazure.visualstudio.com/One/_workitems/edit/39393252).