### PR TITLE
Fix redis client and C string memory leaks in events client

### DIFF
--- a/sonic_data_client/events_client.go
+++ b/sonic_data_client/events_client.go
@@ -87,7 +87,9 @@ type EventClient struct {
 
 func Set_heartbeat(val int) {
 	s := fmt.Sprintf("{\"HEARTBEAT_INTERVAL\":%d}", val)
-	rc := C.event_set_global_options(C.CString(s))
+	cs := C.CString(s)
+	defer C.free(unsafe.Pointer(cs))
+	rc := C.event_set_global_options(cs)
 	if rc != 0 {
 		log.V(4).Infof("Failed to set heartbeat val=%d rc=%d", val, rc)
 	}
@@ -243,6 +245,7 @@ func update_stats(evtc *EventClient) {
 			DB:          dbId,
 			DialTimeout: 0,
 		})
+		defer rclient.Close()
 
 		// Init current values for cumulative keys and clear for absolute
 		for _, key := range STATS_CUMULATIVE_KEYS {

--- a/sonic_data_client/events_client_test.go
+++ b/sonic_data_client/events_client_test.go
@@ -1,0 +1,79 @@
+package client
+
+import (
+	"reflect"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	sdcfg "github.com/sonic-net/sonic-gnmi/sonic_db_config"
+)
+
+// TestUpdateStatsClosesRedisClient verifies that update_stats() releases the
+// COUNTERS_DB redis client it creates when the event subscription is torn down.
+//
+// This is a regression test for a resource leak: the redis client (which owns a
+// TCP socket and background goroutines) was created per events subscription but
+// never Close()d, so every subscribe/unsubscribe cycle leaked one client. The
+// fix adds `defer rclient.Close()` right after the client is created.
+func TestUpdateStatsClosesRedisClient(t *testing.T) {
+	mr := miniredis.RunT(t)
+
+	// Point the COUNTERS_DB lookups used by update_stats at the in-memory redis.
+	patches := gomonkey.ApplyFunc(sdcfg.GetDbDefaultNamespace, func() (string, error) {
+		return "", nil
+	})
+	defer patches.Reset()
+	patches.ApplyFunc(sdcfg.GetDbTcpAddr, func(_ string, _ string) (string, error) {
+		return mr.Addr(), nil
+	})
+	patches.ApplyFunc(sdcfg.GetDbId, func(_ string, _ string) (int, error) {
+		return 0, nil
+	})
+
+	// Record whether the redis client gets closed. Close is deferred inside
+	// update_stats, so it runs exactly when the function returns.
+	var closeCount int32
+	patches.ApplyMethod(reflect.TypeOf(&redis.Client{}), "Close", func(_ *redis.Client) error {
+		atomic.AddInt32(&closeCount, 1)
+		return nil
+	})
+
+	// A non-zero counter makes the initial "wait for activity" loop in
+	// update_stats break immediately so it proceeds to create the redis client.
+	evtc := &EventClient{
+		counters: map[string]uint64{"COUNTERS:TEST": 1},
+		wg:       &sync.WaitGroup{},
+	}
+
+	evtc.wg.Add(1)
+	go update_stats(evtc)
+
+	// Give update_stats time to create the redis client and enter its main loop
+	// before signalling the subscription to stop.
+	time.Sleep(300 * time.Millisecond)
+	evtc.stopMutex.Lock()
+	evtc.stopped = 1
+	evtc.stopMutex.Unlock()
+
+	// Wait for update_stats to return (and thus run the deferred Close).
+	done := make(chan struct{})
+	go func() {
+		evtc.wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("update_stats did not return after stop was signalled")
+	}
+
+	if atomic.LoadInt32(&closeCount) == 0 {
+		t.Fatal("update_stats returned without closing its redis client (resource leak)")
+	}
+}


### PR DESCRIPTION


#### Why I did it
The gNMI events client had two resource leaks in sonic_data_client/events_client.go, both reachable in normal operation:

COUNTERS_DB redis client leak. update_stats() creates a redis.Client for COUNTERS_DB once per events subscription and never closes it. Each subscribe/unsubscribe cycle abandoned a client, leaking its TCP socket and internal background goroutines. Over time (repeated telemetry event subscriptions) this accumulates.

C.CString leak. Set_heartbeat() passed C.CString(s) inline to event_set_global_options() without ever freeing it. C.CString always allocates on the C heap and the caller owns the buffer; the callee takes a const char * and does not free it, so every call leaked the string (invoked on each events subscribe that carries a heartbeat path parameter).
#### How I did it

- update_stats(): added defer rclient.Close() immediately after the client is created, so it's released on every return path when the subscription is torn down.
- Set_heartbeat(): capture the C.CString result in a variable and defer C.free(unsafe.Pointer(cs)) (same pattern already used elsewhere in this file and in mixed_db_client.go).
- Added TestUpdateStatsClosesRedisClient (sonic_data_client/events_client_test.go), a white-box unit test that patches the COUNTERS_DB lookups to an in-memory miniredis, intercepts (*redis.Client).Close, drives update_stats() through a subscribe→stop cycle, and asserts the client is closed.

#### How to verify it
cd src/sonic-gnmi
go test ./sonic_data_client/ -run TestUpdateStatsClosesRedisClient -v
The test fails without the defer rclient.Close() fix (closeCount == 0) and passes with it. The C.CString fix is verifiable under the LeakSanitizer harness (make check_memleak); note sonic_data_client is currently excluded from that target in the Makefile due to unrelated libyang leaks in the test environment, so the CString fix is covered by code inspection against the existing free pattern.
#### Which release branch to backport (provide reason below if selected)
Not Applicable

#### Tested branch


- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605
- [ ] N/A

#### Test result

master: 

$ cd src/sonic-gnmi
$ go test ./sonic_data_client/ -run TestUpdateStatsClosesRedisClient -v
=== RUN   TestUpdateStatsClosesRedisClient
--- PASS: TestUpdateStatsClosesRedisClient (~1.0s)
PASS
ok      github.com/sonic-net/sonic-gnmi/sonic_data_client

#### Description for the changelog
[sonic-gnmi] Fix redis client and C string memory leaks in the gNMI events client

#### Link to config_db schema for YANG module changes
N/A — no CONFIG_DB tables or YANG models are added or changed. This is a code-only resource-cleanup fix in the events data client.

#### A picture of a cute animal (not mandatory but encouraged)

