### PR TITLE
gnmi: add BGP running configuration and preserve CONFIG_DB wildcard structure

### DIFF
--- a/gnmi_server/bgp_cli_test.go
+++ b/gnmi_server/bgp_cli_test.go
@@ -1,0 +1,85 @@
+package gnmi
+
+// Tests SHOW bgp running-config
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/agiledragon/gomonkey/v2"
+	pb "github.com/openconfig/gnmi/proto/gnmi"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+)
+
+func TestGetBGPRunningConfig(t *testing.T) {
+	s := createServer(t, ServerPort)
+	go runServer(t, s)
+	defer s.ForceStop()
+
+	tlsConfig := &tls.Config{InsecureSkipVerify: true}
+	opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
+
+	conn, err := grpc.Dial(TargetAddr, opts...)
+	if err != nil {
+		t.Fatalf("Dialing to %q failed: %v", TargetAddr, err)
+	}
+	defer conn.Close()
+
+	gClient := pb.NewGNMIClient(conn)
+	ctx, cancel := context.WithTimeout(context.Background(), QueryTimeout*time.Second)
+	defer cancel()
+
+	mockOutputFile := "../testdata/VTYSH_SHOW_BGP_RUNNING_CONFIG.txt"
+	mockOutput, err := os.ReadFile(mockOutputFile)
+	if err != nil {
+		t.Fatalf("Reading %q failed: %v", mockOutputFile, err)
+	}
+	wantRunningConfig, err := json.Marshal(string(mockOutput))
+	if err != nil {
+		t.Fatalf("Marshaling mock output failed: %v", err)
+	}
+
+	tests := []struct {
+		desc           string
+		wantRetCode    codes.Code
+		wantRespVal    interface{}
+		valTest        bool
+		mockOutputFile string
+	}{
+		{
+			desc:        "query SHOW bgp running-config read error",
+			wantRetCode: codes.NotFound,
+		},
+		{
+			desc:           "query SHOW bgp running-config",
+			wantRetCode:    codes.OK,
+			wantRespVal:    wantRunningConfig,
+			valTest:        true,
+			mockOutputFile: mockOutputFile,
+		},
+	}
+
+	textPbPath := `
+		elem: <name: "bgp" >
+		elem: <name: "running-config" >
+	`
+	for _, test := range tests {
+		var patches *gomonkey.Patches
+		if test.mockOutputFile != "" {
+			patches = MockNSEnterCommand(t, test.mockOutputFile)
+		}
+
+		t.Run(test.desc, func(t *testing.T) {
+			runTestGet(t, ctx, gClient, "SHOW", textPbPath, test.wantRetCode, test.wantRespVal, test.valTest)
+		})
+		if patches != nil {
+			patches.Reset()
+		}
+	}
+}

--- a/gnmi_server/bgp_cli_test.go
+++ b/gnmi_server/bgp_cli_test.go
@@ -5,6 +5,7 @@ package gnmi
 import (
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"net"
 	"os"
 	"path/filepath"
@@ -80,6 +81,7 @@ func TestGetBGPRunningConfig(t *testing.T) {
 		wantRespVal    interface{}
 		valTest        bool
 		mockOutputFile string
+		mockError      error
 	}{
 		{
 			desc:        "deny SHOW bgp running-config over TCP",
@@ -90,6 +92,7 @@ func TestGetBGPRunningConfig(t *testing.T) {
 			desc:        "query SHOW bgp running-config read error",
 			client:      pb.NewGNMIClient(udsConn),
 			wantRetCode: codes.NotFound,
+			mockError:   errors.New("vtysh failed"),
 		},
 		{
 			desc:           "query SHOW bgp running-config",
@@ -109,6 +112,8 @@ func TestGetBGPRunningConfig(t *testing.T) {
 		var patches *gomonkey.Patches
 		if test.mockOutputFile != "" {
 			patches = MockNSEnterCommand(t, test.mockOutputFile)
+		} else if test.mockError != nil {
+			patches = MockNSEnterCommandError(test.mockError)
 		}
 
 		t.Run(test.desc, func(t *testing.T) {
@@ -127,6 +132,10 @@ func TestContainsBGPRunningConfigPath(t *testing.T) {
 		paths  []*pb.Path
 		want   bool
 	}{
+		{
+			name:  "nil prefix",
+			paths: []*pb.Path{{Elem: []*pb.PathElem{{Name: "bgp"}, {Name: "running-config"}}}},
+		},
 		{
 			name:   "elem path",
 			prefix: &pb.Path{Target: "SHOW"},

--- a/gnmi_server/bgp_cli_test.go
+++ b/gnmi_server/bgp_cli_test.go
@@ -5,33 +5,61 @@ package gnmi
 import (
 	"crypto/tls"
 	"encoding/json"
+	"net"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/agiledragon/gomonkey/v2"
 	pb "github.com/openconfig/gnmi/proto/gnmi"
+	testcert "github.com/sonic-net/sonic-gnmi/testdata/tls"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/status"
 )
 
 func TestGetBGPRunningConfig(t *testing.T) {
-	s := createServer(t, ServerPort)
+	socketPath := filepath.Join(t.TempDir(), "gnmi.sock")
+	certificate, err := testcert.NewCert()
+	if err != nil {
+		t.Fatalf("Loading server certificate failed: %v", err)
+	}
+	tlsConfig := &tls.Config{
+		ClientAuth:   tls.RequestClientCert,
+		Certificates: []tls.Certificate{certificate},
+	}
+	s, err := NewServer(&Config{
+		Port:                ServerPort,
+		UnixSocket:          socketPath,
+		EnableTranslibWrite: true,
+		EnableNativeWrite:   true,
+		Threshold:           100,
+		ImgDir:              "/tmp",
+	}, []grpc.ServerOption{grpc.Creds(credentials.NewTLS(tlsConfig))}, nil)
+	if err != nil {
+		t.Fatalf("Creating server failed: %v", err)
+	}
 	go runServer(t, s)
 	defer s.ForceStop()
 
-	tlsConfig := &tls.Config{InsecureSkipVerify: true}
-	opts := []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}
-
-	conn, err := grpc.Dial(TargetAddr, opts...)
+	clientTLSConfig := &tls.Config{InsecureSkipVerify: true}
+	tcpConn, err := grpc.Dial(TargetAddr, grpc.WithTransportCredentials(credentials.NewTLS(clientTLSConfig)))
 	if err != nil {
 		t.Fatalf("Dialing to %q failed: %v", TargetAddr, err)
 	}
-	defer conn.Close()
+	defer tcpConn.Close()
 
-	gClient := pb.NewGNMIClient(conn)
+	udsConn, err := grpc.Dial("unix://"+socketPath, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("Dialing to %q failed: %v", socketPath, err)
+	}
+	defer udsConn.Close()
+
 	ctx, cancel := context.WithTimeout(context.Background(), QueryTimeout*time.Second)
 	defer cancel()
 
@@ -47,17 +75,25 @@ func TestGetBGPRunningConfig(t *testing.T) {
 
 	tests := []struct {
 		desc           string
+		client         pb.GNMIClient
 		wantRetCode    codes.Code
 		wantRespVal    interface{}
 		valTest        bool
 		mockOutputFile string
 	}{
 		{
+			desc:        "deny SHOW bgp running-config over TCP",
+			client:      pb.NewGNMIClient(tcpConn),
+			wantRetCode: codes.PermissionDenied,
+		},
+		{
 			desc:        "query SHOW bgp running-config read error",
+			client:      pb.NewGNMIClient(udsConn),
 			wantRetCode: codes.NotFound,
 		},
 		{
 			desc:           "query SHOW bgp running-config",
+			client:         pb.NewGNMIClient(udsConn),
 			wantRetCode:    codes.OK,
 			wantRespVal:    wantRunningConfig,
 			valTest:        true,
@@ -76,10 +112,100 @@ func TestGetBGPRunningConfig(t *testing.T) {
 		}
 
 		t.Run(test.desc, func(t *testing.T) {
-			runTestGet(t, ctx, gClient, "SHOW", textPbPath, test.wantRetCode, test.wantRespVal, test.valTest)
+			runTestGet(t, ctx, test.client, "SHOW", textPbPath, test.wantRetCode, test.wantRespVal, test.valTest)
 		})
 		if patches != nil {
 			patches.Reset()
 		}
+	}
+}
+
+func TestContainsBGPRunningConfigPath(t *testing.T) {
+	tests := []struct {
+		name   string
+		prefix *pb.Path
+		paths  []*pb.Path
+		want   bool
+	}{
+		{
+			name:   "elem path",
+			prefix: &pb.Path{Target: "SHOW"},
+			paths:  []*pb.Path{{Elem: []*pb.PathElem{{Name: "bgp"}, {Name: "running-config"}}}},
+			want:   true,
+		},
+		{
+			name:   "split prefix",
+			prefix: &pb.Path{Target: "SHOW", Elem: []*pb.PathElem{{Name: "bgp"}}},
+			paths:  []*pb.Path{{Elem: []*pb.PathElem{{Name: "running-config"}}}},
+			want:   true,
+		},
+		{
+			name:   "deprecated prefix does not bypass elem path",
+			prefix: &pb.Path{Target: "SHOW", Element: []string{"ignored"}},
+			paths:  []*pb.Path{{Elem: []*pb.PathElem{{Name: "bgp"}, {Name: "running-config"}}}},
+			want:   true,
+		},
+		{
+			name:   "deprecated element path is not routed by SHOW client",
+			prefix: &pb.Path{Target: "SHOW"},
+			paths:  []*pb.Path{{Element: []string{"bgp", "running-config"}}},
+		},
+		{
+			name:   "other SHOW path",
+			prefix: &pb.Path{Target: "SHOW"},
+			paths:  []*pb.Path{{Elem: []*pb.PathElem{{Name: "ipv6"}, {Name: "bgp"}, {Name: "summary"}}}},
+		},
+		{
+			name:   "other target",
+			prefix: &pb.Path{Target: "CONFIG_DB"},
+			paths:  []*pb.Path{{Elem: []*pb.PathElem{{Name: "bgp"}, {Name: "running-config"}}}},
+		},
+		{
+			name:   "sensitive path after benign path",
+			prefix: &pb.Path{Target: "SHOW"},
+			paths: []*pb.Path{
+				{Elem: []*pb.PathElem{{Name: "clock"}}},
+				{Elem: []*pb.PathElem{{Name: "bgp"}, {Name: "running-config"}}},
+			},
+			want: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := containsBGPRunningConfigPath(test.prefix, test.paths); got != test.want {
+				t.Fatalf("containsBGPRunningConfigPath() = %t, want %t", got, test.want)
+			}
+		})
+	}
+}
+
+func TestGetBGPRunningConfigMixedPathEncodingDeniedOverTCP(t *testing.T) {
+	ctx := peer.NewContext(context.Background(), &peer.Peer{Addr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1234}})
+	s := &Server{config: &Config{}}
+	_, err := s.Get(ctx, &pb.GetRequest{
+		Prefix: &pb.Path{Target: "SHOW", Element: []string{"ignored"}},
+		Path: []*pb.Path{{
+			Elem: []*pb.PathElem{{Name: "bgp"}, {Name: "running-config"}},
+		}},
+		Encoding: pb.Encoding_JSON_IETF,
+	})
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("Get() code = %v, want PermissionDenied; err=%v", status.Code(err), err)
+	}
+}
+
+func TestGetBGPRunningConfigAuthenticationPrecedesTCPDenial(t *testing.T) {
+	ctx := peer.NewContext(context.Background(), &peer.Peer{Addr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1234}})
+	s := &Server{config: &Config{UserAuth: AuthTypes{"cert": true}}}
+	_, err := s.Get(ctx, &pb.GetRequest{
+		Prefix: &pb.Path{Target: "SHOW"},
+		Path: []*pb.Path{{
+			Elem: []*pb.PathElem{{Name: "bgp"}, {Name: "running-config"}},
+		}},
+		Encoding: pb.Encoding_JSON_IETF,
+	})
+	if status.Code(err) != codes.Unauthenticated {
+		t.Fatalf("Get() code = %v, want Unauthenticated; err=%v", status.Code(err), err)
 	}
 }

--- a/gnmi_server/cli_helpers_test.go
+++ b/gnmi_server/cli_helpers_test.go
@@ -26,7 +26,7 @@ const (
 	QueryTimeout = 10
 )
 
-func MockNSEnterBGPSummary(t *testing.T, fileName string) *gomonkey.Patches {
+func MockNSEnterCommand(t *testing.T, fileName string) *gomonkey.Patches {
 	fileContentBytes, err := ioutil.ReadFile(fileName)
 	if err != nil {
 		t.Fatalf("read file %v err: %v", fileName, err)

--- a/gnmi_server/cli_helpers_test.go
+++ b/gnmi_server/cli_helpers_test.go
@@ -40,6 +40,16 @@ func MockNSEnterCommand(t *testing.T, fileName string) *gomonkey.Patches {
 	return patches
 }
 
+func MockNSEnterCommandError(commandErr error) *gomonkey.Patches {
+	patches := gomonkey.ApplyFunc(exec.Command, func(name string, args ...string) *exec.Cmd {
+		return &exec.Cmd{}
+	})
+	patches.ApplyMethod(reflect.TypeOf(&exec.Cmd{}), "CombinedOutput", func(_ *exec.Cmd) ([]byte, error) {
+		return nil, commandErr
+	})
+	return patches
+}
+
 func MockReadFile(fileName string, fileContent string, fileReadErr error) {
 	sdc.ImplIoutilReadFile = func(filePath string) ([]byte, error) {
 		if filePath == fileName {

--- a/gnmi_server/config_db_cli_test.go
+++ b/gnmi_server/config_db_cli_test.go
@@ -1,0 +1,37 @@
+package gnmi
+
+import (
+	"crypto/tls"
+	"testing"
+	"time"
+
+	pb "github.com/openconfig/gnmi/proto/gnmi"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+)
+
+func TestGetConfigDBWildcardPreservesTables(t *testing.T) {
+	s := createServer(t, ServerPort)
+	go runServer(t, s)
+	defer s.ForceStop()
+	defer ResetDataSetsAndMappings(t)
+
+	tlsConfig := &tls.Config{InsecureSkipVerify: true}
+	conn, err := grpc.Dial(TargetAddr, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
+	if err != nil {
+		t.Fatalf("Dialing to %q failed: %v", TargetAddr, err)
+	}
+	defer conn.Close()
+
+	ResetDataSetsAndMappings(t)
+	AddDataSet(t, ConfigDbNum, "../testdata/CONFIG_DB_RUNNING_CONFIG.txt")
+
+	ctx, cancel := context.WithTimeout(context.Background(), QueryTimeout*time.Second)
+	defer cancel()
+	runTestGet(t, ctx, pb.NewGNMIClient(conn), "CONFIG_DB", `elem: <name: "*" >`, codes.OK,
+		[]byte(`{"ACL_TABLE":{"DATAACL":{"ports":["Ethernet0","Ethernet4"],"type":"L3"}},"BGP_NEIGHBOR":{"10.0.0.1":{"asn":"65000","name":"leaf"}},"DEVICE_METADATA":{"localhost":{"hostname":"sonic","type":"ToRRouter"}},"NTP_SERVER":{"10.0.0.1":{}}}`), true)
+	runTestGet(t, ctx, pb.NewGNMIClient(conn), "CONFIG_DB", `elem: <name: "BGP_NEIGHBOR" >`, codes.OK,
+		[]byte(`{"10.0.0.1":{"asn":"65000","name":"leaf"}}`), true)
+}

--- a/gnmi_server/ipv6_cli_test.go
+++ b/gnmi_server/ipv6_cli_test.go
@@ -114,7 +114,7 @@ func TestGetIPv6BGPSummary(t *testing.T) {
 		}
 		var patches *gomonkey.Patches
 		if test.mockOutputFile != "" {
-			patches = MockNSEnterBGPSummary(t, test.mockOutputFile)
+			patches = MockNSEnterCommand(t, test.mockOutputFile)
 		}
 
 		t.Run(test.desc, func(t *testing.T) {

--- a/gnmi_server/server.go
+++ b/gnmi_server/server.go
@@ -1020,7 +1020,7 @@ func (s *Server) Get(ctx context.Context, req *gnmipb.GetRequest) (*gnmipb.GetRe
 		dc, err = sdc.NewShowClient(paths, prefix)
 		authTarget = "gnmi_show"
 	} else if targetDbName, ok, _, _ := sdc.IsTargetDb(target); ok {
-		dc, err = sdc.NewDbClient(paths, prefix)
+		dc, err = sdc.NewDbClientForGet(paths, prefix)
 		if err == nil {
 			// For Get requests, validate that all requested keys exist in Redis.
 			// NewDbClient allows non-existent paths (needed for Subscribe to monitor

--- a/gnmi_server/server.go
+++ b/gnmi_server/server.go
@@ -798,11 +798,9 @@ func authenticate(config *Config, ctx context.Context, target string, writeAcces
 
 	// Skip authentication for UDS (Unix Domain Socket) connections.
 	// UDS security is enforced at the file-system level via socket permissions.
-	if pr, ok := peer.FromContext(ctx); ok && pr.Addr != nil {
-		if _, isUnix := pr.Addr.(*net.UnixAddr); isUnix {
-			rc.Auth.AuthEnabled = false
-			return ctx, nil
-		}
+	if isUnixPeer(ctx) {
+		rc.Auth.AuthEnabled = false
+		return ctx, nil
 	}
 
 	if !config.UserAuth.Any() {
@@ -873,6 +871,35 @@ func authenticate(config *Config, ctx context.Context, target string, writeAcces
 	log.V(5).Infof("authenticate user %v, roles %v", rc.Auth.User, rc.Auth.Roles)
 
 	return ctx, nil
+}
+
+func isUnixPeer(ctx context.Context) bool {
+	pr, ok := peer.FromContext(ctx)
+	if !ok || pr.Addr == nil {
+		return false
+	}
+	_, ok = pr.Addr.(*net.UnixAddr)
+	return ok
+}
+
+func containsBGPRunningConfigPath(prefix *gnmipb.Path, paths []*gnmipb.Path) bool {
+	if prefix.GetTarget() != "SHOW" {
+		return false
+	}
+	for _, path := range paths {
+		// Match the Elem precedence used by the SHOW client router. Deprecated
+		// Element fields do not override an Elem path.
+		elems := append([]*gnmipb.PathElem{}, prefix.GetElem()...)
+		elems = append(elems, path.GetElem()...)
+		names := make([]string, 0, len(elems))
+		for _, elem := range elems {
+			names = append(names, elem.GetName())
+		}
+		if len(names) == 2 && names[0] == "bgp" && names[1] == "running-config" {
+			return true
+		}
+	}
+	return false
 }
 
 // Subscribe implements the gNMI Subscribe RPC.
@@ -1057,6 +1084,10 @@ func (s *Server) Get(ctx context.Context, req *gnmipb.GetRequest) (*gnmipb.GetRe
 	if err != nil {
 		common_utils.IncCounter(common_utils.GNMI_GET_FAIL)
 		return nil, err
+	}
+	if containsBGPRunningConfigPath(prefix, paths) && !isUnixPeer(ctx) {
+		common_utils.IncCounter(common_utils.GNMI_GET_FAIL)
+		return nil, status.Error(codes.PermissionDenied, "BGP running configuration is available only over the Unix domain socket")
 	}
 	// Checked after authenticate so unauthenticated callers get
 	// Unauthenticated instead of a policy result.

--- a/gnmi_server/server.go
+++ b/gnmi_server/server.go
@@ -883,7 +883,7 @@ func isUnixPeer(ctx context.Context) bool {
 }
 
 func containsBGPRunningConfigPath(prefix *gnmipb.Path, paths []*gnmipb.Path) bool {
-	if prefix.GetTarget() != "SHOW" {
+	if prefix == nil || prefix.GetTarget() != "SHOW" {
 		return false
 	}
 	for _, path := range paths {

--- a/show_client/bgp_cli.go
+++ b/show_client/bgp_cli.go
@@ -1,0 +1,20 @@
+package show_client
+
+import (
+	"encoding/json"
+
+	log "github.com/golang/glog"
+	sdc "github.com/sonic-net/sonic-gnmi/sonic_data_client"
+)
+
+const vtyshBGPRunningConfigCommand = `vtysh -c "show running-config bgp"`
+
+func getBGPRunningConfig(options sdc.OptionMap) ([]byte, error) {
+	vtyshOutput, err := GetDataFromHostCommand(vtyshBGPRunningConfigCommand)
+	if err != nil {
+		log.Errorf("Unable to successfully execute command %v, got error %v", vtyshBGPRunningConfigCommand, err)
+		return nil, err
+	}
+
+	return json.Marshal(vtyshOutput)
+}

--- a/show_client/show_paths.go
+++ b/show_client/show_paths.go
@@ -51,6 +51,11 @@ func init() {
 		showCmdOptionVerbose,
 	)
 	sdc.RegisterCliPath(
+		[]string{"SHOW", "bgp", "running-config"},
+		getBGPRunningConfig,
+		nil,
+	)
+	sdc.RegisterCliPath(
 		[]string{"SHOW", "ipv6", "bgp", "summary"},
 		getIPv6BGPSummary,
 		nil,

--- a/sonic_data_client/client_test.go
+++ b/sonic_data_client/client_test.go
@@ -1841,6 +1841,72 @@ func TestTableData2Msi_SkipsEmptyData(t *testing.T) {
 	})
 }
 
+func TestTableData2TypedValue_ConfigDBWildcardPreservesTables(t *testing.T) {
+	cleanup := setupTestTarget2RedisDb(t)
+	defer cleanup()
+
+	rclient := Target2RedisDb[""]["CONFIG_DB"]
+	rclient.HSet(context.Background(), "DEVICE_METADATA|localhost", "hostname", "sonic")
+	rclient.HSet(context.Background(), "PORT|Ethernet0", "admin_status", "up", "lanes@", "1,2")
+	rclient.HSet(context.Background(), "NTP_SERVER|10.0.0.1", "NULL", "NULL")
+	rclient.Set(context.Background(), "CONFIG_DB_INITIALIZED", "1", 0)
+
+	tblPath := tablePath{dbNamespace: "", dbName: "CONFIG_DB", tableName: "*", delimitor: "|"}
+	path := &gnmipb.Path{Elem: []*gnmipb.PathElem{{Name: "*"}}}
+	client := DbClient{
+		pathG2S:                map[*gnmipb.Path][]tablePath{path: {tblPath}},
+		preserveConfigDBTables: true,
+	}
+	values, err := client.Get(nil)
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if len(values) != 1 {
+		t.Fatalf("Get() returned %d values, want 1", len(values))
+	}
+	var got map[string]interface{}
+	if err := json.Unmarshal(values[0].GetVal().GetJsonIetfVal(), &got); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	want := map[string]interface{}{
+		"DEVICE_METADATA": map[string]interface{}{
+			"localhost": map[string]interface{}{"hostname": "sonic"},
+		},
+		"PORT": map[string]interface{}{
+			"Ethernet0": map[string]interface{}{
+				"admin_status": "up",
+				"lanes":        []interface{}{"1", "2"},
+			},
+		},
+		"NTP_SERVER": map[string]interface{}{
+			"10.0.0.1": map[string]interface{}{},
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("tableData2TypedValue() = %#v, want %#v", got, want)
+	}
+}
+
+func TestDbClientGet_ConfigDBWildcardLegacyBehavior(t *testing.T) {
+	cleanup := setupTestTarget2RedisDb(t)
+	defer cleanup()
+
+	rclient := Target2RedisDb[""]["CONFIG_DB"]
+	rclient.HSet(context.Background(), "PORT|Ethernet0", "admin_status", "up")
+
+	path := &gnmipb.Path{Elem: []*gnmipb.PathElem{{Name: "*"}}}
+	tblPath := tablePath{dbNamespace: "", dbName: "CONFIG_DB", tableName: "*", delimitor: "|"}
+	client := DbClient{pathG2S: map[*gnmipb.Path][]tablePath{path: {tblPath}}}
+	values, err := client.Get(nil)
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if got := string(values[0].GetVal().GetJsonIetfVal()); got != `{"Ethernet0":{"admin_status":"up"}}` {
+		t.Fatalf("legacy Get() = %s", got)
+	}
+}
+
 func TestSubscribeTableData2TypedValue(t *testing.T) {
 	cleanup := setupTestTarget2RedisDb(t)
 	defer cleanup()

--- a/sonic_data_client/db_client.go
+++ b/sonic_data_client/db_client.go
@@ -479,7 +479,7 @@ func (c *DbClient) Get(w *sync.WaitGroup) ([]*spb.Value, error) {
 			Val:       val,
 		})
 	}
-	log.V(6).Infof("Getting #%v", values)
+	log.V(6).Infof("Get returned %d database value(s)", len(values))
 	log.V(4).Infof("Get done, total time taken: %v ms", int64(time.Since(ts)/time.Millisecond))
 	return values, nil
 }
@@ -989,7 +989,7 @@ func emitJSON(v *map[string]interface{}) ([]byte, error) {
 	defer func() {
 		if r := recover(); r != nil {
 			log.V(2).Infof("Recovered from panic: %v", r)
-			log.V(2).Infof("Current state of map to be serialized is: %v", *v)
+			log.V(2).Infof("Map to be serialized contains %d entries", len(*v))
 		}
 	}()
 	j, err := json.Marshal(*v)
@@ -1030,12 +1030,12 @@ func TableData2Msi(tblPath *tablePath, useKey bool, op *string, msi *map[string]
 		dbkeys = []string{tblPath.tableName + tblPath.delimitor + tblPath.tableKey}
 	}
 
-	log.V(4).Infof("dbkeys to be pulled from redis %v", dbkeys)
+	log.V(4).Infof("Pulling %d key(s) from Redis", len(dbkeys))
 
 	// Asked to use jsonField and jsonTableKey in the final json value
 	if tblPath.jsonField != "" && tblPath.jsonTableKey != "" {
 		val, err := redisDb.HGet(context.Background(), dbkeys[0], tblPath.field).Result()
-		log.V(4).Infof("Data pulled for key %s and field %s: %s", dbkeys[0], tblPath.field, val)
+		log.V(4).Infof("Data pulled for key %s and field %s", dbkeys[0], tblPath.field)
 		if err != nil {
 			log.V(3).Infof("redis HGet failed for %v %v", tblPath, err)
 			// ignore non-existing field which was derived from virtual path
@@ -1043,7 +1043,7 @@ func TableData2Msi(tblPath *tablePath, useKey bool, op *string, msi *map[string]
 		}
 		fv = map[string]string{tblPath.jsonField: val}
 		makeJSON_redis(msi, &tblPath.jsonTableKey, op, fv)
-		log.V(6).Infof("Added json key %v fv %v ", tblPath.jsonTableKey, fv)
+		log.V(6).Infof("Added JSON key %v with %d field(s)", tblPath.jsonTableKey, len(fv))
 		return nil
 	}
 
@@ -1053,7 +1053,7 @@ func TableData2Msi(tblPath *tablePath, useKey bool, op *string, msi *map[string]
 			log.V(2).Infof("redis HGetAll failed for  %v, dbkey %s", tblPath, dbkey)
 			return err
 		}
-		log.V(4).Infof("Data pulled for dbkey %s: %v", dbkey, fv)
+		log.V(4).Infof("Data pulled for dbkey %s with %d field(s)", dbkey, len(fv))
 
 		if len(fv) == 0 {
 			log.V(6).Infof("No data for dbkey %s, skipping", dbkey)
@@ -1069,26 +1069,26 @@ func TableData2Msi(tblPath *tablePath, useKey bool, op *string, msi *map[string]
 			// Split dbkey string into two parts and second part is key in table
 			keys := strings.SplitN(dbkey, tblPath.delimitor, 2)
 			if len(keys) < 2 {
-				return fmt.Errorf("dbkey: %s, failed split from delimitor %v", dbkey, tblPath.delimitor)
+				return fmt.Errorf("dbkey: %s, failed split from delimiter %v", dbkey, tblPath.delimitor)
 			}
 			key = keys[1]
 			err = makeJSON_redis(msi, &key, op, fv)
 		}
 		if err != nil {
-			log.V(2).Infof("makeJSON err %s for fv %v", err, fv)
+			log.V(2).Infof("makeJSON failed for dbkey %s: %v", dbkey, err)
 			return err
 		}
-		log.V(6).Infof("Added idex %v fv %v ", idx, fv)
+		log.V(6).Infof("Added Redis result %d with %d field(s)", idx, len(fv))
 	}
 	return nil
 }
 
 func Msi2TypedValue(msi map[string]interface{}) (*gnmipb.TypedValue, error) {
-	log.V(4).Infof("State of map after adding redis data %v", msi)
+	log.V(4).Infof("Marshaling map with %d Redis data entries", len(msi))
 	jv, err := emitJSON(&msi)
 	if err != nil {
-		log.V(2).Infof("emitJSON err %s for  %v", err, msi)
-		return nil, fmt.Errorf("emitJSON err %s for  %v", err, msi)
+		log.V(2).Infof("emitJSON failed for map with %d entries: %v", len(msi), err)
+		return nil, fmt.Errorf("emitJSON failed: %v", err)
 	}
 	if jv == nil { // json and err is nil because panic potentially happened
 		return nil, fmt.Errorf("emitJSON failed to grab json value of map due to potential panic")
@@ -1122,7 +1122,7 @@ func tableData2TypedValue(tblPaths []tablePath, op *string) (*gnmipb.TypedValue,
 				if err != nil {
 					return nil, err
 				}
-				log.V(4).Infof("Data pulled for key %s and field %s: %s", key, tblPath.field, val)
+				log.V(4).Infof("Data pulled for key %s and field %s", key, tblPath.field)
 				return &gnmipb.TypedValue{
 					Value: &gnmipb.TypedValue_StringVal{
 						StringVal: val,
@@ -1167,7 +1167,7 @@ func configDBTables2Msi(tblPath *tablePath, msi *map[string]interface{}) error {
 		}
 		parts := strings.SplitN(dbkey, tblPath.delimitor, 2)
 		if len(parts) != 2 {
-			return fmt.Errorf("dbkey: %s, failed split from delimitor %v", dbkey, tblPath.delimitor)
+			return fmt.Errorf("dbkey: %s, failed split from delimiter %v", dbkey, tblPath.delimitor)
 		}
 		table, ok := (*msi)[parts[0]].(map[string]interface{})
 		if !ok {

--- a/sonic_data_client/db_client.go
+++ b/sonic_data_client/db_client.go
@@ -190,10 +190,11 @@ func (val Value) GetTimestamp() int64 {
 }
 
 type DbClient struct {
-	prefix  *gnmipb.Path
-	pathG2S map[*gnmipb.Path][]tablePath
-	q       *queue.PriorityQueue
-	channel chan struct{}
+	prefix                 *gnmipb.Path
+	pathG2S                map[*gnmipb.Path][]tablePath
+	preserveConfigDBTables bool
+	q                      *queue.PriorityQueue
+	channel                chan struct{}
 
 	synced sync.WaitGroup  // Control when to send gNMI sync_response
 	w      *sync.WaitGroup // wait for all sub go routines to finish
@@ -205,6 +206,15 @@ type DbClient struct {
 }
 
 func NewDbClient(paths []*gnmipb.Path, prefix *gnmipb.Path) (Client, error) {
+	return newDbClient(paths, prefix, false)
+}
+
+// NewDbClientForGet creates a DbClient with unary Get response semantics.
+func NewDbClientForGet(paths []*gnmipb.Path, prefix *gnmipb.Path) (Client, error) {
+	return newDbClient(paths, prefix, true)
+}
+
+func newDbClient(paths []*gnmipb.Path, prefix *gnmipb.Path, preserveConfigDBTables bool) (Client, error) {
 	var client DbClient
 	var err error
 
@@ -220,6 +230,7 @@ func NewDbClient(paths []*gnmipb.Path, prefix *gnmipb.Path) (Client, error) {
 
 	client.prefix = prefix
 	client.pathG2S = make(map[*gnmipb.Path][]tablePath)
+	client.preserveConfigDBTables = preserveConfigDBTables
 	err = populateAllDbtablePath(prefix, paths, &client.pathG2S)
 
 	if err != nil {
@@ -450,7 +461,13 @@ func (c *DbClient) Get(w *sync.WaitGroup) ([]*spb.Value, error) {
 	var values []*spb.Value
 	ts := time.Now()
 	for gnmiPath, tblPaths := range c.pathG2S {
-		val, err := tableData2TypedValue(tblPaths, nil)
+		var val *gnmipb.TypedValue
+		var err error
+		if c.preserveConfigDBTables && isConfigDBWildcard(tblPaths) {
+			val, err = configDBTables2TypedValue(&tblPaths[0])
+		} else {
+			val, err = tableData2TypedValue(tblPaths, nil)
+		}
 		if err != nil {
 			return nil, err
 		}
@@ -1118,6 +1135,63 @@ func tableData2TypedValue(tblPaths []tablePath, op *string) (*gnmipb.TypedValue,
 		}
 	}
 	return Msi2TypedValue(msi)
+}
+
+func isConfigDBWildcard(tblPaths []tablePath) bool {
+	return len(tblPaths) == 1 && tblPaths[0].dbName == "CONFIG_DB" &&
+		tblPaths[0].tableName == "*" && tblPaths[0].tableKey == ""
+}
+
+func configDBTables2TypedValue(tblPath *tablePath) (*gnmipb.TypedValue, error) {
+	msi := make(map[string]interface{})
+	if err := configDBTables2Msi(tblPath, &msi); err != nil {
+		return nil, err
+	}
+	return Msi2TypedValue(msi)
+}
+
+func configDBTables2Msi(tblPath *tablePath, msi *map[string]interface{}) error {
+	redisDb := Target2RedisDb[tblPath.dbNamespace][tblPath.dbName]
+	pattern := "*" + tblPath.delimitor + "*"
+	dbkeys, err := redisDb.Keys(context.Background(), pattern).Result()
+	if err != nil {
+		return fmt.Errorf("redis Keys failed for %v, pattern %s %v", tblPath, pattern, err)
+	}
+	for _, dbkey := range dbkeys {
+		fields, err := redisDb.HGetAll(context.Background(), dbkey).Result()
+		if err != nil {
+			return fmt.Errorf("redis HGetAll failed for %v, dbkey %s: %v", tblPath, dbkey, err)
+		}
+		if len(fields) == 0 {
+			continue
+		}
+		parts := strings.SplitN(dbkey, tblPath.delimitor, 2)
+		if len(parts) != 2 {
+			return fmt.Errorf("dbkey: %s, failed split from delimitor %v", dbkey, tblPath.delimitor)
+		}
+		table, ok := (*msi)[parts[0]].(map[string]interface{})
+		if !ok {
+			table = make(map[string]interface{})
+			(*msi)[parts[0]] = table
+		}
+		table[parts[1]] = configDBFieldValues(fields)
+	}
+	return nil
+}
+
+func configDBFieldValues(fields map[string]string) map[string]interface{} {
+	values := make(map[string]interface{})
+	for field, value := range fields {
+		if field == "NULL" {
+			continue
+		}
+		if strings.HasSuffix(field, "@") {
+			values[strings.TrimSuffix(field, "@")] = strings.Split(value, ",")
+		} else {
+			values[field] = value
+		}
+	}
+	return values
 }
 
 // subscribeTableData2TypedValue is used by Poll and Sample subscribe modes.

--- a/sonic_data_client/show_client.go
+++ b/sonic_data_client/show_client.go
@@ -117,7 +117,7 @@ func (c *ShowClient) Get(w *sync.WaitGroup) ([]*spb.Value, error) {
 				}},
 		})
 	}
-	log.V(6).Infof("Getting #%v", values)
+	log.V(6).Infof("Get returned %d SHOW value(s)", len(values))
 	log.V(4).Infof("Get done, total time taken: %v ms", int64(time.Since(ts)/time.Millisecond))
 	return values, nil
 }

--- a/testdata/CONFIG_DB_RUNNING_CONFIG.txt
+++ b/testdata/CONFIG_DB_RUNNING_CONFIG.txt
@@ -1,0 +1,17 @@
+{
+  "ACL_TABLE|DATAACL": {
+    "ports@": "Ethernet0,Ethernet4",
+    "type": "L3"
+  },
+  "BGP_NEIGHBOR|10.0.0.1": {
+    "asn": "65000",
+    "name": "leaf"
+  },
+  "DEVICE_METADATA|localhost": {
+    "hostname": "sonic",
+    "type": "ToRRouter"
+  },
+  "NTP_SERVER|10.0.0.1": {
+    "NULL": "NULL"
+  }
+}

--- a/testdata/VTYSH_SHOW_BGP_RUNNING_CONFIG.txt
+++ b/testdata/VTYSH_SHOW_BGP_RUNNING_CONFIG.txt
@@ -1,0 +1,9 @@
+Building configuration...
+
+Current configuration:
+!
+router bgp 65100
+ bgp router-id 10.0.0.1
+ neighbor 10.0.0.2 remote-as 65200
+!
+end


### PR DESCRIPTION
## Summary
- `SHOW /bgp/running-config` returns `vtysh -c "show running-config bgp"` output as a `JSON_IETF` string.
- The BGP path accepts only Unix domain socket requests. TCP requests are denied.
- SHOW and database Get logging report metadata without response payloads.
- Unary `Get` requests to `CONFIG_DB /*` preserve table names, list fields, and `NULL` semantics.
- Unary `Get` requests exclude bare Redis keys that do not represent table rows.
- A dedicated `Get` constructor leaves `Subscribe` and dial-out behavior unchanged.
- Non-wildcard table reads remain unchanged.

## Validation
Tests passed:
- `TestGetBGPRunningConfig`
- `TestGetBGPRunningConfigMixedPathEncodingDeniedOverTCP`
- `TestGetBGPRunningConfigAuthenticationPrecedesTCPDenial`
- `TestContainsBGPRunningConfigPath`
- `TestGetIPv6BGPSummary`
- `TestGetConfigDBWildcardPreservesTables`
- `TestTableData2TypedValue_ConfigDBWildcardPreservesTables`
- `TestDbClientGet_ConfigDBWildcardLegacyBehavior`

Checks passed:
- `gofmt`
- `git diff --check`

## Device validation
Device validation on `vlab-01` replaced only `/usr/sbin/telemetry` in the running `gnmi` container.
The replacement binary came from build `1205695`'s `amd64` package.

- `SHOW /bgp/running-config` returned 4,820 bytes. The output matched `vtysh -c "show running-config bgp"` exactly.
- `CONFIG_DB /*` returned 63 tables. The output matched `sonic-cfggen -d --print-data` exactly.
- The gNMI service remained active.

## Limits
- Device validation did not cover a full container-image rollout or multi-ASIC behavior.
- Unary `CONFIG_DB /*` reads run Redis `KEYS` followed by `HGETALL`. This sequence does not provide an atomic snapshot.
