### PR TITLE
[202605] Backport payload-safe tablePath logging (#768)

### DIFF
--- a/sonic_data_client/db_client.go
+++ b/sonic_data_client/db_client.go
@@ -146,6 +146,27 @@ type tablePath struct {
 	isVirtualPath bool
 }
 
+// String omits request payloads so tablePath can be logged as valid text.
+func (p tablePath) String() string {
+	operation := fmt.Sprintf("unknown(%d)", p.operation)
+	switch p.operation {
+	case opAdd:
+		operation = "add"
+	case opRemove:
+		operation = "remove"
+	}
+
+	return fmt.Sprintf(
+		"tablePath{namespace=%+q db=%+q table=%+q key=%+q field=%+q operation=%+q index=%d json_bytes=%d proto_bytes=%d virtual=%t}",
+		p.dbNamespace, p.dbName, p.tableName, p.tableKey, p.field, operation,
+		p.index, len(p.jsonValue), len(p.protoValue), p.isVirtualPath,
+	)
+}
+
+func (p tablePath) GoString() string {
+	return p.String()
+}
+
 type Value struct {
 	*spb.Value
 }

--- a/sonic_data_client/table_path_test.go
+++ b/sonic_data_client/table_path_test.go
@@ -1,0 +1,56 @@
+package client
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"unicode"
+	"unicode/utf8"
+)
+
+func TestTablePathFormattingRedactsPayloads(t *testing.T) {
+	protoPayload := "proto-do-not-log" + string([]byte{0xe1, 0x00, 0xff})
+	jsonPayload := `{"password":"do-not-log"}`
+	path := tablePath{
+		dbNamespace: "localhost",
+		dbName:      "DPU_APPL_DB",
+		tableName:   "DASH_VNET_TABLE",
+		tableKey:    string([]byte{'V', 0xe1}),
+		field:       "pb",
+		jsonValue:   jsonPayload,
+		protoValue:  protoPayload,
+		index:       -1,
+		operation:   opAdd,
+	}
+
+	for _, format := range []string{"%v", "%+v", "%#v"} {
+		for _, value := range []any{path, []tablePath{path}} {
+			got := fmt.Sprintf(format, value)
+			if !utf8.ValidString(got) {
+				t.Fatalf("format %s produced invalid UTF-8: %q", format, got)
+			}
+			for _, r := range got {
+				if r > unicode.MaxASCII {
+					t.Fatalf("format %s produced non-ASCII output: %q", format, got)
+				}
+			}
+			for _, marker := range []string{"proto-do-not-log", "do-not-log"} {
+				if strings.Contains(got, marker) {
+					t.Fatalf("format %s exposed payload marker %q: %q", format, marker, got)
+				}
+			}
+			for _, want := range []string{
+				`db="DPU_APPL_DB"`,
+				`table="DASH_VNET_TABLE"`,
+				`key="V\xe1"`,
+				`operation="add"`,
+				`json_bytes=25`,
+				`proto_bytes=19`,
+			} {
+				if !strings.Contains(got, want) {
+					t.Errorf("format %s missing %s: %q", format, want, got)
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
#### Why I did it

Backport #768 so the 202605 release does not write raw protobuf payload bytes from `tablePath` values into gNMI text logs. Those bytes can be invalid UTF-8, which made Ansible omit `stdout` while collecting diagnostics and masked the original gNMI result.

#### How I did it

Cherry-picked the merged #768 commit (`23e37370e65edbce6d348d19b2514f66d57aa4a6`) onto `202605` as one backport commit. `git range-diff` reports the code patch as identical to the merged change; the only commit-message difference is the `-x` cherry-pick provenance line.

The change adds payload-safe `String` and `GoString` formatting for `tablePath`, keeps useful path metadata, and replaces JSON/protobuf values with their byte lengths.

#### How to verify it

- `git range-diff`: code patch identical to #768
- `gofmt -d sonic_data_client/db_client.go sonic_data_client/table_path_test.go`: clean
- `git diff --check`: pass
- Master focused test from #768: `TestTablePathFormattingRedactsPayloads` passed
- Official 202605 package and physical protobuf Set validation completed; see the sanitized validation comment below

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://msazure.visualstudio.com/One/_workitems/edit/39376939
Failure type: other - latent payload-unsafe logging exposed by DASH protobuf SETs

The target release failure was reproduced on `SONiC.20260510.11` in Elastictest plan https://elastictest.org/scheduler/testplan/6a8ced4c5585d0b8ab0a86e5.

#### Tested branch

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202605
- [ ] N/A

#### Test result

- master: focused `sonic_data_client` regression test passed in the SONiC Trixie build environment as documented in #768.
- 202605: official PR package validated on physical `SONiC.20260510.11`; authenticated protobuf Set update/delete succeeded, payload-safe `tablePath` logging remained valid UTF-8, and the release gNMI auth module passed both cases. See the sanitized validation comment below.

#### Description for the changelog

Prevent `tablePath` logging from exposing request payloads or writing invalid UTF-8 bytes to gNMI text logs.

#### Link to config_db schema for YANG module changes

N/A
