### PR TITLE
telemetry: generate DPU ephemeral TLS certificates

### DIFF
--- a/pkg/dpuephemeraltls/certificate.go
+++ b/pkg/dpuephemeraltls/certificate.go
@@ -30,8 +30,16 @@ func New(now time.Time) (tls.Certificate, error) {
 	ipAddresses := make([]net.IP, 0, len(addrs))
 	seen := map[string]bool{}
 	for _, addr := range addrs {
-		ip, _, err := net.ParseCIDR(addr.String())
-		if err != nil || ip.IsLoopback() || ip.IsUnspecified() {
+		var ip net.IP
+		switch addr := addr.(type) {
+		case *net.IPNet:
+			ip = addr.IP
+		case *net.IPAddr:
+			ip = addr.IP
+		default:
+			ip, _, _ = net.ParseCIDR(addr.String())
+		}
+		if ip == nil || ip.IsLoopback() || ip.IsUnspecified() {
 			continue
 		}
 		key := ip.String()

--- a/pkg/dpuephemeraltls/certificate.go
+++ b/pkg/dpuephemeraltls/certificate.go
@@ -1,0 +1,98 @@
+package dpuephemeraltls
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"os"
+	"sort"
+	"time"
+)
+
+const certificateLifetime = 10 * 365 * 24 * time.Hour
+
+var interfaceAddrs = net.InterfaceAddrs
+var hostName = os.Hostname
+
+// New generates a self-signed server certificate for the DPU's current identities.
+func New(now time.Time) (tls.Certificate, error) {
+	addrs, err := interfaceAddrs()
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("list interface addresses: %w", err)
+	}
+
+	ipAddresses := make([]net.IP, 0, len(addrs))
+	seen := map[string]bool{}
+	for _, addr := range addrs {
+		ip, _, err := net.ParseCIDR(addr.String())
+		if err != nil || ip.IsLoopback() || ip.IsUnspecified() {
+			continue
+		}
+		key := ip.String()
+		if !seen[key] {
+			seen[key] = true
+			ipAddresses = append(ipAddresses, ip)
+		}
+	}
+	if len(ipAddresses) == 0 {
+		return tls.Certificate{}, fmt.Errorf("no non-loopback IP addresses found")
+	}
+	sort.Slice(ipAddresses, func(i, j int) bool {
+		return ipAddresses[i].String() < ipAddresses[j].String()
+	})
+
+	dnsNames := []string{}
+	hostname, _ := hostName()
+	if hostname != "" {
+		dnsNames = append(dnsNames, hostname)
+	}
+
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("generate serial number: %w", err)
+	}
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 3072)
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("generate private key: %w", err)
+	}
+
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject:      pkix.Name{Organization: []string{"SONiC DPU"}},
+		DNSNames:     dnsNames,
+		IPAddresses:  ipAddresses,
+		NotBefore:    now.Add(-5 * time.Minute),
+		NotAfter:     now.Add(certificateLifetime),
+		KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+
+	derBytes, err := x509.CreateCertificate(
+		rand.Reader, &template, &template, &privateKey.PublicKey, privateKey)
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("create certificate: %w", err)
+	}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+	keyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(privateKey),
+	})
+	certificate, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("load generated key pair: %w", err)
+	}
+	certificate.Leaf, err = x509.ParseCertificate(derBytes)
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("parse generated certificate: %w", err)
+	}
+	return certificate, nil
+}

--- a/pkg/dpuephemeraltls/certificate_test.go
+++ b/pkg/dpuephemeraltls/certificate_test.go
@@ -26,7 +26,7 @@ func TestNew(t *testing.T) {
 		return []net.Addr{
 			testAddr("127.0.0.1/8"),
 			testAddr("169.254.200.1/24"),
-			testAddr("10.0.0.2/24"),
+			&net.IPAddr{IP: net.ParseIP("10.0.0.2")},
 			testAddr("10.0.0.2/24"),
 		}, nil
 	}

--- a/pkg/dpuephemeraltls/certificate_test.go
+++ b/pkg/dpuephemeraltls/certificate_test.go
@@ -1,0 +1,117 @@
+package dpuephemeraltls
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+)
+
+type testAddr string
+
+func (a testAddr) Network() string { return "ip+net" }
+func (a testAddr) String() string  { return string(a) }
+
+func TestNew(t *testing.T) {
+	originalInterfaceAddrs := interfaceAddrs
+	originalHostName := hostName
+	defer func() {
+		interfaceAddrs = originalInterfaceAddrs
+		hostName = originalHostName
+	}()
+
+	interfaceAddrs = func() ([]net.Addr, error) {
+		return []net.Addr{
+			testAddr("127.0.0.1/8"),
+			testAddr("169.254.200.1/24"),
+			testAddr("10.0.0.2/24"),
+			testAddr("10.0.0.2/24"),
+		}, nil
+	}
+	hostName = func() (string, error) { return "dpu0", nil }
+	now := time.Date(2026, time.August, 28, 12, 0, 0, 0, time.UTC)
+
+	certificate, err := New(now)
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+	leaf := certificate.Leaf
+	if leaf == nil {
+		t.Fatal("generated certificate has no parsed leaf")
+	}
+	for _, identity := range []string{"169.254.200.1", "10.0.0.2", "dpu0"} {
+		if err := leaf.VerifyHostname(identity); err != nil {
+			t.Errorf("certificate does not match %q: %v", identity, err)
+		}
+	}
+	if err := leaf.VerifyHostname("127.0.0.1"); err == nil {
+		t.Error("certificate unexpectedly contains a loopback SAN")
+	}
+	if got, want := leaf.NotAfter.Sub(now), certificateLifetime; got != want {
+		t.Errorf("certificate lifetime = %v, want %v", got, want)
+	}
+
+	listener, err := tls.Listen("tcp", "127.0.0.1:0", &tls.Config{
+		Certificates: []tls.Certificate{certificate},
+		MinVersion:   tls.VersionTLS12,
+	})
+	if err != nil {
+		t.Fatalf("tls.Listen() failed: %v", err)
+	}
+	defer listener.Close()
+	serverErr := make(chan error, 1)
+	go func() {
+		connection, err := listener.Accept()
+		if err == nil {
+			err = connection.(*tls.Conn).Handshake()
+			connection.Close()
+		}
+		serverErr <- err
+	}()
+
+	roots := x509.NewCertPool()
+	roots.AddCert(leaf)
+	client, err := tls.Dial("tcp", listener.Addr().String(), &tls.Config{
+		RootCAs:    roots,
+		ServerName: "169.254.200.1",
+		MinVersion: tls.VersionTLS12,
+	})
+	if err != nil {
+		t.Fatalf("TLS client failed to verify generated certificate by IP: %v", err)
+	}
+	client.Close()
+	if err := <-serverErr; err != nil {
+		t.Fatalf("TLS server handshake failed: %v", err)
+	}
+}
+
+func TestNewRequiresAddress(t *testing.T) {
+	originalInterfaceAddrs := interfaceAddrs
+	originalHostName := hostName
+	defer func() {
+		interfaceAddrs = originalInterfaceAddrs
+		hostName = originalHostName
+	}()
+
+	interfaceAddrs = func() ([]net.Addr, error) {
+		return []net.Addr{testAddr("127.0.0.1/8")}, nil
+	}
+	hostName = func() (string, error) { return "dpu0", nil }
+	if _, err := New(time.Now()); err == nil {
+		t.Fatal("New() succeeded without a non-loopback address")
+	}
+}
+
+func TestNewAddressError(t *testing.T) {
+	originalInterfaceAddrs := interfaceAddrs
+	defer func() { interfaceAddrs = originalInterfaceAddrs }()
+
+	interfaceAddrs = func() ([]net.Addr, error) {
+		return nil, fmt.Errorf("address failure")
+	}
+	if _, err := New(time.Now()); err == nil {
+		t.Fatal("New() succeeded after an address error")
+	}
+}

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/sonic-net/sonic-gnmi/common_utils"
 	gnmi "github.com/sonic-net/sonic-gnmi/gnmi_server"
+	"github.com/sonic-net/sonic-gnmi/pkg/dpuephemeraltls"
 	"github.com/sonic-net/sonic-gnmi/pkg/interceptors"
 	"github.com/sonic-net/sonic-gnmi/pkg/pathblacklist"
 	testcert "github.com/sonic-net/sonic-gnmi/testdata/tls"
@@ -53,6 +54,7 @@ type TelemetryConfig struct {
 	ZmqAddress               *string
 	ZmqPort                  *string
 	Insecure                 *bool
+	DPUEphemeralTLS          *bool
 	NoTLS                    *bool
 	AllowNoClientCert        *bool
 	JwtRefInt                *uint64
@@ -186,6 +188,7 @@ func setupFlags(fs *flag.FlagSet) (*TelemetryConfig, *gnmi.Config, error) {
 		ZmqAddress:               fs.String("zmq_address", "", "Orchagent ZMQ address, deprecated, please use zmq_port."),
 		ZmqPort:                  fs.String("zmq_port", "", "Orchagent ZMQ port, when not set or empty string telemetry server will switch to Redis based communication channel."),
 		Insecure:                 fs.Bool("insecure", false, "Skip providing TLS cert and key, for testing only!"),
+		DPUEphemeralTLS:          fs.Bool("dpu_ephemeral_tls", false, "Generate a self-signed TLS certificate for DPU host communication"),
 		NoTLS:                    fs.Bool("noTLS", false, "disable TLS, for testing only!"),
 		AllowNoClientCert:        fs.Bool("allow_no_client_auth", false, "When set, telemetry server will request but not require a client certificate."),
 		JwtRefInt:                fs.Uint64("jwt_refresh_int", 900, "Seconds before JWT expiry the token can be refreshed."),
@@ -268,7 +271,17 @@ func setupFlags(fs *flag.FlagSet) (*TelemetryConfig, *gnmi.Config, error) {
 		}
 	}
 
-	if !*telemetryCfg.NoTLS && !*telemetryCfg.Insecure {
+	if *telemetryCfg.NoTLS && *telemetryCfg.DPUEphemeralTLS {
+		return nil, nil, fmt.Errorf("dpu_ephemeral_tls cannot be combined with noTLS")
+	}
+	if *telemetryCfg.Insecure && *telemetryCfg.DPUEphemeralTLS {
+		return nil, nil, fmt.Errorf("dpu_ephemeral_tls cannot be combined with insecure")
+	}
+	if *telemetryCfg.DPUEphemeralTLS && (*telemetryCfg.ServerCert != "" || *telemetryCfg.ServerKey != "") {
+		return nil, nil, fmt.Errorf("dpu_ephemeral_tls cannot be combined with server_crt or server_key")
+	}
+
+	if !*telemetryCfg.NoTLS && !*telemetryCfg.Insecure && !*telemetryCfg.DPUEphemeralTLS {
 		switch {
 		case *telemetryCfg.ServerCert == "":
 			return nil, nil, fmt.Errorf("serverCert must be set.")
@@ -332,7 +345,7 @@ func setupFlags(fs *flag.FlagSet) (*TelemetryConfig, *gnmi.Config, error) {
 	if cfg.CertzMetaFile == "" {
 		cfg.CertzMetaFile = "/keys/grpc-version.json"
 	}
-	if !*telemetryCfg.Insecure {
+	if !*telemetryCfg.Insecure && !*telemetryCfg.DPUEphemeralTLS {
 		cfg.GetOptions = gnmi.SrvAdvConfig
 	}
 	if *telemetryCfg.CaCert == "" && telemetryCfg.UserAuth.Enabled("cert") {
@@ -476,7 +489,12 @@ func startGNMIServer(telemetryCfg *TelemetryConfig, cfg *gnmi.Config, serverCont
 		if !*telemetryCfg.NoTLS {
 			var certificate tls.Certificate
 			var err error
-			if *telemetryCfg.Insecure {
+			if *telemetryCfg.DPUEphemeralTLS {
+				certificate, err = dpuephemeraltls.New(time.Now())
+				if err != nil {
+					log.Exitf("could not generate DPU ephemeral certificate: %s", err)
+				}
+			} else if *telemetryCfg.Insecure {
 				certificate, err = testcert.NewCert()
 				if err != nil {
 					log.Errorf("could not load server key pair: %s", err)

--- a/telemetry/telemetry_test.go
+++ b/telemetry/telemetry_test.go
@@ -110,6 +110,15 @@ func TestFlags(t *testing.T) {
 			"",
 		},
 		{
+			[]string{"cmd", "-port", "2021", "-threshold", "500", "-idle_conn_duration", "4", "-v", "0", "-dpu_ephemeral_tls"},
+			2021,
+			500,
+			4,
+			0,
+			"",
+			"",
+		},
+		{
 			[]string{"cmd", "-port", "5050", "-threshold", "10", "-idle_conn_duration", "3", "-v", "-3", "-noTLS", "-bind_address", "127.0.0.1"},
 			5050,
 			10,
@@ -188,6 +197,39 @@ func TestFlags(t *testing.T) {
 		if *config.Vrf != test.expectedVrf {
 			t.Errorf("Expected vrf to be %s, got %s", test.expectedVrf, *config.Vrf)
 		}
+	}
+}
+
+func TestDPUEphemeralTLSFlagConflicts(t *testing.T) {
+	originalArgs := os.Args
+	defer func() { os.Args = originalArgs }()
+
+	tests := [][]string{
+		{"cmd", "-port", "50052", "-dpu_ephemeral_tls", "-insecure"},
+		{"cmd", "-port", "50052", "-dpu_ephemeral_tls", "-noTLS", "-bind_address", "127.0.0.1"},
+		{"cmd", "-port", "50052", "-dpu_ephemeral_tls", "-server_crt", "server.crt", "-server_key", "server.key"},
+	}
+	for _, args := range tests {
+		fs := flag.NewFlagSet("testDPUEphemeralTLSFlagConflicts", flag.ContinueOnError)
+		os.Args = args
+		if _, _, err := setupFlags(fs); err == nil {
+			t.Errorf("setupFlags(%v) succeeded, want conflicting mode error", args)
+		}
+	}
+}
+
+func TestDPUEphemeralTLSPreservesAuthzPolicy(t *testing.T) {
+	originalArgs := os.Args
+	defer func() { os.Args = originalArgs }()
+
+	fs := flag.NewFlagSet("testDPUEphemeralTLSPreservesAuthzPolicy", flag.ContinueOnError)
+	os.Args = []string{"cmd", "-port", "50052", "-dpu_ephemeral_tls", "-authz_policy_enabled"}
+	_, cfg, err := setupFlags(fs)
+	if err != nil {
+		t.Fatalf("setupFlags() failed: %v", err)
+	}
+	if !cfg.AuthzPolicy {
+		t.Fatal("dpu_ephemeral_tls unexpectedly disabled authz policy")
 	}
 }
 


### PR DESCRIPTION
## Why

The SmartSwitch DPU launcher selects `telemetry --insecure` when no server certificate is configured. The generic `--insecure` path calls `testdata/tls.NewCert()`.

The generated certificate contains only the `example.com` SAN and expires after one hour. A Python gRPC client cannot verify a DPU IP address against the certificate.

## References

- Required by: sonic-net/sonic-host-services#427
- Related: sonic-net/sonic-buildimage#29188
- ADO: 39456783

## What

- `telemetry` adds `--dpu_ephemeral_tls` and leaves generic `--insecure` behavior unchanged.
- The mode generates a process-local, self-signed certificate with the DPU's current non-loopback IP addresses and hostname as SANs. The mode does not hard-code a midplane address.
- Address discovery accepts both CIDR and direct IP values returned by `net.InterfaceAddrs()`.
- The mode sets `NotBefore` to five minutes before generation and uses a ten-year certificate lifetime. `telemetry` generates a new key and certificate on each restart.
- When another TLS mode or server key pair is configured, `telemetry` rejects `--dpu_ephemeral_tls`.
- The mode does not change client authentication or authz policy selection.

## Validation

- `go test -race ./pkg/dpuephemeraltls`
- `go test -count=10 ./pkg/dpuephemeraltls`
- `go vet ./pkg/dpuephemeraltls`
- The package tests include a TLS handshake with server verification by IP address.

## Security scope

The mode encrypts transport and provides a leaf certificate that clients can pin. The certificate does not provide CA-backed DPU identity.

Restart `telemetry` after a DPU IP address changes to regenerate the certificate.
